### PR TITLE
refactor: ハードコードUIを .tscn/.tres に移行（Phase 2）

### DIFF
--- a/GCTonePrism_Launcher/resources/styles/exit_button_focus.tres
+++ b/GCTonePrism_Launcher/resources/styles/exit_button_focus.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0, 0, 0, 0)
+draw_center = false
+border_color = Color(0, 0, 0, 0)
+shadow_color = Color(0, 0, 0, 0)
+shadow_size = 0

--- a/GCTonePrism_Launcher/resources/styles/exit_button_hover.tres
+++ b/GCTonePrism_Launcher/resources/styles/exit_button_hover.tres
@@ -1,0 +1,15 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0.9, 0.9, 0.9, 1)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+shadow_color = Color(0, 0, 0, 0.3)
+shadow_size = 4
+shadow_offset = Vector2(0, 0)
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0

--- a/GCTonePrism_Launcher/resources/styles/exit_button_normal.tres
+++ b/GCTonePrism_Launcher/resources/styles/exit_button_normal.tres
@@ -1,0 +1,15 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(1, 1, 1, 1)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+shadow_color = Color(0, 0, 0, 0.3)
+shadow_size = 4
+shadow_offset = Vector2(0, 0)
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0

--- a/GCTonePrism_Launcher/resources/styles/exit_button_pressed.tres
+++ b/GCTonePrism_Launcher/resources/styles/exit_button_pressed.tres
@@ -1,0 +1,15 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0.7, 0.7, 0.7, 1)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+shadow_color = Color(0, 0, 0, 0.3)
+shadow_size = 4
+shadow_offset = Vector2(0, 0)
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0

--- a/GCTonePrism_Launcher/resources/styles/play_button_focus.tres
+++ b/GCTonePrism_Launcher/resources/styles/play_button_focus.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0, 0, 0, 0)
+draw_center = false
+border_color = Color(0, 0, 0, 0)
+shadow_color = Color(0, 0, 0, 0)
+shadow_size = 0

--- a/GCTonePrism_Launcher/resources/styles/play_button_hover.tres
+++ b/GCTonePrism_Launcher/resources/styles/play_button_hover.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0.2, 0.8, 0.2, 1)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+content_margin_left = 20.0
+content_margin_right = 20.0

--- a/GCTonePrism_Launcher/resources/styles/play_button_normal.tres
+++ b/GCTonePrism_Launcher/resources/styles/play_button_normal.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0, 0.6, 0, 1)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+content_margin_left = 20.0
+content_margin_right = 20.0

--- a/GCTonePrism_Launcher/resources/styles/play_button_pressed.tres
+++ b/GCTonePrism_Launcher/resources/styles/play_button_pressed.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0, 0.4, 0, 1)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+content_margin_left = 20.0
+content_margin_right = 20.0

--- a/GCTonePrism_Launcher/resources/styles/progress_background.tres
+++ b/GCTonePrism_Launcher/resources/styles/progress_background.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0.2, 0.2, 0.2, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/GCTonePrism_Launcher/resources/styles/progress_fill_easy.tres
+++ b/GCTonePrism_Launcher/resources/styles/progress_fill_easy.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0.2, 0.8, 0.2, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/GCTonePrism_Launcher/resources/styles/progress_fill_hard.tres
+++ b/GCTonePrism_Launcher/resources/styles/progress_fill_hard.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0.9, 0.2, 0.2, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/GCTonePrism_Launcher/resources/styles/progress_fill_medium.tres
+++ b/GCTonePrism_Launcher/resources/styles/progress_fill_medium.tres
@@ -1,0 +1,8 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+bg_color = Color(0.9, 0.9, 0.2, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/GCTonePrism_Launcher/scenes/components/back_button.tscn
+++ b/GCTonePrism_Launcher/scenes/components/back_button.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=6 format=3]
+
+[ext_resource type="Texture2D" path="res://images/turn_back.png" id="1_icon"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_normal.tres" id="2_normal"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_hover.tres" id="3_hover"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_pressed.tres" id="4_pressed"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_focus.tres" id="5_focus"]
+
+[node name="BackButton" type="Button"]
+custom_minimum_size = Vector2(60, 60)
+theme_override_styles/normal = ExtResource("2_normal")
+theme_override_styles/hover = ExtResource("3_hover")
+theme_override_styles/pressed = ExtResource("4_pressed")
+theme_override_styles/focus = ExtResource("5_focus")
+icon = ExtResource("1_icon")
+icon_alignment = 1
+expand_icon = true

--- a/GCTonePrism_Launcher/scenes/components/common_dialog.gd
+++ b/GCTonePrism_Launcher/scenes/components/common_dialog.gd
@@ -12,8 +12,8 @@ var _buttons: Array[Button] = []
 
 var _glow_timer: float = 0.0
 
-# フォーカスモーフ用
-var _focus_border: Panel = null
+# フォーカスモーフ用（.tscnで定義済み）
+@onready var _focus_border: Panel = $FocusBorder
 var _focus_target_rect: Rect2 = Rect2()
 var _focus_target_radius: float = 16.0
 var _focus_current_radius: float = 16.0
@@ -78,23 +78,6 @@ func _input(event: InputEvent) -> void:
 func _ready():
 	_title_label.text = ""
 	_message_label.text = ""
-	_setup_focus_border()
-
-func _setup_focus_border() -> void:
-	_focus_border = Panel.new()
-	_focus_border.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	_focus_border.z_index = 100
-	_focus_border.visible = false
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.6, 0.6, 0.6, 0)
-	style.draw_center = false
-	style.border_color = Color(1, 1, 1, 1)
-	style.set_corner_radius_all(16)
-	style.set_expand_margin_all(6)
-	style.shadow_color = Color(1, 1, 1, 1)
-	style.shadow_size = 12
-	_focus_border.add_theme_stylebox_override("panel", style)
-	add_child(_focus_border)
 
 func setup(title: String, message: String):
 	if not is_node_ready():

--- a/GCTonePrism_Launcher/scenes/components/common_dialog.tscn
+++ b/GCTonePrism_Launcher/scenes/components/common_dialog.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://common_dialog_scene"]
+[gd_scene load_steps=5 format=3 uid="uid://common_dialog_scene"]
 
 [ext_resource type="Script" path="res://scenes/components/common_dialog.gd" id="1_script"]
 [ext_resource type="FontFile" uid="uid://dolk7yphok5xu" path="res://fonts/NotoSansJP-Regular.ttf" id="2_font_reg"]
@@ -54,6 +54,21 @@ expand_margin_top = 6.0
 expand_margin_right = 6.0
 expand_margin_bottom = 6.0
 shadow_color = Color(1, 1, 1, 0.5)
+shadow_size = 12
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_FocusBorder"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+draw_center = false
+border_color = Color(1, 1, 1, 1)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+expand_margin_left = 6.0
+expand_margin_top = 6.0
+expand_margin_right = 6.0
+expand_margin_bottom = 6.0
+shadow_color = Color(1, 1, 1, 1)
 shadow_size = 12
 
 [node name="CommonDialog" type="Control"]
@@ -135,3 +150,13 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_BtnHover")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_BtnPressed")
 theme_override_styles/focus = SubResource("StyleBoxFlat_BtnFocus")
 text = "Button"
+
+[node name="FocusBorder" type="Panel" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 0
+offset_right = 160.0
+offset_bottom = 50.0
+mouse_filter = 2
+z_index = 100
+theme_override_styles/panel = SubResource("StyleBoxFlat_FocusBorder")

--- a/GCTonePrism_Launcher/scenes/components/store_all_games_button.tscn
+++ b/GCTonePrism_Launcher/scenes/components/store_all_games_button.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="FontFile" path="res://fonts/NotoSansJP-Bold.ttf" id="1_font_bold"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_Normal"]
+bg_color = Color(0.2, 0.2, 0.2, 0.6)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_Hover"]
+bg_color = Color(0.3, 0.3, 0.3, 0.8)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_Pressed"]
+bg_color = Color(0.25, 0.25, 0.25, 0.9)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+
+[node name="AllGamesButton" type="Button"]
+custom_minimum_size = Vector2(0, 60)
+focus_mode = 2
+theme_override_fonts/font = ExtResource("1_font_bold")
+theme_override_font_sizes/font_size = 22
+theme_override_colors/font_color = Color(0.9, 0.9, 0.9, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_styles/normal = SubResource("StyleBoxFlat_Normal")
+theme_override_styles/hover = SubResource("StyleBoxFlat_Hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_Pressed")
+text = "すべてのゲーム →"

--- a/GCTonePrism_Launcher/scenes/components/store_banner.tscn
+++ b/GCTonePrism_Launcher/scenes/components/store_banner.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Material" path="res://shaders/gradient_overlay_material.tres" id="1_material"]
+[ext_resource type="Script" path="res://scenes/components/auto_scroll_container.gd" id="2_scroll"]
+[ext_resource type="FontFile" path="res://fonts/NotoSansJP-Bold.ttf" id="3_font_bold"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_Banner"]
+bg_color = Color(0.1, 0.1, 0.1, 1)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_Gradient"]
+bg_color = Color(1, 1, 1, 1)
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+
+[node name="StoreBanner" type="Panel"]
+custom_minimum_size = Vector2(800, 500)
+size = Vector2(800, 500)
+focus_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_Banner")
+clip_children = 2
+
+[node name="BackgroundImage" type="TextureRect" parent="."]
+position = Vector2(0, 0)
+size = Vector2(800, 500)
+mouse_filter = 2
+expand_mode = 1
+stretch_mode = 6
+
+[node name="GradientOverlay" type="Panel" parent="."]
+position = Vector2(0, 325)
+size = Vector2(800, 175)
+mouse_filter = 2
+material = ExtResource("1_material")
+theme_override_styles/panel = SubResource("StyleBoxFlat_Gradient")
+
+[node name="TitleScroll" type="Control" parent="."]
+script = ExtResource("2_scroll")
+position = Vector2(24, 444)
+size = Vector2(752, 48)
+mouse_filter = 2
+
+[node name="TitleLabel" type="Label" parent="TitleScroll"]
+position = Vector2(0, 0)
+size = Vector2(752, 48)
+mouse_filter = 2
+theme_override_fonts/font = ExtResource("3_font_bold")
+theme_override_font_sizes/font_size = 32
+theme_override_colors/font_color = Color(1, 1, 1, 1)

--- a/GCTonePrism_Launcher/scenes/components/store_game_tile.tscn
+++ b/GCTonePrism_Launcher/scenes/components/store_game_tile.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="FontFile" path="res://fonts/NotoSansJP-Regular.ttf" id="1_font_reg"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_Tile"]
+bg_color = Color(0.15, 0.15, 0.15, 1)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+
+[node name="GameTile" type="VBoxContainer"]
+theme_override_constants/separation = 6
+
+[node name="TilePanel" type="Panel" parent="."]
+custom_minimum_size = Vector2(200, 200)
+focus_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_Tile")
+clip_children = 2
+
+[node name="Thumbnail" type="TextureRect" parent="TilePanel"]
+position = Vector2(0, 0)
+size = Vector2(200, 200)
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TitleLabel" type="Label" parent="."]
+custom_minimum_size = Vector2(200, 0)
+theme_override_fonts/font = ExtResource("1_font_reg")
+theme_override_font_sizes/font_size = 14
+theme_override_colors/font_color = Color(0.85, 0.85, 0.85, 1)
+horizontal_alignment = 1
+clip_text = true

--- a/GCTonePrism_Launcher/scenes/components/store_section_header.tscn
+++ b/GCTonePrism_Launcher/scenes/components/store_section_header.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="FontFile" path="res://fonts/NotoSansJP-Bold.ttf" id="1_font_bold"]
+[ext_resource type="FontFile" path="res://fonts/NotoSansJP-Regular.ttf" id="2_font_reg"]
+
+[node name="SectionHeader" type="HBoxContainer"]
+theme_override_constants/separation = 20
+
+[node name="SectionTitle" type="Label" parent="."]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_font_bold")
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+
+[node name="Spacer" type="Control" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ViewAllButton" type="Button" parent="."]
+visible = false
+layout_mode = 2
+focus_mode = 2
+theme_override_fonts/font = ExtResource("2_font_reg")
+theme_override_font_sizes/font_size = 20
+theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+flat = true
+text = "すべて見る →"

--- a/GCTonePrism_Launcher/scenes/game_selection.gd
+++ b/GCTonePrism_Launcher/scenes/game_selection.gd
@@ -78,28 +78,13 @@ func _ready():
 	# フォーカス枠を最前面に
 	_static_focus_border.z_index = 100
 
-	# ボタンスタイル設定
+	# ボタンスタイル設定（スタイルは .tscn で適用済み）
 	_glow_animator.register_focus_border(_static_focus_border)
 	_style_mgr.setup_exit_button(_exit_button)
-	_style_mgr.setup_play_button(_play_button)
 
 	# 戻るボタン（ブラウズから来たときのみ表示）
 	if not AppState.return_scene.is_empty() and _exit_button:
-		var back_button = Button.new()
-		back_button.name = "BackButton"
-		back_button.text = "←"
-		back_button.custom_minimum_size = Vector2(60, 60)
-		back_button.add_theme_font_size_override("font_size", 28)
-		# 退出ボタンと同じスタイル
-		_style_mgr.setup_exit_button(back_button)
-		# 戻るアイコンを適用
-		back_button.text = ""
-		var back_icon = load("res://images/turn_back.png")
-		if back_icon:
-			back_button.icon = back_icon
-		back_button.icon_alignment = HORIZONTAL_ALIGNMENT_CENTER
-		back_button.expand_icon = true
-		# 退出ボタンの前に挿入
+		var back_button = preload("res://scenes/components/back_button.tscn").instantiate()
 		var hbox = _exit_button.get_parent()
 		hbox.add_child(back_button)
 		hbox.move_child(back_button, _exit_button.get_index())
@@ -113,12 +98,8 @@ func _ready():
 	if _play_button:
 		_play_button.pressed.connect(func(): _launch_game())
 
-	# InfoPanelの背景スタイル
-	var info_style = StyleBoxFlat.new()
-	info_style.bg_color = Color(0, 0, 0, 0.7)
-	info_style.set_corner_radius_all(20)
+	# InfoPanelの背景スタイルは .tscn で適用済み
 	if _info_panel:
-		_info_panel.add_theme_stylebox_override("panel", info_style)
 		var guide_label = _info_panel.get_node_or_null("MarginContainer/VBoxContainer/GuideLabel")
 		if guide_label:
 			guide_label.visible = false

--- a/GCTonePrism_Launcher/scenes/game_selection.tscn
+++ b/GCTonePrism_Launcher/scenes/game_selection.tscn
@@ -1,10 +1,25 @@
-[gd_scene load_steps=17 format=3 uid="uid://bjoy2n8lqir0y"]
+[gd_scene load_steps=24 format=3 uid="uid://bjoy2n8lqir0y"]
 
 [ext_resource type="Script" uid="uid://dj0y4s0v4pp1c" path="res://scenes/game_selection.gd" id="1_game_selection"]
 [ext_resource type="FontFile" uid="uid://dolk7yphok5xu" path="res://fonts/NotoSansJP-Regular.ttf" id="2_font_regular"]
 [ext_resource type="FontFile" uid="uid://xjqfmx60jtvo" path="res://fonts/NotoSansJP-Bold.ttf" id="3_font_bold"]
 [ext_resource type="Texture2D" uid="uid://j27gk8qemr4d" path="res://icon.svg" id="4_icon"]
 [ext_resource type="Script" path="res://scenes/components/auto_scroll_container.gd" id="5_auto_scroll"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_normal.tres" id="6_exit_normal"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_hover.tres" id="7_exit_hover"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_pressed.tres" id="8_exit_pressed"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_focus.tres" id="9_exit_focus"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/play_button_normal.tres" id="10_play_normal"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/play_button_hover.tres" id="11_play_hover"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/play_button_pressed.tres" id="12_play_pressed"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/play_button_focus.tres" id="13_play_focus"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_InfoPanel"]
+bg_color = Color(0, 0, 0, 0.7)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
 
 [sub_resource type="Animation" id="Animation_transition_down"]
 resource_name = "transition_down"
@@ -308,6 +323,7 @@ offset_right = -40.0
 offset_bottom = -60.0
 grow_horizontal = 0
 grow_vertical = 0
+theme_override_styles/panel = SubResource("StyleBoxFlat_InfoPanel")
 
 [node name="MarginContainer" type="MarginContainer" parent="InfoPanel"]
 layout_mode = 1
@@ -348,6 +364,10 @@ layout_mode = 2
 size_flags_vertical = 4
 theme_override_fonts/font = ExtResource("3_font_bold")
 theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = ExtResource("10_play_normal")
+theme_override_styles/hover = ExtResource("11_play_hover")
+theme_override_styles/pressed = ExtResource("12_play_pressed")
+theme_override_styles/focus = ExtResource("13_play_focus")
 text = "プレイ"
 
 [node name="CreatorScrollWrapper" type="Control" parent="InfoPanel/MarginContainer/VBoxContainer"]
@@ -589,6 +609,10 @@ size_flags_horizontal = 3
 [node name="ExitButton" type="Button" parent="TopBar/MarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
+theme_override_styles/normal = ExtResource("6_exit_normal")
+theme_override_styles/hover = ExtResource("7_exit_hover")
+theme_override_styles/pressed = ExtResource("8_exit_pressed")
+theme_override_styles/focus = ExtResource("9_exit_focus")
 icon_alignment = 1
 expand_icon = true
 

--- a/GCTonePrism_Launcher/scenes/store_browse.gd
+++ b/GCTonePrism_Launcher/scenes/store_browse.gd
@@ -173,8 +173,7 @@ func _ready():
 		_exit_button.pressed.connect(_on_exit_button_pressed)
 		_style_mgr.setup_exit_button(_exit_button)
 
-	# フォーカスボーダーのスタイル設定
-	_setup_focus_border()
+	# フォーカスボーダーのスタイルは .tscn で適用済み
 
 	# 初期フォーカス
 	_current_section = 0
@@ -615,20 +614,6 @@ func _update_slideshow_bar(section_index: int) -> void:
 
 # --- フォーカス表示 ---
 
-func _setup_focus_border() -> void:
-	if not _focus_border:
-		return
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.6, 0.6, 0.6, 0)
-	style.draw_center = false
-	style.border_color = Color(1, 1, 1, 1)
-	style.set_corner_radius_all(16)
-	style.set_expand_margin_all(8)
-	style.shadow_color = Color(1, 1, 1, 1)
-	style.shadow_size = 12
-	_focus_border.add_theme_stylebox_override("panel", style)
-	_focus_border.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	_focus_border.z_index = 100
 
 func _update_focus_visual() -> void:
 	if not _focus_border or _section_ui.is_empty():

--- a/GCTonePrism_Launcher/scenes/store_browse.tscn
+++ b/GCTonePrism_Launcher/scenes/store_browse.tscn
@@ -1,8 +1,27 @@
-[gd_scene load_steps=8 format=3]
+[gd_scene load_steps=13 format=3]
 
 [ext_resource type="Script" path="res://scenes/store_browse.gd" id="1_store_browse"]
 [ext_resource type="FontFile" uid="uid://dolk7yphok5xu" path="res://fonts/NotoSansJP-Regular.ttf" id="2_font_regular"]
 [ext_resource type="FontFile" uid="uid://xjqfmx60jtvo" path="res://fonts/NotoSansJP-Bold.ttf" id="3_font_bold"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_normal.tres" id="4_exit_normal"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_hover.tres" id="5_exit_hover"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_pressed.tres" id="6_exit_pressed"]
+[ext_resource type="StyleBoxFlat" path="res://resources/styles/exit_button_focus.tres" id="7_exit_focus"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_FocusBorder"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+draw_center = false
+border_color = Color(1, 1, 1, 1)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+expand_margin_left = 8.0
+expand_margin_top = 8.0
+expand_margin_right = 8.0
+expand_margin_bottom = 8.0
+shadow_color = Color(1, 1, 1, 1)
+shadow_size = 12
 
 [sub_resource type="Gradient" id="Gradient_TopBar"]
 colors = PackedColorArray(0, 0, 0, 0.8, 0, 0, 0, 0)
@@ -69,6 +88,8 @@ anchors_preset = 0
 offset_right = 200.0
 offset_bottom = 200.0
 mouse_filter = 2
+z_index = 100
+theme_override_styles/panel = SubResource("StyleBoxFlat_FocusBorder")
 
 [node name="TopBar" type="Control" parent="."]
 layout_mode = 1
@@ -116,6 +137,10 @@ size_flags_horizontal = 3
 [node name="ExitButton" type="Button" parent="TopBar/MarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
+theme_override_styles/normal = ExtResource("4_exit_normal")
+theme_override_styles/hover = ExtResource("5_exit_hover")
+theme_override_styles/pressed = ExtResource("6_exit_pressed")
+theme_override_styles/focus = ExtResource("7_exit_focus")
 icon_alignment = 1
 expand_icon = true
 

--- a/GCTonePrism_Launcher/scripts/button_style_manager.gd
+++ b/GCTonePrism_Launcher/scripts/button_style_manager.gd
@@ -2,8 +2,9 @@ class_name ButtonStyleManager
 extends RefCounted
 ## ボタンスタイル生成を担当
 ## グローアニメーションは GlowAnimator を参照
+## スタイル（StyleBoxFlat）は .tscn で適用済み、ここではアイコンとフォーカス制御のみ
 
-## 終了ボタンのスタイルを設定する
+## 終了ボタンのアイコン・フォーカス制御を設定する
 func setup_exit_button(exit_button: Button) -> void:
 	if not exit_button:
 		return
@@ -11,38 +12,6 @@ func setup_exit_button(exit_button: Button) -> void:
 	var icon_tex = load("res://images/exit.jpg")
 	if icon_tex:
 		exit_button.icon = icon_tex
-
-	# 通常スタイル（白ボタン）
-	var style_normal = StyleBoxFlat.new()
-	style_normal.bg_color = Color.WHITE
-	style_normal.set_corner_radius_all(12)
-	style_normal.shadow_color = Color(0, 0, 0, 0.3)
-	style_normal.shadow_size = 4
-	style_normal.shadow_offset = Vector2(0, 0)
-	style_normal.content_margin_left = 4
-	style_normal.content_margin_right = 4
-	style_normal.content_margin_top = 4
-	style_normal.content_margin_bottom = 4
-	exit_button.add_theme_stylebox_override("normal", style_normal)
-
-	# ホバー
-	var style_hover = style_normal.duplicate()
-	style_hover.bg_color = Color(0.9, 0.9, 0.9, 1.0)
-	exit_button.add_theme_stylebox_override("hover", style_hover)
-
-	# 押下
-	var style_pressed = style_normal.duplicate()
-	style_pressed.bg_color = Color(0.7, 0.7, 0.7, 1.0)
-	exit_button.add_theme_stylebox_override("pressed", style_pressed)
-
-	# フォーカス（透明 — 共有フォーカス枠で管理）
-	var style_focus = StyleBoxFlat.new()
-	style_focus.bg_color = Color.TRANSPARENT
-	style_focus.draw_center = false
-	style_focus.border_color = Color.TRANSPARENT
-	style_focus.shadow_color = Color.TRANSPARENT
-	style_focus.shadow_size = 0
-	exit_button.add_theme_stylebox_override("focus", style_focus)
 
 	# フォーカス制御 (Self-loop) - シーンツリーに追加後に設定
 	if exit_button.is_inside_tree():
@@ -56,34 +25,6 @@ func setup_exit_button(exit_button: Button) -> void:
 			exit_button.focus_neighbor_top = exit_button.get_path()
 		, CONNECT_ONE_SHOT)
 
-## プレイボタンのスタイルを設定する
-func setup_play_button(play_button: Button) -> void:
-	if not play_button:
-		return
-
-	# 通常スタイル（緑）
-	var style_normal = StyleBoxFlat.new()
-	style_normal.bg_color = Color(0.0, 0.6, 0.0, 1.0)
-	style_normal.set_corner_radius_all(10)
-	style_normal.content_margin_left = 20
-	style_normal.content_margin_right = 20
-	play_button.add_theme_stylebox_override("normal", style_normal)
-
-	# ホバー
-	var style_hover = style_normal.duplicate()
-	style_hover.bg_color = Color(0.2, 0.8, 0.2, 1.0)
-	play_button.add_theme_stylebox_override("hover", style_hover)
-
-	# フォーカス（透明 — 共有フォーカス枠で管理）
-	var style_focus = StyleBoxFlat.new()
-	style_focus.bg_color = Color.TRANSPARENT
-	style_focus.draw_center = false
-	style_focus.border_color = Color.TRANSPARENT
-	style_focus.shadow_color = Color.TRANSPARENT
-	style_focus.shadow_size = 0
-	play_button.add_theme_stylebox_override("focus", style_focus)
-
-	# 押下
-	var style_pressed = style_normal.duplicate()
-	style_pressed.bg_color = Color(0.0, 0.4, 0.0, 1.0)
-	play_button.add_theme_stylebox_override("pressed", style_pressed)
+## プレイボタンのスタイルを設定する（スタイルは .tscn で適用済み）
+func setup_play_button(_play_button: Button) -> void:
+	pass

--- a/GCTonePrism_Launcher/scripts/game_info_display.gd
+++ b/GCTonePrism_Launcher/scripts/game_info_display.gd
@@ -145,18 +145,16 @@ func _update_background(game: GameInfo, slide_dir_y: int,
 		_bg_tween.tween_property(background_old, "position", Vector2(0, old_target_y), 0.3).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
 		_bg_tween.tween_property(background_old, "modulate", Color(1, 1, 1, 0), 0.3)
 
-func _update_bar_style(bar: ProgressBar, value: int) -> void:
-	var style = StyleBoxFlat.new()
-	style.set_corner_radius_all(4)
-	if value <= 1:
-		style.bg_color = Color(0.2, 0.8, 0.2, 1.0)
-	elif value == 2:
-		style.bg_color = Color(0.9, 0.9, 0.2, 1.0)
-	else:
-		style.bg_color = Color(0.9, 0.2, 0.2, 1.0)
-	bar.add_theme_stylebox_override("fill", style)
+static var _fill_easy: StyleBoxFlat = preload("res://resources/styles/progress_fill_easy.tres")
+static var _fill_medium: StyleBoxFlat = preload("res://resources/styles/progress_fill_medium.tres")
+static var _fill_hard: StyleBoxFlat = preload("res://resources/styles/progress_fill_hard.tres")
+static var _progress_bg: StyleBoxFlat = preload("res://resources/styles/progress_background.tres")
 
-	var bg = StyleBoxFlat.new()
-	bg.set_corner_radius_all(4)
-	bg.bg_color = Color(0.2, 0.2, 0.2, 1.0)
-	bar.add_theme_stylebox_override("background", bg)
+func _update_bar_style(bar: ProgressBar, value: int) -> void:
+	if value <= 1:
+		bar.add_theme_stylebox_override("fill", _fill_easy)
+	elif value == 2:
+		bar.add_theme_stylebox_override("fill", _fill_medium)
+	else:
+		bar.add_theme_stylebox_override("fill", _fill_hard)
+	bar.add_theme_stylebox_override("background", _progress_bg)

--- a/GCTonePrism_Launcher/scripts/store_banner_builder.gd
+++ b/GCTonePrism_Launcher/scripts/store_banner_builder.gd
@@ -71,25 +71,14 @@ static func build_slideshow_section(section: StoreSectionInfo, viewport_width: f
 	bars.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	container.add_child(bars)
 
-	# 下部グラデーションオーバーレイ
+	# 下部グラデーションオーバーレイ（シェーダーは .tres で定義済み）
 	var ss_gradient_height := StoreBrowseBuilder.FEATURED_HEIGHT * 0.35
 	var ss_gradient = Panel.new()
 	ss_gradient.name = "SlideshowGradient"
 	ss_gradient.position = Vector2(0, StoreBrowseBuilder.FEATURED_HEIGHT - ss_gradient_height)
 	ss_gradient.size = Vector2(banner_width, ss_gradient_height)
 	ss_gradient.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	var ss_shader_code = """
-shader_type canvas_item;
-void fragment() {
-	float alpha = smoothstep(0.0, 1.0, UV.y);
-	COLOR = vec4(0.0, 0.0, 0.0, alpha * 0.85 * COLOR.a);
-}
-"""
-	var ss_shader = Shader.new()
-	ss_shader.code = ss_shader_code
-	var ss_mat = ShaderMaterial.new()
-	ss_mat.shader = ss_shader
-	ss_gradient.material = ss_mat
+	ss_gradient.material = preload("res://shaders/gradient_overlay_strong_material.tres")
 	var ss_grad_style = StyleBoxFlat.new()
 	ss_grad_style.bg_color = Color(1, 1, 1, 1)
 	ss_grad_style.corner_radius_bottom_left = 16
@@ -180,25 +169,14 @@ static func create_banner(game: GameInfo, banner_size: Vector2, custom_text: Str
 
 	banner.add_child(tex_rect)
 
-	# 下部グラデーションオーバーレイ
+	# 下部グラデーションオーバーレイ（シェーダーは .tres で定義済み）
 	var gradient_height := banner_size.y * 0.35
 	var gradient_panel = Panel.new()
 	gradient_panel.name = "GradientOverlay"
 	gradient_panel.position = Vector2(0, banner_size.y - gradient_height)
 	gradient_panel.size = Vector2(banner_size.x, gradient_height)
 	gradient_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	var shader_code = """
-shader_type canvas_item;
-void fragment() {
-	float alpha = smoothstep(0.0, 1.0, UV.y);
-	COLOR = vec4(0.0, 0.0, 0.0, alpha * 0.5 * COLOR.a);
-}
-"""
-	var shader = Shader.new()
-	shader.code = shader_code
-	var mat = ShaderMaterial.new()
-	mat.shader = shader
-	gradient_panel.material = mat
+	gradient_panel.material = preload("res://shaders/gradient_overlay_material.tres")
 	var grad_style = StyleBoxFlat.new()
 	grad_style.bg_color = Color(1, 1, 1, 1)
 	grad_style.corner_radius_bottom_left = 16

--- a/GCTonePrism_Launcher/scripts/store_browse_builder.gd
+++ b/GCTonePrism_Launcher/scripts/store_browse_builder.gd
@@ -43,20 +43,9 @@ static func build_normal_section(section: StoreSectionInfo, viewport_width: floa
 	container.name = "Section_%d" % section.section_id
 	container.add_theme_constant_override("separation", 12)
 
-	# ヘッダー行: セクション名 + 「すべて見る →」
-	var header = HBoxContainer.new()
-	header.add_theme_constant_override("separation", 20)
-
-	var title_label = Label.new()
-	title_label.text = section.title
-	title_label.add_theme_font_override("font", _get_font_bold())
-	title_label.add_theme_font_size_override("font_size", 28)
-	title_label.add_theme_color_override("font_color", Color.WHITE)
-	header.add_child(title_label)
-
-	var spacer = Control.new()
-	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	header.add_child(spacer)
+	# ヘッダー行（.tscn テンプレートを使用）
+	var header = preload("res://scenes/components/store_section_header.tscn").instantiate()
+	header.get_node("SectionTitle").text = section.title
 
 	# 画面幅から表示上限を自動計算（タイルサイズ+間隔で割る）
 	var available_width = viewport_width - FEATURED_PADDING * 2
@@ -66,16 +55,8 @@ static func build_normal_section(section: StoreSectionInfo, viewport_width: floa
 
 	# ゲーム数が画面に収まるなら「すべて見る」不要
 	if section.games.size() > effective_max:
-		var view_all_btn = Button.new()
-		view_all_btn.name = "ViewAllButton"
-		view_all_btn.text = "すべて見る →"
-		view_all_btn.flat = true
-		view_all_btn.add_theme_font_override("font", _get_font_regular())
-		view_all_btn.add_theme_font_size_override("font_size", 20)
-		view_all_btn.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
-		view_all_btn.add_theme_color_override("font_hover_color", Color.WHITE)
-		view_all_btn.focus_mode = Control.FOCUS_ALL
-		header.add_child(view_all_btn)
+		var view_all_btn = header.get_node("ViewAllButton")
+		view_all_btn.visible = true
 
 	container.add_child(header)
 
@@ -95,78 +76,25 @@ static func build_normal_section(section: StoreSectionInfo, viewport_width: floa
 ## ゲームタイル（通常セクション用 200x200 + 下部タイトル）を作成
 ## 戻り値はVBoxContainer（Panel + Label）、フォーカス対象はPanel部分
 static func _create_game_tile(game: GameInfo) -> Control:
-	var wrapper = VBoxContainer.new()
+	var wrapper = preload("res://scenes/components/store_game_tile.tscn").instantiate()
 	wrapper.name = "Tile_%s" % game.game_id
-	wrapper.add_theme_constant_override("separation", 6)
-
-	# サムネイルパネル
-	var tile = Panel.new()
-	tile.name = "TilePanel"
-	tile.custom_minimum_size = TILE_SIZE
-	tile.focus_mode = Control.FOCUS_ALL
-
-	# 背景スタイル
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.15, 0.15, 0.15)
-	style.set_corner_radius_all(16)
-	tile.add_theme_stylebox_override("panel", style)
-	tile.clip_children = CanvasItem.CLIP_CHILDREN_AND_DRAW
 
 	# サムネイル画像
-	var tex_rect = TextureRect.new()
-	tex_rect.name = "Thumbnail"
-	tex_rect.position = Vector2.ZERO
-	tex_rect.size = TILE_SIZE
-	tex_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-	tex_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
-
 	var thumb_path = _resolve_thumbnail_path(game)
 	if not thumb_path.is_empty():
 		var image = Image.load_from_file(thumb_path)
 		if image != null:
-			tex_rect.texture = ImageTexture.create_from_image(image)
+			wrapper.get_node("TilePanel/Thumbnail").texture = ImageTexture.create_from_image(image)
 
-	tile.add_child(tex_rect)
-	wrapper.add_child(tile)
-
-	# タイトルラベル（アイコン下、中央揃え）
-	var title_label = Label.new()
-	title_label.name = "TitleLabel"
-	title_label.text = game.title
-	title_label.add_theme_font_override("font", _get_font_regular())
-	title_label.add_theme_font_size_override("font_size", 14)
-	title_label.add_theme_color_override("font_color", Color(0.85, 0.85, 0.85))
-	title_label.custom_minimum_size = Vector2(TILE_SIZE.x, 0)
-	title_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	title_label.clip_text = true
-	wrapper.add_child(title_label)
+	# タイトル
+	wrapper.get_node("TitleLabel").text = game.title
 
 	return wrapper
 
-## 「すべてのゲーム」ボタンを構築
+## 「すべてのゲーム」ボタンを構築（.tscn テンプレートを使用）
 static func build_all_games_button(viewport_width: float) -> Button:
-	var btn = Button.new()
-	btn.name = "AllGamesButton"
-	btn.text = "すべてのゲーム →"
-	btn.add_theme_font_override("font", _get_font_bold())
-	btn.add_theme_font_size_override("font_size", 22)
-	btn.add_theme_color_override("font_color", Color(0.9, 0.9, 0.9))
-	btn.add_theme_color_override("font_hover_color", Color.WHITE)
+	var btn = preload("res://scenes/components/store_all_games_button.tscn").instantiate()
 	btn.custom_minimum_size = Vector2(viewport_width - FEATURED_PADDING * 2, 60)
-	btn.focus_mode = Control.FOCUS_ALL
-	# スタイル
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.2, 0.2, 0.2, 0.6)
-	style.set_corner_radius_all(12)
-	btn.add_theme_stylebox_override("normal", style)
-	var hover_style = StyleBoxFlat.new()
-	hover_style.bg_color = Color(0.3, 0.3, 0.3, 0.8)
-	hover_style.set_corner_radius_all(12)
-	btn.add_theme_stylebox_override("hover", hover_style)
-	var pressed_style = StyleBoxFlat.new()
-	pressed_style.bg_color = Color(0.25, 0.25, 0.25, 0.9)
-	pressed_style.set_corner_radius_all(12)
-	btn.add_theme_stylebox_override("pressed", pressed_style)
 	return btn
 
 ## サムネイルパスを解決

--- a/GCTonePrism_Launcher/shaders/gradient_overlay.gdshader
+++ b/GCTonePrism_Launcher/shaders/gradient_overlay.gdshader
@@ -1,0 +1,6 @@
+shader_type canvas_item;
+uniform float alpha_multiplier : hint_range(0.0, 1.0) = 0.5;
+void fragment() {
+	float alpha = smoothstep(0.0, 1.0, UV.y);
+	COLOR = vec4(0.0, 0.0, 0.0, alpha * alpha_multiplier * COLOR.a);
+}

--- a/GCTonePrism_Launcher/shaders/gradient_overlay.gdshader.uid
+++ b/GCTonePrism_Launcher/shaders/gradient_overlay.gdshader.uid
@@ -1,0 +1,1 @@
+uid://yt74yjpgmqx7

--- a/GCTonePrism_Launcher/shaders/gradient_overlay_material.tres
+++ b/GCTonePrism_Launcher/shaders/gradient_overlay_material.tres
@@ -1,0 +1,7 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3]
+
+[ext_resource type="Shader" path="res://shaders/gradient_overlay.gdshader" id="1_shader"]
+
+[resource]
+shader = ExtResource("1_shader")
+shader_parameter/alpha_multiplier = 0.5

--- a/GCTonePrism_Launcher/shaders/gradient_overlay_strong_material.tres
+++ b/GCTonePrism_Launcher/shaders/gradient_overlay_strong_material.tres
@@ -1,0 +1,7 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3]
+
+[ext_resource type="Shader" path="res://shaders/gradient_overlay.gdshader" id="1_shader"]
+
+[resource]
+shader = ExtResource("1_shader")
+shader_parameter/alpha_multiplier = 0.85


### PR DESCRIPTION
## Summary
- GDScript内でNode.new()やStyleBoxFlat.new()で動的生成していたUI構造を、.tscnシーンファイルや.tresリソースファイルに移行
- インラインシェーダーコードを `.gdshader` + `.tres` マテリアルに外部化
- 12個のStyleBoxFlat `.tres` リソース、5つのコンポーネント `.tscn` テンプレートを新規作成
- GDScriptから約130行のスタイル生成コードを削除（-245行 / +423行、大半は新規リソースファイル）
- **見た目の変更なし**（Phase 3 MD3化の準備）

## 新規ファイル
### シェーダー (`shaders/`)
- `gradient_overlay.gdshader` — パラメータ化されたグラデーションシェーダー
- `gradient_overlay_material.tres` — バナー用（alpha_multiplier=0.5）
- `gradient_overlay_strong_material.tres` — スライドショー用（alpha_multiplier=0.85）

### スタイル (`resources/styles/`)
- exit_button_{normal,hover,pressed,focus}.tres
- play_button_{normal,hover,pressed,focus}.tres
- progress_fill_{easy,medium,hard}.tres, progress_background.tres

### コンポーネント (`scenes/components/`)
- `back_button.tscn` — 戻るボタン
- `store_game_tile.tscn` — ゲームタイル（200x200）
- `store_section_header.tscn` — セクションヘッダー
- `store_all_games_button.tscn` — 「すべてのゲーム」ボタン
- `store_banner.tscn` — バナーテンプレート

## Test plan
- [ ] Godotエディタでパースエラーなし
- [ ] ゲーム選択画面の見た目が変更前と同一
- [ ] ストアブラウズ画面の見た目が変更前と同一
- [ ] ダイアログのフォーカス枠が正常動作
- [ ] 進捗バーの色分け（Easy緑/Medium黄/Hard赤）が正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)