### PR TITLE
feat(manager): データベースバックアップ・復元機能 (v0.8.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,10 @@ prism.db
 *.db-journal
 *.db-wal
 
+# データベースバックアップ（Manager のバックアップ機能で生成される）
+backups/
+# 旧版 Manager 由来でプロジェクトルート直下に作られた退避ファイル
+safety_before_restore_*.db
+
 # ゲームファイル（容量が大きいため除外）
 games/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,79 @@
 
 ## Manager（管理ソフト）
 
+### [Manager v0.8.0] - 2026-05-07
+
+#### Added
+
+- **データベースバックアップ機能 (#96)**: `prism.db` のスナップショットを Manager から取得・管理できる機能を新設
+  - **新規タブ「バックアップ」**: MainForm に4タブ目を追加し、専用UIを設置
+  - **手動バックアップ**: 「今すぐバックアップ」ボタンで即時実行。SQLite Online Backup API (`SQLiteConnection.BackupDatabase`) を使用するため、Launcher が `prism.db` を開いている状態でも整合性を保ったコピーが可能
+  - **自動バックアップ**: Manager 起動時に「前回バックアップから設定間隔（デフォルト 24h）以上経過していたら走らせる」方式。バックグラウンドタスクで起動をブロックしない
+  - **マルチPC重複防止**: `settings.last_backup_at` を `BEGIN IMMEDIATE` (System.Data.SQLite における `IsolationLevel.Serializable`) で更新する lease 方式。複数のManagerが同時起動した場合でも片方のみが自動バックアップを走らせる
+  - **バックアップ履歴一覧**: DataGridView で過去 100 件までを表示（開始日時 / 完了日時 / 実行PC / トリガ / 状態 / サイズ / ファイルパス）
+  - **世代管理**: 設定値 `backup_retention_count`（デフォルト 30）を超える古いバックアップは自動削除
+  - **保存先設定**: デフォルトは `<DBフォルダ>/backups/`、`BackupSettingsForm` から任意のフォルダに変更可能（FolderBrowserDialog 経由）
+  - **リストア機能**: 履歴から選択 → 警告（「全Launcher を停止してください」「現DBは退避されます」）+ 4桁確認コード入力（`ResetDatabaseConfirmForm` の安全パターンを踏襲）→ 現DBを `safety_before_restore_HHmmss.db` として Online Backup API で退避 → SQLite 接続プールクリア → `prism.db` / `prism.db-wal` / `prism.db-shm` 削除 → バックアップを `prism.db` としてコピー → DB再初期化
+- **新規ファイル**:
+  - `Models/BackupLogEntry.cs` — `backup_log` テーブルのモデル（UNIX秒 → `DateTime` 変換ヘルパー付き）
+  - `Repositories/BackupLogRepository.cs` — `backup_log` の CRUD（in_progress → success/failed の状態遷移）
+  - `Repositories/SettingsRepository.cs` — `settings` テーブルへの汎用アクセサ + バックアップ lease 取得 (`TryAcquireBackupLease`)
+  - `Services/BackupService.cs` — バックアップのドメインロジック、Online Backup API 呼び出し、リテンション処理、`BackupResult` 結果モデル
+  - `Services/RestoreService.cs` — 退避 + 接続プールクリア + 上書きの安全な復元手順
+  - `Controls/BackupSectionPanel.cs` (.Designer.cs) — バックアップタブのUserControl
+  - `BackupSettingsForm.cs` (.Designer.cs) — 設定ダイアログ
+  - `RestoreConfirmForm.cs` (.Designer.cs) — 復元確認ダイアログ
+
+#### Changed
+
+- **DBスキーマ v8 → v9**: additive migration（既存テーブル変更なし、Launcher 互換性に影響なし）
+  - `backup_log` テーブル新設（id, started_at, completed_at, pc_name, file_path, file_size_bytes, status, error_message, trigger_type）
+  - `settings` テーブルに 4 キー追加（`last_backup_at`, `backup_destination_path`, `backup_auto_interval_hours`, `backup_retention_count`）
+  - 自動マイグレーション（`SchemaManager.MigrateV8ToV9`）が起動時に実行される
+- **`settings` テーブルの KVS スキーマ整合化**: SPECIFICATION 1.3.1 (2026-02-08) で「単一行 → KVS方式」に変更されていたが、既存DB向けマイグレーションが実装されていなかったため、それより前に作られたDBは古いスキーマのままだった。Manager v0.8.0 では起動時に `settings` テーブルの `key` カラム有無を検査し、無ければ古いテーブルを `settings_legacy_v8_or_earlier` にリネームしてから KVS 方式の新テーブルを作成する移行処理を追加（`EnsureSettingsTableIsKvsSchema`）。旧データに実コードからの参照は無かったためデータロスは発生しないが、念のため legacy テーブルとして退避
+- **`DatabaseManager` ファサードを拡張**: 新規プロパティ `BackupService`, `RestoreService`, `BackupLogRepository`, `SettingsRepository` を追加
+- **`ProcessingDialog` を拡張 (#99 関連)**: `MarqueeMode` プロパティ（進捗が定量化できない処理向けの流れるバー）と `AllowCancel` プロパティ（中断不可な処理向けにキャンセルボタン非表示化）を追加
+- **進捗バーが付いていなかった重め操作にプログレス表示を追加 (#99)**:
+  - **EditGameForm**: ゲームID変更時の `Directory.Move(oldFolder, newFolder)` + `UpdateGameId` をマーキー進捗で表示。失敗時のロールバック（フォルダを元に戻す）処理にも進捗メッセージ。共有フォルダ越し・クロスボリューム時の体感速度を改善
+  - **SettingsSectionPanel**: 「データベースリセット」操作（DBファイル削除 + テーブル再作成 + マイグレーション再実行）をマーキー進捗で表示
+  - **GameSectionPanel**: 「ゲーム削除」操作（CASCADE で developers / game_versions / game_genres / play_records / surveys / store_section_games の関連レコード削除）をマーキー進捗で表示
+
+#### Fixed
+
+- **`backup_log` の自己参照スナップショット問題**: 「今すぐバックアップ」中の `backup_log` には `in_progress` 行が既に書き込まれているため、SQLite Online Backup API でコピーした .db ファイルにも自分自身の `in_progress` 行が含まれてしまう。後でその .db から復元すると、履歴一覧に「進行中のままのゴースト行」が現れる挙動だった
+  - **`InsertInProgress` 時点で予定ファイルパスを記録するよう変更**: 旧実装ではバックアップ完了後にファイルパスを書き込んでいたため、自己参照スナップショットには空の `file_path` が入っていた。最初から書き込むことで「実ファイルが存在するか」での判別が可能になった
+  - **`BackupLogRepository.ReconcileInProgressEntries(reasonIfMissing, thresholdSeconds)` を新設**: 各 `in_progress` 行について実ファイルの有無を確認し、存在すれば `success`（実ファイルサイズで `file_size_bytes` 更新）、存在しなければ `failed` に更新する。閾値秒数を null にすると全件対象、指定すると古い行のみ対象（実行中のバックアップに干渉しない）
+  - **`MainForm` 起動時**: 閾値 600 秒で呼ぶ（Manager クラッシュ等で取り残された古い行のみリコンサイル）
+  - **`MainForm.OnDatabaseRestored`**: 閾値なしで呼ぶ（復元直後はスナップショットの状態なので、参照されているファイルが実在すれば正しく `success` として復元される）
+  - これにより「**バックアップ実体ファイルは存在しているのに失敗扱いになる**」という不自然なUXが解消され、復元に使ったまさにそのファイルが「成功」表示で履歴に残る
+- **更新ボタンが新しいエントリを反映しないことがある問題の改善**: System.Data.SQLite の接続プールが古いスナップショットを保持して新しいコミットを見せないケースに対応。`BackupSectionPanel.RefreshDisplay()` 内で `SQLiteConnection.ClearAllPools()` を呼んで強制的にプールを掃除してから読み直すように変更
+- **更新ボタンに包括リコンサイル機能を追加**: `BackupSectionPanel.RefreshDisplay()` で表示更新前に以下を実行：
+  - `ReconcileInProgressEntries` を `recoverFailedWithExistingFile=true` で実行 — `failed` 行のうち `file_path` が指すファイルが実在するものを `success` に救済
+  - `RecoverLegacyFailedEntriesByFolderScan` を実行 — `file_path` が空のまま残っている `failed` 行について、バックアップフォルダ内の `prism_yyyyMMdd_HHmmss.db` 形式のファイル名と `started_at` を ±1 秒範囲で照合し、一致すれば `success` として復元（旧バージョン Manager 由来のゴースト救済）
+  - 「ファイルが本当に無い `failed` 行」（実際のディスク満杯エラー等）はそのまま保持されるので、誤って成功扱いに戻すことはない
+
+#### Changed (UI)
+
+- **バックアップ履歴の状態表示を視覚的に改善**: 表示は **成功 / 失敗 / 実行中** の3状態に統一しつつ、状態セルに **背景色**（淡緑 / 淡赤 / 淡青）と **ツールチップ** を追加。技術的な詳細（クラッシュ残骸 vs 実行直後の通常ケースなど）はツールチップに押し込んで本体表示はシンプルに：
+  - **成功** → 「バックアップは完了済みです。この行から復元できます。」
+  - **失敗** → `error_message` の内容（「中断理由: ◯◯」）。空なら「実ファイルが存在しないため復元には使えません。」
+  - **実行中（30秒以内）** → 「現在実行中です（経過: X 秒）」
+  - **実行中（30秒以上）** → 「前回 Manager 異常終了の残骸の可能性があります（経過: X 分）。更新ボタンを押すと実ファイルの有無で 成功/失敗 が確定します。」
+  - 選択中も色味が保たれるよう `SelectionBackColor` も状態に合わせて設定
+
+#### Changed (Safety Backup の取り扱い改善)
+
+- **DBスキーマ v9 → v10**: `backup_log.trigger_type` の CHECK 制約を `('manual', 'auto')` から `('manual', 'auto', 'safety')` に拡張。SQLite では CHECK 制約を ALTER できないため、`backup_log_new` を作成してデータを移し替える方式で実施
+- **退避ファイルの保存先を整理**: 旧 `<DBフォルダ>/safety_before_restore_yyyyMMdd_HHmmss.db`（プロジェクトルート直下）から、`<DBフォルダ>/backups/safety/safety_yyyyMMdd_HHmmss.db` に変更
+  - `RestoreService.Restore` 内で退避先を構築・作成
+  - Manager 起動時に旧形式のファイルを `backups/safety/` へ自動移動（`BackupService.MigrateLegacySafetyFilesToSafetyFolder`、idempotent）
+- **退避ファイルの世代管理**: `backups/safety/` 内のファイルを最新10件まで保持し、超過分は古いものから自動削除（`RestoreService.ApplySafetyRetention`）
+- **退避ファイルを履歴UIに統合**: `BackupLogRepository.RegisterUnknownSafetyFiles` で `backups/safety/` をスキャンし、`backup_log` に未登録の退避ファイルを `trigger_type='safety'`, `status='success'` で自動登録。`started_at` はファイル名のタイムスタンプから復元
+  - Manager 起動時 / バックアップ復元後 / 更新ボタン押下時の各タイミングで実行
+  - 履歴グリッドで「退避」とラベル表示（「手動」「自動」と並ぶ第3のトリガ種別）
+  - 退避ファイルから直接「選択したバックアップから復元」も可能（誤った復元のロールバック手段）
+- **`.gitignore` 修正**: `backups/`（通常バックアップ＋退避フォルダ）と旧形式の `safety_before_restore_*.db` を git 管理から除外。これまで `git add .` でうっかりコミットされる危険があった
+
 ### [Manager v0.7.6] - 2026-03-29
 
 #### Changed

--- a/GCTonePrism_Manager/BackupSettingsForm.Designer.cs
+++ b/GCTonePrism_Manager/BackupSettingsForm.Designer.cs
@@ -1,0 +1,196 @@
+namespace GCTonePrism.Manager
+{
+    partial class BackupSettingsForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows フォーム デザイナーで生成されたコード
+
+        private void InitializeComponent()
+        {
+            this.lblDestPath = new System.Windows.Forms.Label();
+            this.txtDestPath = new System.Windows.Forms.TextBox();
+            this.btnBrowse = new System.Windows.Forms.Button();
+            this.lblDestHint = new System.Windows.Forms.Label();
+            this.lblInterval = new System.Windows.Forms.Label();
+            this.numInterval = new System.Windows.Forms.NumericUpDown();
+            this.lblIntervalUnit = new System.Windows.Forms.Label();
+            this.lblRetention = new System.Windows.Forms.Label();
+            this.numRetention = new System.Windows.Forms.NumericUpDown();
+            this.lblRetentionUnit = new System.Windows.Forms.Label();
+            this.btnOk = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.numInterval)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numRetention)).BeginInit();
+            this.SuspendLayout();
+            //
+            // lblDestPath
+            //
+            this.lblDestPath.AutoSize = true;
+            this.lblDestPath.Location = new System.Drawing.Point(20, 25);
+            this.lblDestPath.Name = "lblDestPath";
+            this.lblDestPath.Size = new System.Drawing.Size(115, 15);
+            this.lblDestPath.TabIndex = 0;
+            this.lblDestPath.Text = "バックアップ保存先:";
+            //
+            // txtDestPath
+            //
+            this.txtDestPath.Location = new System.Drawing.Point(20, 45);
+            this.txtDestPath.Name = "txtDestPath";
+            this.txtDestPath.Size = new System.Drawing.Size(440, 23);
+            this.txtDestPath.TabIndex = 1;
+            //
+            // btnBrowse
+            //
+            this.btnBrowse.Location = new System.Drawing.Point(470, 44);
+            this.btnBrowse.Name = "btnBrowse";
+            this.btnBrowse.Size = new System.Drawing.Size(80, 26);
+            this.btnBrowse.TabIndex = 2;
+            this.btnBrowse.Text = "参照...";
+            this.btnBrowse.UseVisualStyleBackColor = true;
+            this.btnBrowse.Click += new System.EventHandler(this.btnBrowse_Click);
+            //
+            // lblDestHint
+            //
+            this.lblDestHint.AutoSize = true;
+            this.lblDestHint.ForeColor = System.Drawing.Color.DimGray;
+            this.lblDestHint.Location = new System.Drawing.Point(20, 75);
+            this.lblDestHint.Name = "lblDestHint";
+            this.lblDestHint.Size = new System.Drawing.Size(420, 15);
+            this.lblDestHint.TabIndex = 3;
+            this.lblDestHint.Text = "空欄にするとデフォルト（DBファイルの隣の backups/ フォルダ）が使われます";
+            //
+            // lblInterval
+            //
+            this.lblInterval.AutoSize = true;
+            this.lblInterval.Location = new System.Drawing.Point(20, 115);
+            this.lblInterval.Name = "lblInterval";
+            this.lblInterval.Size = new System.Drawing.Size(180, 15);
+            this.lblInterval.TabIndex = 4;
+            this.lblInterval.Text = "自動バックアップ間隔 (Manager起動時にチェック):";
+            //
+            // numInterval
+            //
+            this.numInterval.Location = new System.Drawing.Point(20, 135);
+            this.numInterval.Maximum = new decimal(new int[] { 720, 0, 0, 0 });
+            this.numInterval.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            this.numInterval.Name = "numInterval";
+            this.numInterval.Size = new System.Drawing.Size(80, 23);
+            this.numInterval.TabIndex = 5;
+            this.numInterval.Value = new decimal(new int[] { 24, 0, 0, 0 });
+            //
+            // lblIntervalUnit
+            //
+            this.lblIntervalUnit.AutoSize = true;
+            this.lblIntervalUnit.Location = new System.Drawing.Point(108, 138);
+            this.lblIntervalUnit.Name = "lblIntervalUnit";
+            this.lblIntervalUnit.Size = new System.Drawing.Size(160, 15);
+            this.lblIntervalUnit.TabIndex = 6;
+            this.lblIntervalUnit.Text = "時間以上経過していたら実行";
+            //
+            // lblRetention
+            //
+            this.lblRetention.AutoSize = true;
+            this.lblRetention.Location = new System.Drawing.Point(20, 175);
+            this.lblRetention.Name = "lblRetention";
+            this.lblRetention.Size = new System.Drawing.Size(95, 15);
+            this.lblRetention.TabIndex = 7;
+            this.lblRetention.Text = "保持する世代数:";
+            //
+            // numRetention
+            //
+            this.numRetention.Location = new System.Drawing.Point(20, 195);
+            this.numRetention.Maximum = new decimal(new int[] { 999, 0, 0, 0 });
+            this.numRetention.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            this.numRetention.Name = "numRetention";
+            this.numRetention.Size = new System.Drawing.Size(80, 23);
+            this.numRetention.TabIndex = 8;
+            this.numRetention.Value = new decimal(new int[] { 30, 0, 0, 0 });
+            //
+            // lblRetentionUnit
+            //
+            this.lblRetentionUnit.AutoSize = true;
+            this.lblRetentionUnit.Location = new System.Drawing.Point(108, 198);
+            this.lblRetentionUnit.Name = "lblRetentionUnit";
+            this.lblRetentionUnit.Size = new System.Drawing.Size(280, 15);
+            this.lblRetentionUnit.TabIndex = 9;
+            this.lblRetentionUnit.Text = "個 (これを超えた古いバックアップは自動削除されます)";
+            //
+            // btnOk
+            //
+            this.btnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOk.Location = new System.Drawing.Point(370, 240);
+            this.btnOk.Name = "btnOk";
+            this.btnOk.Size = new System.Drawing.Size(90, 32);
+            this.btnOk.TabIndex = 10;
+            this.btnOk.Text = "保存";
+            this.btnOk.UseVisualStyleBackColor = true;
+            this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
+            //
+            // btnCancel
+            //
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(470, 240);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(90, 32);
+            this.btnCancel.TabIndex = 11;
+            this.btnCancel.Text = "キャンセル";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            //
+            // BackupSettingsForm
+            //
+            this.AcceptButton = this.btnOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(580, 290);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnOk);
+            this.Controls.Add(this.lblRetentionUnit);
+            this.Controls.Add(this.numRetention);
+            this.Controls.Add(this.lblRetention);
+            this.Controls.Add(this.lblIntervalUnit);
+            this.Controls.Add(this.numInterval);
+            this.Controls.Add(this.lblInterval);
+            this.Controls.Add(this.lblDestHint);
+            this.Controls.Add(this.btnBrowse);
+            this.Controls.Add(this.txtDestPath);
+            this.Controls.Add(this.lblDestPath);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "BackupSettingsForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "バックアップ設定";
+            ((System.ComponentModel.ISupportInitialize)(this.numInterval)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numRetention)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblDestPath;
+        private System.Windows.Forms.TextBox txtDestPath;
+        private System.Windows.Forms.Button btnBrowse;
+        private System.Windows.Forms.Label lblDestHint;
+        private System.Windows.Forms.Label lblInterval;
+        private System.Windows.Forms.NumericUpDown numInterval;
+        private System.Windows.Forms.Label lblIntervalUnit;
+        private System.Windows.Forms.Label lblRetention;
+        private System.Windows.Forms.NumericUpDown numRetention;
+        private System.Windows.Forms.Label lblRetentionUnit;
+        private System.Windows.Forms.Button btnOk;
+        private System.Windows.Forms.Button btnCancel;
+    }
+}

--- a/GCTonePrism_Manager/BackupSettingsForm.cs
+++ b/GCTonePrism_Manager/BackupSettingsForm.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Windows.Forms;
+using GCTonePrism.Manager.Repositories;
+using GCTonePrism.Manager.Services;
+
+namespace GCTonePrism.Manager
+{
+    /// <summary>
+    /// バックアップ機能の設定ダイアログ。
+    /// 保存先パス、自動バックアップ間隔、世代数を設定する。
+    /// </summary>
+    public partial class BackupSettingsForm : Form
+    {
+        private readonly SettingsRepository _settingsRepo;
+        private readonly BackupService _backupService;
+
+        public BackupSettingsForm(SettingsRepository settingsRepo, BackupService backupService)
+        {
+            InitializeComponent();
+            _settingsRepo = settingsRepo;
+            _backupService = backupService;
+            LoadSettings();
+        }
+
+        private void LoadSettings()
+        {
+            txtDestPath.Text = _settingsRepo.GetString("backup_destination_path", "");
+
+            int interval = _settingsRepo.GetInt32("backup_auto_interval_hours", 24);
+            if (interval < numInterval.Minimum) interval = (int)numInterval.Minimum;
+            if (interval > numInterval.Maximum) interval = (int)numInterval.Maximum;
+            numInterval.Value = interval;
+
+            int retention = _settingsRepo.GetInt32("backup_retention_count", 30);
+            if (retention < numRetention.Minimum) retention = (int)numRetention.Minimum;
+            if (retention > numRetention.Maximum) retention = (int)numRetention.Maximum;
+            numRetention.Value = retention;
+        }
+
+        private void btnBrowse_Click(object sender, EventArgs e)
+        {
+            using (var dialog = new FolderBrowserDialog())
+            {
+                dialog.Description = "バックアップ保存先フォルダを選択してください";
+                if (!string.IsNullOrEmpty(txtDestPath.Text))
+                {
+                    dialog.SelectedPath = txtDestPath.Text;
+                }
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    txtDestPath.Text = dialog.SelectedPath;
+                }
+            }
+        }
+
+        private void btnOk_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                _settingsRepo.SetString("backup_destination_path", txtDestPath.Text.Trim());
+                _settingsRepo.SetInt32("backup_auto_interval_hours", (int)numInterval.Value);
+                _settingsRepo.SetInt32("backup_retention_count", (int)numRetention.Value);
+                DialogResult = DialogResult.OK;
+                Close();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"設定の保存に失敗しました: {ex.Message}", "エラー",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+    }
+}

--- a/GCTonePrism_Manager/Controls/BackupSectionPanel.Designer.cs
+++ b/GCTonePrism_Manager/Controls/BackupSectionPanel.Designer.cs
@@ -1,0 +1,193 @@
+namespace GCTonePrism.Manager.Controls
+{
+    partial class BackupSectionPanel
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region コンポーネント デザイナーで生成されたコード
+
+        private void InitializeComponent()
+        {
+            this.grpActions = new System.Windows.Forms.GroupBox();
+            this.btnBackupNow = new System.Windows.Forms.Button();
+            this.lblLastBackup = new System.Windows.Forms.Label();
+            this.btnRefresh = new System.Windows.Forms.Button();
+            this.grpHistory = new System.Windows.Forms.GroupBox();
+            this.gridHistory = new System.Windows.Forms.DataGridView();
+            this.grpControls = new System.Windows.Forms.GroupBox();
+            this.btnRestore = new System.Windows.Forms.Button();
+            this.btnSettings = new System.Windows.Forms.Button();
+            this.lblDestPath = new System.Windows.Forms.Label();
+            this.grpActions.SuspendLayout();
+            this.grpHistory.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.gridHistory)).BeginInit();
+            this.grpControls.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // grpActions
+            //
+            this.grpActions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpActions.Controls.Add(this.btnBackupNow);
+            this.grpActions.Controls.Add(this.lblLastBackup);
+            this.grpActions.Controls.Add(this.btnRefresh);
+            this.grpActions.Location = new System.Drawing.Point(20, 20);
+            this.grpActions.Name = "grpActions";
+            this.grpActions.Size = new System.Drawing.Size(1040, 80);
+            this.grpActions.TabIndex = 0;
+            this.grpActions.TabStop = false;
+            this.grpActions.Text = "バックアップ操作";
+            //
+            // btnBackupNow
+            //
+            this.btnBackupNow.BackColor = System.Drawing.Color.SeaGreen;
+            this.btnBackupNow.Font = new System.Drawing.Font("MS UI Gothic", 10F, System.Drawing.FontStyle.Bold);
+            this.btnBackupNow.ForeColor = System.Drawing.Color.White;
+            this.btnBackupNow.Location = new System.Drawing.Point(20, 28);
+            this.btnBackupNow.Name = "btnBackupNow";
+            this.btnBackupNow.Size = new System.Drawing.Size(180, 36);
+            this.btnBackupNow.TabIndex = 0;
+            this.btnBackupNow.Text = "今すぐバックアップ";
+            this.btnBackupNow.UseVisualStyleBackColor = false;
+            this.btnBackupNow.Click += new System.EventHandler(this.btnBackupNow_Click);
+            //
+            // lblLastBackup
+            //
+            this.lblLastBackup.AutoSize = true;
+            this.lblLastBackup.Location = new System.Drawing.Point(220, 38);
+            this.lblLastBackup.Name = "lblLastBackup";
+            this.lblLastBackup.Size = new System.Drawing.Size(150, 15);
+            this.lblLastBackup.TabIndex = 1;
+            this.lblLastBackup.Text = "最終バックアップ: 未取得";
+            //
+            // btnRefresh
+            //
+            this.btnRefresh.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRefresh.Location = new System.Drawing.Point(940, 30);
+            this.btnRefresh.Name = "btnRefresh";
+            this.btnRefresh.Size = new System.Drawing.Size(80, 30);
+            this.btnRefresh.TabIndex = 2;
+            this.btnRefresh.Text = "更新";
+            this.btnRefresh.UseVisualStyleBackColor = true;
+            this.btnRefresh.Click += new System.EventHandler(this.btnRefresh_Click);
+            //
+            // grpHistory
+            //
+            this.grpHistory.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top
+            | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpHistory.Controls.Add(this.gridHistory);
+            this.grpHistory.Location = new System.Drawing.Point(20, 110);
+            this.grpHistory.Name = "grpHistory";
+            this.grpHistory.Size = new System.Drawing.Size(1040, 380);
+            this.grpHistory.TabIndex = 1;
+            this.grpHistory.TabStop = false;
+            this.grpHistory.Text = "バックアップ履歴";
+            //
+            // gridHistory
+            //
+            this.gridHistory.AllowUserToAddRows = false;
+            this.gridHistory.AllowUserToDeleteRows = false;
+            this.gridHistory.AllowUserToResizeRows = false;
+            this.gridHistory.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.gridHistory.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.gridHistory.Location = new System.Drawing.Point(3, 19);
+            this.gridHistory.MultiSelect = false;
+            this.gridHistory.Name = "gridHistory";
+            this.gridHistory.ReadOnly = true;
+            this.gridHistory.RowHeadersVisible = false;
+            this.gridHistory.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.gridHistory.Size = new System.Drawing.Size(1034, 358);
+            this.gridHistory.TabIndex = 0;
+            //
+            // grpControls
+            //
+            this.grpControls.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpControls.Controls.Add(this.lblDestPath);
+            this.grpControls.Controls.Add(this.btnRestore);
+            this.grpControls.Controls.Add(this.btnSettings);
+            this.grpControls.Location = new System.Drawing.Point(20, 500);
+            this.grpControls.Name = "grpControls";
+            this.grpControls.Size = new System.Drawing.Size(1040, 70);
+            this.grpControls.TabIndex = 2;
+            this.grpControls.TabStop = false;
+            this.grpControls.Text = "操作";
+            //
+            // btnRestore
+            //
+            this.btnRestore.BackColor = System.Drawing.Color.IndianRed;
+            this.btnRestore.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Bold);
+            this.btnRestore.ForeColor = System.Drawing.Color.White;
+            this.btnRestore.Location = new System.Drawing.Point(20, 25);
+            this.btnRestore.Name = "btnRestore";
+            this.btnRestore.Size = new System.Drawing.Size(220, 32);
+            this.btnRestore.TabIndex = 0;
+            this.btnRestore.Text = "選択したバックアップから復元...";
+            this.btnRestore.UseVisualStyleBackColor = false;
+            this.btnRestore.Click += new System.EventHandler(this.btnRestore_Click);
+            //
+            // btnSettings
+            //
+            this.btnSettings.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSettings.Location = new System.Drawing.Point(940, 26);
+            this.btnSettings.Name = "btnSettings";
+            this.btnSettings.Size = new System.Drawing.Size(80, 30);
+            this.btnSettings.TabIndex = 1;
+            this.btnSettings.Text = "設定...";
+            this.btnSettings.UseVisualStyleBackColor = true;
+            this.btnSettings.Click += new System.EventHandler(this.btnSettings_Click);
+            //
+            // lblDestPath
+            //
+            this.lblDestPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblDestPath.AutoEllipsis = true;
+            this.lblDestPath.Location = new System.Drawing.Point(260, 32);
+            this.lblDestPath.Name = "lblDestPath";
+            this.lblDestPath.Size = new System.Drawing.Size(670, 18);
+            this.lblDestPath.TabIndex = 2;
+            this.lblDestPath.Text = "保存先: ";
+            //
+            // BackupSectionPanel
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.grpActions);
+            this.Controls.Add(this.grpHistory);
+            this.Controls.Add(this.grpControls);
+            this.Name = "BackupSectionPanel";
+            this.Size = new System.Drawing.Size(1080, 590);
+            this.grpActions.ResumeLayout(false);
+            this.grpActions.PerformLayout();
+            this.grpHistory.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.gridHistory)).EndInit();
+            this.grpControls.ResumeLayout(false);
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox grpActions;
+        private System.Windows.Forms.Button btnBackupNow;
+        private System.Windows.Forms.Label lblLastBackup;
+        private System.Windows.Forms.Button btnRefresh;
+        private System.Windows.Forms.GroupBox grpHistory;
+        private System.Windows.Forms.DataGridView gridHistory;
+        private System.Windows.Forms.GroupBox grpControls;
+        private System.Windows.Forms.Button btnRestore;
+        private System.Windows.Forms.Button btnSettings;
+        private System.Windows.Forms.Label lblDestPath;
+    }
+}

--- a/GCTonePrism_Manager/Controls/BackupSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/BackupSectionPanel.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Data.SQLite;
+using System.Drawing;
+using System.IO;
+using System.Threading;
+using System.Windows.Forms;
+using GCTonePrism.Manager.Models;
+using GCTonePrism.Manager.Services;
+
+namespace GCTonePrism.Manager.Controls
+{
+    public partial class BackupSectionPanel : UserControl
+    {
+        private DatabaseManager _dbManager;
+
+        /// <summary>
+        /// バックアップやリストアによってDB状態が変化したときに通知される
+        /// </summary>
+        public event Action DatabaseChanged;
+
+        public BackupSectionPanel()
+        {
+            InitializeComponent();
+            ConfigureGrid();
+        }
+
+        public void Initialize(DatabaseManager dbManager)
+        {
+            _dbManager = dbManager;
+            RefreshDisplay();
+        }
+
+        private void ConfigureGrid()
+        {
+            gridHistory.AutoGenerateColumns = false;
+            gridHistory.Columns.Clear();
+            gridHistory.Columns.Add(new DataGridViewTextBoxColumn { Name = "started", HeaderText = "開始日時", Width = 150 });
+            gridHistory.Columns.Add(new DataGridViewTextBoxColumn { Name = "completed", HeaderText = "完了日時", Width = 150 });
+            gridHistory.Columns.Add(new DataGridViewTextBoxColumn { Name = "pc", HeaderText = "実行PC", Width = 110 });
+            gridHistory.Columns.Add(new DataGridViewTextBoxColumn { Name = "trigger", HeaderText = "トリガ", Width = 60 });
+            gridHistory.Columns.Add(new DataGridViewTextBoxColumn { Name = "status", HeaderText = "状態", Width = 70 });
+            gridHistory.Columns.Add(new DataGridViewTextBoxColumn { Name = "size", HeaderText = "サイズ", Width = 90 });
+            gridHistory.Columns.Add(new DataGridViewTextBoxColumn { Name = "file", HeaderText = "ファイルパス", Width = 380 });
+        }
+
+        public void RefreshDisplay()
+        {
+            if (_dbManager == null) return;
+
+            try
+            {
+                // 接続プールに古いスナップショットが残ると新しい書き込みが見えないことがあるので
+                // プールを掃除して常に最新コミット状態を読みに行くようにする
+                SQLiteConnection.ClearAllPools();
+
+                // 表示更新前にリコンサイル：
+                //   - in_progress 行 → ファイル実在で success/failed 判定（閾値なし=全件）
+                //   - failed 行のうちファイルが見つかるもの → success に救済
+                //   - file_path が空の failed 行 → バックアップフォルダをスキャンして
+                //     started_at と一致するファイルがあれば success に復元（旧版ゴースト救済）
+                //   - backups/safety/ の未登録ファイルを backup_log に登録
+                try
+                {
+                    var (recoveredSuccess, markedFailed) = _dbManager.BackupLogRepository.ReconcileInProgressEntries(
+                        "バックアップファイルが見つかりませんでした",
+                        thresholdSeconds: null,
+                        recoverFailedWithExistingFile: true);
+                    int legacyRecovered = _dbManager.BackupLogRepository.RecoverLegacyFailedEntriesByFolderScan(
+                        _dbManager.BackupService.GetEffectiveDestinationDirectory());
+                    int safetyAdded = _dbManager.BackupLogRepository.RegisterUnknownSafetyFiles(
+                        _dbManager.BackupService.GetSafetyDirectory(),
+                        Environment.MachineName);
+                    if (recoveredSuccess > 0 || markedFailed > 0 || legacyRecovered > 0 || safetyAdded > 0)
+                    {
+                        Console.WriteLine($"[BackupSectionPanel] 更新時リコンサイル: 成功化 {recoveredSuccess} / 失敗化 {markedFailed} / 旧版救済 {legacyRecovered} / 退避新規 {safetyAdded}");
+                    }
+                }
+                catch (Exception reconcileEx)
+                {
+                    Console.WriteLine($"[BackupSectionPanel] リコンサイル中にエラー: {reconcileEx.Message}");
+                }
+
+                // 最終バックアップ表示
+                var last = _dbManager.BackupLogRepository.GetLastSuccess();
+                if (last != null)
+                {
+                    string sizeStr = last.FileSizeBytes.HasValue ? FormatBytes(last.FileSizeBytes.Value) : "-";
+                    lblLastBackup.Text = $"最終バックアップ: {last.StartedAtLocal:yyyy/MM/dd HH:mm:ss} ({sizeStr})";
+                }
+                else
+                {
+                    lblLastBackup.Text = "最終バックアップ: 未取得";
+                }
+
+                lblDestPath.Text = $"保存先: {_dbManager.BackupService.GetEffectiveDestinationDirectory()}";
+
+                // 履歴
+                var entries = _dbManager.BackupLogRepository.GetRecent(100);
+                long nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                gridHistory.Rows.Clear();
+                foreach (var entry in entries)
+                {
+                    string status = GetStatusDisplay(entry, nowUnix);
+                    string statusTooltip = GetStatusTooltip(entry, nowUnix);
+                    string trigger;
+                    switch (entry.TriggerType)
+                    {
+                        case "manual": trigger = "手動"; break;
+                        case "auto": trigger = "自動"; break;
+                        case "safety": trigger = "退避"; break;
+                        default: trigger = entry.TriggerType ?? ""; break;
+                    }
+                    string size = entry.FileSizeBytes.HasValue ? FormatBytes(entry.FileSizeBytes.Value) : "-";
+                    string completed = entry.CompletedAtLocal.HasValue
+                        ? entry.CompletedAtLocal.Value.ToString("yyyy/MM/dd HH:mm:ss")
+                        : "-";
+                    int rowIndex = gridHistory.Rows.Add(
+                        entry.StartedAtLocal.ToString("yyyy/MM/dd HH:mm:ss"),
+                        completed,
+                        entry.PcName,
+                        trigger,
+                        status,
+                        size,
+                        entry.FilePath ?? "");
+                    // 行のTagに元データを保存（Restore で取り出す）
+                    gridHistory.Rows[rowIndex].Tag = entry;
+                    // 状態セルにツールチップと色を適用
+                    var statusCell = gridHistory.Rows[rowIndex].Cells["status"];
+                    if (!string.IsNullOrEmpty(statusTooltip))
+                    {
+                        statusCell.ToolTipText = statusTooltip;
+                    }
+                    statusCell.Style.BackColor = GetStatusBackColor(entry);
+                    statusCell.Style.SelectionBackColor = GetStatusSelectionBackColor(entry);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"履歴の取得に失敗しました: {ex.Message}", "エラー",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void btnBackupNow_Click(object sender, EventArgs e)
+        {
+            if (_dbManager == null) return;
+
+            BackupResult result = null;
+            using (var dialog = new ProcessingDialog((progress, token) =>
+            {
+                result = _dbManager.BackupService.RunManualBackup(progress, token);
+            }))
+            {
+                dialog.Text = "バックアップ実行中";
+                dialog.ShowDialog(this);
+            }
+
+            if (result == null) return;
+
+            if (result.IsSuccess)
+            {
+                MessageBox.Show(
+                    $"バックアップが完了しました。\n\nファイル: {result.FilePath}\nサイズ: {FormatBytes(result.FileSizeBytes)}",
+                    "バックアップ成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            else if (result.IsFailed)
+            {
+                MessageBox.Show(
+                    $"バックアップに失敗しました。\n\n{result.Message}",
+                    "バックアップ失敗", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+
+            RefreshDisplay();
+        }
+
+        private void btnRefresh_Click(object sender, EventArgs e)
+        {
+            RefreshDisplay();
+        }
+
+        private void btnSettings_Click(object sender, EventArgs e)
+        {
+            if (_dbManager == null) return;
+
+            using (var form = new BackupSettingsForm(_dbManager.SettingsRepository, _dbManager.BackupService))
+            {
+                if (form.ShowDialog(this) == DialogResult.OK)
+                {
+                    RefreshDisplay();
+                }
+            }
+        }
+
+        private void btnRestore_Click(object sender, EventArgs e)
+        {
+            if (_dbManager == null) return;
+            if (gridHistory.SelectedRows.Count == 0)
+            {
+                MessageBox.Show("復元したいバックアップを履歴一覧から選択してください。", "未選択",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            var row = gridHistory.SelectedRows[0];
+            var entry = row.Tag as BackupLogEntry;
+            if (entry == null || string.IsNullOrEmpty(entry.FilePath))
+            {
+                MessageBox.Show("選択したエントリにはファイルパス情報がありません。", "情報なし",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            if (!File.Exists(entry.FilePath))
+            {
+                MessageBox.Show($"バックアップファイルが見つかりません:\n{entry.FilePath}", "ファイルなし",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            using (var confirm = new RestoreConfirmForm(entry))
+            {
+                if (confirm.ShowDialog(this) != DialogResult.Yes) return;
+            }
+
+            string safetyPath = null;
+            Exception caught = null;
+            using (var dialog = new ProcessingDialog((progress, token) =>
+            {
+                safetyPath = _dbManager.RestoreService.Restore(entry.FilePath, progress, token);
+            }))
+            {
+                dialog.Text = "復元中";
+                var dr = dialog.ShowDialog(this);
+                if (dr == DialogResult.Abort)
+                {
+                    caught = new Exception("復元中にエラーが発生しました（詳細はログを確認）");
+                }
+            }
+
+            if (caught != null)
+            {
+                MessageBox.Show($"復元に失敗しました。\n\n{caught.Message}", "エラー",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            MessageBox.Show(
+                $"復元が完了しました。\n\n復元前のDBは退避されました:\n{safetyPath}\n\nManager のデータを再読み込みします。",
+                "復元成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+            DatabaseChanged?.Invoke();
+            RefreshDisplay();
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            if (bytes < 1024) return $"{bytes} B";
+            double kb = bytes / 1024.0;
+            if (kb < 1024) return $"{kb:F1} KB";
+            double mb = kb / 1024.0;
+            if (mb < 1024) return $"{mb:F2} MB";
+            double gb = mb / 1024.0;
+            return $"{gb:F2} GB";
+        }
+
+        /// <summary>
+        /// 状態の表示文字列。DB上は3状態 (success / failed / in_progress) のままシンプルに保つ。
+        /// </summary>
+        private static string GetStatusDisplay(BackupLogEntry entry, long nowUnixSec)
+        {
+            switch (entry.Status)
+            {
+                case "success": return "成功";
+                case "failed": return "失敗";
+                case "in_progress": return "実行中";
+                default: return entry.Status ?? "";
+            }
+        }
+
+        /// <summary>
+        /// 状態セルのツールチップ。in_progress については経過時間と「本当に実行中 vs 残骸の可能性」を文脈で出す。
+        /// </summary>
+        private static string GetStatusTooltip(BackupLogEntry entry, long nowUnixSec)
+        {
+            switch (entry.Status)
+            {
+                case "success":
+                    return "バックアップは完了済みです。この行から復元できます。";
+                case "failed":
+                    return string.IsNullOrEmpty(entry.ErrorMessage)
+                        ? "バックアップに失敗しました。実ファイルが存在しないため復元には使えません。"
+                        : $"中断理由: {entry.ErrorMessage}";
+                case "in_progress":
+                    long age = nowUnixSec - entry.StartedAt;
+                    if (age < 30)
+                    {
+                        return $"現在実行中です（経過: {age} 秒）。完了まで少々お待ちください。";
+                    }
+                    string elapsed = age < 60
+                        ? $"{age} 秒"
+                        : (age < 3600 ? $"{age / 60} 分" : $"{age / 3600} 時間");
+                    return $"前回 Manager 異常終了の残骸の可能性があります（経過: {elapsed}）。" +
+                           "更新ボタンを押すと実ファイルの有無で 成功/失敗 が確定します。";
+                default:
+                    return "";
+            }
+        }
+
+        /// <summary>
+        /// 状態セルの背景色（非選択時）
+        /// </summary>
+        private static Color GetStatusBackColor(BackupLogEntry entry)
+        {
+            switch (entry.Status)
+            {
+                case "success": return Color.FromArgb(220, 245, 220); // 淡い緑
+                case "failed": return Color.FromArgb(250, 220, 220);  // 淡い赤
+                case "in_progress": return Color.FromArgb(220, 232, 250); // 淡い青
+                default: return Color.White;
+            }
+        }
+
+        /// <summary>
+        /// 状態セルの背景色（選択時）。標準の青選択色だと色分けが見えなくなるので、選択中も色味を保つ。
+        /// </summary>
+        private static Color GetStatusSelectionBackColor(BackupLogEntry entry)
+        {
+            switch (entry.Status)
+            {
+                case "success": return Color.FromArgb(150, 210, 150); // 中緑
+                case "failed": return Color.FromArgb(220, 150, 150);  // 中赤
+                case "in_progress": return Color.FromArgb(150, 180, 220); // 中青
+                default: return Color.LightGray;
+            }
+        }
+    }
+}

--- a/GCTonePrism_Manager/Controls/BackupSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/BackupSectionPanel.cs
@@ -222,27 +222,38 @@ namespace GCTonePrism.Manager.Controls
             }
 
             string safetyPath = null;
-            Exception caught = null;
+            DialogResult dr;
             using (var dialog = new ProcessingDialog((progress, token) =>
             {
                 safetyPath = _dbManager.RestoreService.Restore(entry.FilePath, progress, token);
             }))
             {
                 dialog.Text = "復元中";
-                var dr = dialog.ShowDialog(this);
-                if (dr == DialogResult.Abort)
-                {
-                    caught = new Exception("復元中にエラーが発生しました（詳細はログを確認）");
-                }
+                dr = dialog.ShowDialog(this);
             }
 
-            if (caught != null)
+            // ProcessingDialog は OperationCanceledException を Cancel、
+            // それ以外の例外を Abort として返す（成功時は OK）。
+            // Cancel を OK と区別せず成功扱いにすると、キャンセル後も
+            // DatabaseChanged が走って中途半端な状態の DB をリロードしてしまう。
+            // （Codex P1 指摘 "Handle restore cancellation before reporting success" 対応）
+            if (dr == DialogResult.Cancel)
             {
-                MessageBox.Show($"復元に失敗しました。\n\n{caught.Message}", "エラー",
-                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    "復元はキャンセルされました。\n\nデータベースは変更されていません。",
+                    "キャンセル", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
 
+            if (dr == DialogResult.Abort)
+            {
+                MessageBox.Show(
+                    "復元中にエラーが発生しました（詳細はログを確認）",
+                    "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            // dr == DialogResult.OK: 復元成功
             MessageBox.Show(
                 $"復元が完了しました。\n\n復元前のDBは退避されました:\n{safetyPath}\n\nManager のデータを再読み込みします。",
                 "復元成功", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -282,28 +282,49 @@ namespace GCTonePrism.Manager.Controls
                 $"ゲーム「{selectedGame.Title}」を削除しますか？\nこの操作は取り消せません。",
                 "削除確認", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
-            if (result == DialogResult.Yes)
+            if (result != DialogResult.Yes) return;
+
+            // CASCADE で developers / game_versions / game_genres / play_records /
+            // surveys / store_section_games が削除される。共有フォルダ越しでは
+            // 数秒かかるケースもあるので Marquee 進捗を表示する。
+            Exception caught = null;
+            using (var dialog = new ProcessingDialog((progress, token) =>
             {
                 try
                 {
+                    progress?.Report(new ProgressInfo(-1, "ゲームを削除中...",
+                        $"「{selectedGame.Title}」と関連レコードをデータベースから削除しています"));
                     _dbManager.DeleteGame(selectedGame.GameId);
-                    MessageBox.Show("ゲームを削除しました。", "成功",
-                        MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    LoadGames();
-                }
-                catch (System.Data.SQLite.SQLiteException ex)
-                {
-                    MessageBox.Show(
-                        $"ゲームの削除に失敗しました。\n\n{DatabaseManager.GetUserFriendlyErrorMessage(ex)}",
-                        "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show(
-                        $"ゲームの削除に失敗しました。\n\n{ex.Message}",
-                        "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    caught = ex;
+                    throw;
+                }
+            })
+            {
+                Text = "ゲーム削除中",
+                MarqueeMode = true,
+                AllowCancel = false
+            })
+            {
+                var dr = dialog.ShowDialog(this.FindForm());
+                if (dr != DialogResult.OK)
+                {
+                    if (caught is System.Data.SQLite.SQLiteException sqEx)
+                    {
+                        MessageBox.Show(
+                            $"ゲームの削除に失敗しました。\n\n{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}",
+                            "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
+                    // それ以外は ProcessingDialog 内で MessageBox 表示済み
+                    return;
                 }
             }
+
+            MessageBox.Show("ゲームを削除しました。", "成功",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            LoadGames();
         }
 
         private void btnRefresh_Click(object sender, EventArgs e)

--- a/GCTonePrism_Manager/Controls/SettingsSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/SettingsSectionPanel.cs
@@ -55,27 +55,44 @@ namespace GCTonePrism.Manager.Controls
         {
             using (var confirmForm = new ResetDatabaseConfirmForm())
             {
-                if (confirmForm.ShowDialog() == DialogResult.Yes)
+                if (confirmForm.ShowDialog() != DialogResult.Yes) return;
+            }
+
+            // ResetDatabase は DBファイル削除 + テーブル再作成 + マイグレーション再実行を行う。
+            // 共有フォルダ越しでは時間がかかる場合があるので進捗バーを表示する。
+            Exception caught = null;
+            using (var dialog = new ProcessingDialog((progress, token) =>
+            {
+                try
                 {
-                    try
-                    {
-                        _dbManager.ResetDatabase();
-
-                        MessageBox.Show(
-                            "データベースのリセットが完了しました。",
-                            "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-                        UpdateVersionInfo();
-                        DatabaseReset?.Invoke();
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show(
-                            $"データベースのリセットに失敗しました。\n\n{ex.Message}",
-                            "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    }
+                    progress?.Report(new ProgressInfo(-1, "データベースをリセット中...", "ファイル削除と再作成を実行しています"));
+                    _dbManager.ResetDatabase();
+                }
+                catch (Exception ex)
+                {
+                    caught = ex;
+                    throw;
+                }
+            })
+            {
+                Text = "データベースリセット中",
+                MarqueeMode = true,
+                AllowCancel = false
+            })
+            {
+                var dr = dialog.ShowDialog(this);
+                if (dr != DialogResult.OK)
+                {
+                    return;
                 }
             }
+
+            MessageBox.Show(
+                "データベースのリセットが完了しました。",
+                "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+            UpdateVersionInfo();
+            DatabaseReset?.Invoke();
         }
     }
 }

--- a/GCTonePrism_Manager/DatabaseManager.cs
+++ b/GCTonePrism_Manager/DatabaseManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.SQLite;
 using GCTonePrism.Manager.Models;
 using GCTonePrism.Manager.Repositories;
+using GCTonePrism.Manager.Services;
 
 namespace GCTonePrism.Manager
 {
@@ -18,6 +19,10 @@ namespace GCTonePrism.Manager
         private readonly VersionRepository _versionRepo;
         private readonly DeveloperRepository _devRepo;
         private readonly StoreSectionRepository _sectionRepo;
+        private readonly SettingsRepository _settingsRepo;
+        private readonly BackupLogRepository _backupLogRepo;
+        private readonly BackupService _backupService;
+        private readonly RestoreService _restoreService;
 
         public DatabaseManager()
         {
@@ -27,7 +32,17 @@ namespace GCTonePrism.Manager
             _gameRepo = new GameRepository(_conn, _devRepo);
             _versionRepo = new VersionRepository(_conn, _devRepo);
             _sectionRepo = new StoreSectionRepository(_conn);
+            _settingsRepo = new SettingsRepository(_conn);
+            _backupLogRepo = new BackupLogRepository(_conn);
+            _backupService = new BackupService(_conn, _backupLogRepo, _settingsRepo);
+            _restoreService = new RestoreService(_conn);
         }
+
+        // --- バックアップ機能アクセサ ---
+        public BackupService BackupService { get { return _backupService; } }
+        public RestoreService RestoreService { get { return _restoreService; } }
+        public BackupLogRepository BackupLogRepository { get { return _backupLogRepo; } }
+        public SettingsRepository SettingsRepository { get { return _settingsRepo; } }
 
         // --- 接続・スキーマ ---
         public bool DatabaseExists() => _conn.DatabaseExists();

--- a/GCTonePrism_Manager/EditGameForm.cs
+++ b/GCTonePrism_Manager/EditGameForm.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Windows.Forms;
 using GCTonePrism.Manager.Models;
 using GCTonePrism.Manager.Services;
@@ -428,30 +429,64 @@ namespace GCTonePrism.Manager
                     string oldFolder = PathManager.GetGameFolder(oldGameId);
                     string newFolder = PathManager.GetGameFolder(newGameId);
 
-                    bool folderRenamed = false;
-                    if (System.IO.Directory.Exists(oldFolder))
+                    if (System.IO.Directory.Exists(oldFolder) && System.IO.Directory.Exists(newFolder))
                     {
-                        if (System.IO.Directory.Exists(newFolder))
-                        {
-                            throw new InvalidOperationException($"フォルダ「{newFolder}」が既に存在します。");
-                        }
-                        System.IO.Directory.Move(oldFolder, newFolder);
-                        folderRenamed = true;
+                        throw new InvalidOperationException($"フォルダ「{newFolder}」が既に存在します。");
                     }
 
-                    // フォルダリネーム成功後にDB側のID更新（重複チェック含む）
-                    try
+                    // ゲームフォルダのリネームは同一ボリュームでは一瞬だが、共有フォルダ越しや
+                    // クロスボリュームでは内部的にコピー＋削除になり時間がかかる。
+                    // ProcessingDialog で進捗を表示する。
+                    Exception caught = null;
+                    using (var dialog = new ProcessingDialog((IProgress<ProgressInfo> progress, CancellationToken token) =>
                     {
-                        dbManager.UpdateGameId(oldGameId, newGameId);
-                    }
-                    catch
-                    {
-                        // DB更新失敗時はフォルダを元に戻す
-                        if (folderRenamed)
+                        try
                         {
-                            System.IO.Directory.Move(newFolder, oldFolder);
+                            progress?.Report(new ProgressInfo(-1, "フォルダをリネーム中...", $"{oldFolder} → {newFolder}"));
+
+                            bool folderRenamed = false;
+                            if (System.IO.Directory.Exists(oldFolder))
+                            {
+                                System.IO.Directory.Move(oldFolder, newFolder);
+                                folderRenamed = true;
+                            }
+
+                            progress?.Report(new ProgressInfo(-1, "データベースを更新中...", $"ゲームID: {oldGameId} → {newGameId}"));
+
+                            try
+                            {
+                                dbManager.UpdateGameId(oldGameId, newGameId);
+                            }
+                            catch
+                            {
+                                // DB更新失敗時はフォルダを元に戻す
+                                if (folderRenamed)
+                                {
+                                    progress?.Report(new ProgressInfo(-1, "ロールバック中...", "フォルダを元の名前に戻しています"));
+                                    System.IO.Directory.Move(newFolder, oldFolder);
+                                }
+                                throw;
+                            }
                         }
-                        throw;
+                        catch (Exception ex)
+                        {
+                            caught = ex;
+                            throw;
+                        }
+                    })
+                    {
+                        Text = "ゲームIDを変更中",
+                        MarqueeMode = true,
+                        AllowCancel = false
+                    })
+                    {
+                        var dr = dialog.ShowDialog(this);
+                        if (dr != DialogResult.OK)
+                        {
+                            // ProcessingDialog 内で MessageBox 表示済みなのでここでは何もしない
+                            if (caught != null) throw caught;
+                            return;
+                        }
                     }
 
                     // gameFolderを更新（以降のパス処理で使用）

--- a/GCTonePrism_Manager/GCTonePrism_Manager.csproj
+++ b/GCTonePrism_Manager/GCTonePrism_Manager.csproj
@@ -126,11 +126,31 @@
     <Compile Include="Controls\SettingsSectionPanel.Designer.cs">
       <DependentUpon>SettingsSectionPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\BackupSectionPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\BackupSectionPanel.Designer.cs">
+      <DependentUpon>BackupSectionPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="BackupSettingsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="BackupSettingsForm.Designer.cs">
+      <DependentUpon>BackupSettingsForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="RestoreConfirmForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="RestoreConfirmForm.Designer.cs">
+      <DependentUpon>RestoreConfirmForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="DatabaseConnection.cs" />
     <Compile Include="DatabaseManager.cs" />
     <Compile Include="SchemaManager.cs" />
+    <Compile Include="Repositories\BackupLogRepository.cs" />
     <Compile Include="Repositories\DeveloperRepository.cs" />
     <Compile Include="Repositories\GameRepository.cs" />
+    <Compile Include="Repositories\SettingsRepository.cs" />
     <Compile Include="Repositories\StoreSectionRepository.cs" />
     <Compile Include="Repositories\VersionRepository.cs" />
     <Compile Include="MainForm.cs">
@@ -146,6 +166,7 @@
       <DependentUpon>ProcessingDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="ProgressInfo.cs" />
+    <Compile Include="Models\BackupLogEntry.cs" />
     <Compile Include="Models\DeveloperInfo.cs" />
     <Compile Include="Models\GameInfo.cs" />
     <Compile Include="Models\PlayRecord.cs" />
@@ -154,11 +175,13 @@
     <Compile Include="Models\Survey.cs" />
     <Compile Include="GenreList.cs" />
     <Compile Include="PathManager.cs" />
+    <Compile Include="Services\BackupService.cs" />
     <Compile Include="Services\DeveloperListManager.cs" />
     <Compile Include="Services\FileOperationService.cs" />
     <Compile Include="Services\GameFormHelper.cs" />
     <Compile Include="Services\ImagePreviewHelper.cs" />
     <Compile Include="Services\PathConversionHelper.cs" />
+    <Compile Include="Services\RestoreService.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="AddGameForm.resx">

--- a/GCTonePrism_Manager/MainForm.Designer.cs
+++ b/GCTonePrism_Manager/MainForm.Designer.cs
@@ -22,6 +22,7 @@ namespace GCTonePrism.Manager
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabGame = new System.Windows.Forms.TabPage();
             this.tabStore = new System.Windows.Forms.TabPage();
+            this.tabBackup = new System.Windows.Forms.TabPage();
             this.tabSettings = new System.Windows.Forms.TabPage();
             this.statusStrip1.SuspendLayout();
             this.tabControl1.SuspendLayout();
@@ -47,6 +48,7 @@ namespace GCTonePrism.Manager
             //
             this.tabControl1.Controls.Add(this.tabGame);
             this.tabControl1.Controls.Add(this.tabStore);
+            this.tabControl1.Controls.Add(this.tabBackup);
             this.tabControl1.Controls.Add(this.tabSettings);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Font = new System.Drawing.Font("Meiryo UI", 9.5F);
@@ -77,13 +79,23 @@ namespace GCTonePrism.Manager
             this.tabStore.Text = "ストア";
             this.tabStore.UseVisualStyleBackColor = true;
             //
+            // tabBackup
+            //
+            this.tabBackup.Location = new System.Drawing.Point(4, 28);
+            this.tabBackup.Name = "tabBackup";
+            this.tabBackup.Padding = new System.Windows.Forms.Padding(3);
+            this.tabBackup.Size = new System.Drawing.Size(1092, 596);
+            this.tabBackup.TabIndex = 2;
+            this.tabBackup.Text = "バックアップ";
+            this.tabBackup.UseVisualStyleBackColor = true;
+            //
             // tabSettings
             //
             this.tabSettings.Location = new System.Drawing.Point(4, 28);
             this.tabSettings.Name = "tabSettings";
             this.tabSettings.Padding = new System.Windows.Forms.Padding(3);
             this.tabSettings.Size = new System.Drawing.Size(1092, 596);
-            this.tabSettings.TabIndex = 2;
+            this.tabSettings.TabIndex = 3;
             this.tabSettings.Text = "設定";
             this.tabSettings.UseVisualStyleBackColor = true;
             //
@@ -112,6 +124,7 @@ namespace GCTonePrism.Manager
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabGame;
         private System.Windows.Forms.TabPage tabStore;
+        private System.Windows.Forms.TabPage tabBackup;
         private System.Windows.Forms.TabPage tabSettings;
     }
 }

--- a/GCTonePrism_Manager/MainForm.cs
+++ b/GCTonePrism_Manager/MainForm.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GCTonePrism.Manager.Controls;
 using GCTonePrism.Manager.Services;
@@ -15,6 +17,7 @@ namespace GCTonePrism.Manager
         private GameSectionPanel _gameSectionPanel;
         private StoreSectionPanel _storeSectionPanel;
         private SettingsSectionPanel _settingsSectionPanel;
+        private BackupSectionPanel _backupSectionPanel;
 
         public MainForm()
         {
@@ -24,12 +27,15 @@ namespace GCTonePrism.Manager
             _gameSectionPanel = new GameSectionPanel { Dock = DockStyle.Fill };
             _storeSectionPanel = new StoreSectionPanel { Dock = DockStyle.Fill };
             _settingsSectionPanel = new SettingsSectionPanel { Dock = DockStyle.Fill };
+            _backupSectionPanel = new BackupSectionPanel { Dock = DockStyle.Fill };
 
             _gameSectionPanel.StatusChanged += (msg) => UpdateStatusBar(msg);
             _settingsSectionPanel.DatabaseReset += OnDatabaseReset;
+            _backupSectionPanel.DatabaseChanged += OnDatabaseRestored;
 
             tabGame.Controls.Add(_gameSectionPanel);
             tabStore.Controls.Add(_storeSectionPanel);
+            tabBackup.Controls.Add(_backupSectionPanel);
             tabSettings.Controls.Add(_settingsSectionPanel);
         }
 
@@ -88,8 +94,110 @@ namespace GCTonePrism.Manager
             _storeSectionPanel.Initialize(dbManager);
             _settingsSectionPanel.Initialize(dbManager);
 
+            // 旧バージョンが root 直下に作っていた safety ファイルを backups/safety/ へ一度きり移動
+            try
+            {
+                int movedSafety = Services.BackupService.MigrateLegacySafetyFilesToSafetyFolder(
+                    System.IO.Path.GetDirectoryName(PathManager.DatabasePath));
+                if (movedSafety > 0)
+                {
+                    Console.WriteLine($"[MainForm] 旧 safety ファイル {movedSafety} 件を backups/safety/ に移動しました");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[MainForm] 旧 safety ファイル移動失敗: {ex.Message}");
+            }
+
+            // 退避ファイルの未登録分を backup_log に登録（起動時に1回）
+            RegisterUnknownSafetyFiles();
+
+            // 起動時に古い in_progress 行を掃除（クラッシュ残骸 / 自己参照スナップショット由来）
+            CleanupStaleBackupEntries();
+
+            _backupSectionPanel.Initialize(dbManager);
+
             _gameSectionPanel.LoadGames();
             UpdateStatusBar();
+
+            // 起動時に自動バックアップが必要なら走らせる（バックグラウンドで非ブロッキング）
+            StartAutoBackupIfDue();
+        }
+
+        private void RegisterUnknownSafetyFiles()
+        {
+            try
+            {
+                int added = dbManager.BackupLogRepository.RegisterUnknownSafetyFiles(
+                    dbManager.BackupService.GetSafetyDirectory(),
+                    Environment.MachineName);
+                if (added > 0)
+                {
+                    Console.WriteLine($"[MainForm] 退避ファイル {added} 件を backup_log に新規登録しました");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[MainForm] 退避ファイル登録に失敗: {ex.Message}");
+            }
+        }
+
+        private void CleanupStaleBackupEntries()
+        {
+            try
+            {
+                // 起動時は10分以上経過した in_progress のみリコンサイル対象（実行中のバックアップに干渉しないため）
+                var (success, failed) = dbManager.BackupLogRepository.ReconcileInProgressEntries(
+                    "進行中状態のまま放置されたため自動的にfailed扱いにしました（Managerクラッシュ等でバックアップが完了しなかった可能性）",
+                    thresholdSeconds: 600);
+                if (success > 0 || failed > 0)
+                {
+                    Console.WriteLine($"[MainForm] 起動時リコンサイル: 成功化 {success} 件 / 失敗化 {failed} 件");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[MainForm] バックアップ履歴の掃除に失敗しました: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 自動バックアップが期限到来していればバックグラウンドで実行する。
+        /// UIをブロックせず、ステータスバーで進捗を伝える。
+        /// </summary>
+        private async void StartAutoBackupIfDue()
+        {
+            if (dbManager == null) return;
+
+            try
+            {
+                if (!dbManager.BackupService.IsAutoBackupDue())
+                {
+                    return;
+                }
+
+                UpdateStatusBar("自動バックアップを実行中...");
+                BackupResult result = await Task.Run(() =>
+                    dbManager.BackupService.RunAutoBackupIfDue(null, CancellationToken.None));
+
+                if (result == null) return;
+
+                if (result.IsSuccess)
+                {
+                    UpdateStatusBar($"自動バックアップ完了: {System.IO.Path.GetFileName(result.FilePath)}");
+                    _backupSectionPanel.RefreshDisplay();
+                }
+                else if (result.IsFailed)
+                {
+                    UpdateStatusBar($"自動バックアップ失敗: {result.Message}");
+                }
+                // IsSkipped はそのまま（他PCで実行済み等、特に通知不要）
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[MainForm] StartAutoBackupIfDue エラー: {ex.Message}");
+                UpdateStatusBar($"自動バックアップエラー: {ex.Message}");
+            }
         }
 
         private void InitializeDatabase()
@@ -116,6 +224,48 @@ namespace GCTonePrism.Manager
             _gameSectionPanel.LoadGames();
             _storeSectionPanel.LoadSections();
             UpdateStatusBar();
+        }
+
+        /// <summary>
+        /// バックアップからの復元完了時。各パネルを再ロードする。
+        /// </summary>
+        private void OnDatabaseRestored()
+        {
+            try
+            {
+                // 復元によりスキーマやデータが変わっているので、必要なら再初期化
+                dbManager.InitializeDatabase();
+
+                // 復元時に作成された新しい safety ファイルを backup_log に登録（復元先には未登録）
+                RegisterUnknownSafetyFiles();
+
+                // 復元先のスナップショットには「バックアップ撮影時点で進行中だった自分自身の行」が
+                // 含まれている自己参照ゴーストになる。各 in_progress 行について実ファイルが
+                // 存在するか確認し、存在すれば success、存在しなければ failed としてリコンサイルする。
+                try
+                {
+                    var (success, failed) = dbManager.BackupLogRepository.ReconcileInProgressEntries(
+                        "バックアップファイルが見つかりませんでした（バックアップから復元時の自己参照スナップショット由来で、実ファイルも残っていない）");
+                    if (success > 0 || failed > 0)
+                    {
+                        Console.WriteLine($"[MainForm] 復元後リコンサイル: 成功化 {success} 件 / 失敗化 {failed} 件");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[MainForm] 復元後の履歴リコンサイルに失敗しました: {ex.Message}");
+                }
+
+                _gameSectionPanel.LoadGames();
+                _storeSectionPanel.LoadSections();
+                _settingsSectionPanel.UpdateVersionInfo();
+                UpdateStatusBar();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"復元後の再読み込みに失敗しました: {ex.Message}",
+                    "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
 
         private void tabControl1_SelectedIndexChanged(object sender, EventArgs e)

--- a/GCTonePrism_Manager/Models/BackupLogEntry.cs
+++ b/GCTonePrism_Manager/Models/BackupLogEntry.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace GCTonePrism.Manager.Models
+{
+    /// <summary>
+    /// backup_log テーブルの1行に対応するモデル
+    /// </summary>
+    public class BackupLogEntry
+    {
+        public long Id { get; set; }
+        public long StartedAt { get; set; }       // UNIX秒
+        public long? CompletedAt { get; set; }    // UNIX秒、進行中はnull
+        public string PcName { get; set; }
+        public string FilePath { get; set; }
+        public long? FileSizeBytes { get; set; }
+        public string Status { get; set; }        // "in_progress" | "success" | "failed"
+        public string ErrorMessage { get; set; }
+        public string TriggerType { get; set; }   // "manual" | "auto"
+
+        /// <summary>
+        /// StartedAt をローカルタイムの DateTime に変換
+        /// </summary>
+        public DateTime StartedAtLocal
+        {
+            get { return DateTimeOffset.FromUnixTimeSeconds(StartedAt).LocalDateTime; }
+        }
+
+        /// <summary>
+        /// CompletedAt をローカルタイムの DateTime に変換（nullable）
+        /// </summary>
+        public DateTime? CompletedAtLocal
+        {
+            get
+            {
+                if (CompletedAt.HasValue)
+                    return DateTimeOffset.FromUnixTimeSeconds(CompletedAt.Value).LocalDateTime;
+                return null;
+            }
+        }
+    }
+}

--- a/GCTonePrism_Manager/ProcessingDialog.cs
+++ b/GCTonePrism_Manager/ProcessingDialog.cs
@@ -18,6 +18,28 @@ namespace GCTonePrism.Manager
             _cts = new CancellationTokenSource();
         }
 
+        /// <summary>
+        /// 進捗が定量化できない処理向け。Marquee（流れる）スタイルにする。
+        /// </summary>
+        public bool MarqueeMode
+        {
+            get { return pbProgress.Style == ProgressBarStyle.Marquee; }
+            set
+            {
+                pbProgress.Style = value ? ProgressBarStyle.Marquee : ProgressBarStyle.Blocks;
+                if (value) pbProgress.MarqueeAnimationSpeed = 30;
+            }
+        }
+
+        /// <summary>
+        /// キャンセル可能かどうか。途中で中断できない処理（Directory.Move 等）では false に設定する。
+        /// </summary>
+        public bool AllowCancel
+        {
+            get { return btnCancel.Visible; }
+            set { btnCancel.Visible = value; }
+        }
+
         private async void ProcessingDialog_Shown(object sender, EventArgs e)
         {
             var progress = new Progress<ProgressInfo>(ReportProgress);

--- a/GCTonePrism_Manager/Properties/AssemblyInfo.cs
+++ b/GCTonePrism_Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.7.6.0")]
-[assembly: AssemblyFileVersion("0.7.6.0")]
+[assembly: AssemblyVersion("0.8.0.0")]
+[assembly: AssemblyFileVersion("0.8.0.0")]

--- a/GCTonePrism_Manager/Repositories/BackupLogRepository.cs
+++ b/GCTonePrism_Manager/Repositories/BackupLogRepository.cs
@@ -1,0 +1,448 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SQLite;
+using System.Text.RegularExpressions;
+using GCTonePrism.Manager.Models;
+
+namespace GCTonePrism.Manager.Repositories
+{
+    /// <summary>
+    /// backup_log テーブルへのアクセサ
+    /// </summary>
+    public class BackupLogRepository
+    {
+        private readonly DatabaseConnection _conn;
+
+        public BackupLogRepository(DatabaseConnection conn)
+        {
+            _conn = conn;
+        }
+
+        /// <summary>
+        /// 進行中レコードを挿入し、生成された id を返す。
+        /// 予定ファイルパスを最初から保存することで、後で「実ファイルが存在するか」で
+        /// リコンサイル（成功/失敗の確定）が可能になる。
+        /// </summary>
+        public long InsertInProgress(string pcName, string triggerType, long startedAtUnixSec, string plannedFilePath)
+        {
+            return _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    using (var cmd = new SQLiteCommand(
+                        "INSERT INTO backup_log (started_at, pc_name, status, trigger_type, file_path) " +
+                        "VALUES (@started_at, @pc_name, 'in_progress', @trigger_type, @file_path)", connection))
+                    {
+                        cmd.Parameters.AddWithValue("@started_at", startedAtUnixSec);
+                        cmd.Parameters.AddWithValue("@pc_name", pcName ?? "");
+                        cmd.Parameters.AddWithValue("@trigger_type", triggerType);
+                        cmd.Parameters.AddWithValue("@file_path", plannedFilePath ?? "");
+                        cmd.ExecuteNonQuery();
+                    }
+                    return connection.LastInsertRowId;
+                }
+            });
+        }
+
+        public void MarkSuccess(long id, string filePath, long fileSizeBytes, long completedAtUnixSec)
+        {
+            _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    using (var cmd = new SQLiteCommand(
+                        "UPDATE backup_log SET status = 'success', file_path = @file_path, " +
+                        "file_size_bytes = @file_size, completed_at = @completed_at WHERE id = @id", connection))
+                    {
+                        cmd.Parameters.AddWithValue("@file_path", filePath ?? "");
+                        cmd.Parameters.AddWithValue("@file_size", fileSizeBytes);
+                        cmd.Parameters.AddWithValue("@completed_at", completedAtUnixSec);
+                        cmd.Parameters.AddWithValue("@id", id);
+                        cmd.ExecuteNonQuery();
+                    }
+                }
+            });
+        }
+
+        public void MarkFailed(long id, string errorMessage, long completedAtUnixSec)
+        {
+            _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    using (var cmd = new SQLiteCommand(
+                        "UPDATE backup_log SET status = 'failed', error_message = @err, " +
+                        "completed_at = @completed_at WHERE id = @id", connection))
+                    {
+                        cmd.Parameters.AddWithValue("@err", errorMessage ?? "");
+                        cmd.Parameters.AddWithValue("@completed_at", completedAtUnixSec);
+                        cmd.Parameters.AddWithValue("@id", id);
+                        cmd.ExecuteNonQuery();
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// `backup_log` の各行を「実ファイルの有無」でリコンサイルする。
+        ///
+        /// `in_progress` 行：
+        ///   - `file_path` が指すファイルが実在 → `success` に更新し、`file_size_bytes` を実ファイルサイズに
+        ///   - 実在しない（または file_path が空） → `failed` に更新し、reasonIfMissing を記録
+        ///
+        /// `recoverFailedWithExistingFile = true` の場合、`failed` 行も対象：
+        ///   - `file_path` が指すファイルが実在 → `success` に復活させる（auto-marked ゴースト由来の救済）
+        ///   - ファイルが本当に無い → そのまま放置（実際のバックアップ失敗を保持）
+        /// </summary>
+        /// <param name="reasonIfMissing">in_progress でファイルが無かった場合の error_message</param>
+        /// <param name="thresholdSeconds">この秒数より新しい行は対象外（null = 全件対象）</param>
+        /// <param name="recoverFailedWithExistingFile">true なら failed 行も実ファイル存在で success に戻す</param>
+        /// <returns>(成功化した数, 失敗化した数)</returns>
+        public (int reconciledAsSuccess, int reconciledAsFailed) ReconcileInProgressEntries(
+            string reasonIfMissing,
+            long? thresholdSeconds = null,
+            bool recoverFailedWithExistingFile = false)
+        {
+            return _conn.ExecuteWithRetry(() =>
+            {
+                long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                int success = 0;
+                int failed = 0;
+
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+
+                    // 対象行を取得
+                    var inProgressTargets = new List<(long id, string filePath)>();
+                    var failedRecoverableTargets = new List<(long id, string filePath)>();
+
+                    string selectInProgressSql = "SELECT id, file_path FROM backup_log WHERE status = 'in_progress'";
+                    if (thresholdSeconds.HasValue)
+                    {
+                        selectInProgressSql += " AND started_at < @cutoff";
+                    }
+                    using (var cmd = new SQLiteCommand(selectInProgressSql, connection))
+                    {
+                        if (thresholdSeconds.HasValue)
+                        {
+                            cmd.Parameters.AddWithValue("@cutoff", now - thresholdSeconds.Value);
+                        }
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                long id = Convert.ToInt64(reader["id"]);
+                                string fp = reader["file_path"] is DBNull ? "" : reader["file_path"].ToString();
+                                inProgressTargets.Add((id, fp));
+                            }
+                        }
+                    }
+
+                    if (recoverFailedWithExistingFile)
+                    {
+                        // failed 行のうち file_path が指すファイルが実在するもの（auto-marked ゴースト救済）
+                        using (var cmd = new SQLiteCommand(
+                            "SELECT id, file_path FROM backup_log " +
+                            "WHERE status = 'failed' AND file_path IS NOT NULL AND file_path != ''", connection))
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                long id = Convert.ToInt64(reader["id"]);
+                                string fp = reader["file_path"].ToString();
+                                failedRecoverableTargets.Add((id, fp));
+                            }
+                        }
+                    }
+
+                    // in_progress 行のリコンサイル
+                    foreach (var (id, filePath) in inProgressTargets)
+                    {
+                        bool fileExists = !string.IsNullOrEmpty(filePath) && System.IO.File.Exists(filePath);
+                        if (fileExists)
+                        {
+                            long size = new System.IO.FileInfo(filePath).Length;
+                            using (var cmd = new SQLiteCommand(
+                                "UPDATE backup_log SET status = 'success', file_size_bytes = @size, " +
+                                "completed_at = @now WHERE id = @id", connection))
+                            {
+                                cmd.Parameters.AddWithValue("@size", size);
+                                cmd.Parameters.AddWithValue("@now", now);
+                                cmd.Parameters.AddWithValue("@id", id);
+                                cmd.ExecuteNonQuery();
+                            }
+                            success++;
+                        }
+                        else
+                        {
+                            using (var cmd = new SQLiteCommand(
+                                "UPDATE backup_log SET status = 'failed', error_message = @reason, " +
+                                "completed_at = @now WHERE id = @id", connection))
+                            {
+                                cmd.Parameters.AddWithValue("@reason", reasonIfMissing ?? "");
+                                cmd.Parameters.AddWithValue("@now", now);
+                                cmd.Parameters.AddWithValue("@id", id);
+                                cmd.ExecuteNonQuery();
+                            }
+                            failed++;
+                        }
+                    }
+
+                    // failed 行の救済リコンサイル（ファイル実在のもののみ）
+                    foreach (var (id, filePath) in failedRecoverableTargets)
+                    {
+                        if (!System.IO.File.Exists(filePath)) continue; // ファイルが無いなら本当の失敗、そのまま
+                        long size = new System.IO.FileInfo(filePath).Length;
+                        using (var cmd = new SQLiteCommand(
+                            "UPDATE backup_log SET status = 'success', file_size_bytes = @size, " +
+                            "error_message = NULL WHERE id = @id", connection))
+                        {
+                            cmd.Parameters.AddWithValue("@size", size);
+                            cmd.Parameters.AddWithValue("@id", id);
+                            cmd.ExecuteNonQuery();
+                        }
+                        success++;
+                    }
+                }
+                return (success, failed);
+            });
+        }
+
+        public BackupLogEntry GetLastSuccess()
+        {
+            return _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    using (var cmd = new SQLiteCommand(
+                        "SELECT id, started_at, completed_at, pc_name, file_path, file_size_bytes, " +
+                        "status, error_message, trigger_type FROM backup_log " +
+                        "WHERE status = 'success' ORDER BY started_at DESC LIMIT 1", connection))
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        if (reader.Read())
+                            return ReadEntry(reader);
+                        return null;
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// `file_path` が空のまま残っている `failed` 行について、バックアップフォルダ内の
+        /// `prism_yyyyMMdd_HHmmss.db` 形式のファイル名と `started_at` を照合し、
+        /// 一致するファイルが見つかれば `success` として復元する。
+        ///
+        /// 旧バージョンの Manager（`InsertInProgress` がファイルパスを記録していなかった頃）に
+        /// 作られた行が、後のリストアでゴーストとして自動的に `failed` 化されたケースの救済用。
+        /// </summary>
+        /// <returns>復元された行数</returns>
+        public int RecoverLegacyFailedEntriesByFolderScan(string backupFolder)
+        {
+            if (string.IsNullOrEmpty(backupFolder) || !System.IO.Directory.Exists(backupFolder))
+                return 0;
+
+            // ファイル一覧を timestamp → path のマップに
+            var fileMap = new Dictionary<string, string>();
+            var regex = new Regex(@"^prism_(\d{8})_(\d{6})\.db$");
+            try
+            {
+                foreach (var file in System.IO.Directory.EnumerateFiles(backupFolder, "prism_*.db"))
+                {
+                    var name = System.IO.Path.GetFileName(file);
+                    var match = regex.Match(name);
+                    if (!match.Success) continue;
+                    string ts = $"{match.Groups[1].Value}_{match.Groups[2].Value}";
+                    fileMap[ts] = file;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[BackupLogRepository] フォルダスキャン失敗: {ex.Message}");
+                return 0;
+            }
+            if (fileMap.Count == 0) return 0;
+
+            return _conn.ExecuteWithRetry(() =>
+            {
+                int recovered = 0;
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+
+                    // file_path が空の failed 行を取得
+                    var targets = new List<(long id, long startedAt)>();
+                    using (var cmd = new SQLiteCommand(
+                        "SELECT id, started_at FROM backup_log " +
+                        "WHERE status = 'failed' AND (file_path IS NULL OR file_path = '')", connection))
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            targets.Add((Convert.ToInt64(reader["id"]), Convert.ToInt64(reader["started_at"])));
+                        }
+                    }
+
+                    foreach (var (id, startedAt) in targets)
+                    {
+                        var localTime = DateTimeOffset.FromUnixTimeSeconds(startedAt).LocalDateTime;
+                        // タイミングずれ（DateTime.Now と UtcNow.ToUnixTimeSeconds の小さな差）に
+                        // 対応するため ±1 秒の範囲でマッチさせる
+                        for (int offset = -1; offset <= 1; offset++)
+                        {
+                            var candidate = localTime.AddSeconds(offset);
+                            string ts = candidate.ToString("yyyyMMdd_HHmmss");
+                            if (fileMap.TryGetValue(ts, out string filePath))
+                            {
+                                long size = new System.IO.FileInfo(filePath).Length;
+                                using (var cmd = new SQLiteCommand(
+                                    "UPDATE backup_log SET status = 'success', file_path = @fp, " +
+                                    "file_size_bytes = @size, error_message = NULL WHERE id = @id", connection))
+                                {
+                                    cmd.Parameters.AddWithValue("@fp", filePath);
+                                    cmd.Parameters.AddWithValue("@size", size);
+                                    cmd.Parameters.AddWithValue("@id", id);
+                                    cmd.ExecuteNonQuery();
+                                }
+                                recovered++;
+                                break;
+                            }
+                        }
+                    }
+                }
+                return recovered;
+            });
+        }
+
+        /// <summary>
+        /// 退避フォルダ内の `safety_yyyyMMdd_HHmmss.db` および
+        /// 旧形式 `safety_before_restore_yyyyMMdd_HHmmss.db` のファイルを走査し、
+        /// `backup_log` に未登録のものを `trigger_type='safety'`, `status='success'` で挿入する。
+        /// `started_at` はファイル名のタイムスタンプ（ローカル時刻 → UTC秒）から復元する。
+        /// </summary>
+        /// <returns>新規登録された行数</returns>
+        public int RegisterUnknownSafetyFiles(string safetyDir, string pcName)
+        {
+            if (string.IsNullOrEmpty(safetyDir) || !System.IO.Directory.Exists(safetyDir))
+                return 0;
+
+            return _conn.ExecuteWithRetry(() =>
+            {
+                int added = 0;
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+
+                    // 既に登録済みの safety 行の file_path をセットに集める
+                    var existingPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    using (var cmd = new SQLiteCommand(
+                        "SELECT file_path FROM backup_log " +
+                        "WHERE trigger_type = 'safety' AND file_path IS NOT NULL AND file_path != ''",
+                        connection))
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            existingPaths.Add(reader["file_path"].ToString());
+                        }
+                    }
+
+                    var newRegex = new Regex(@"^safety_(\d{8})_(\d{6})\.db$");
+                    var legacyRegex = new Regex(@"^safety_before_restore_(\d{8})_(\d{6})\.db$");
+
+                    foreach (var file in System.IO.Directory.EnumerateFiles(safetyDir, "*.db"))
+                    {
+                        string name = System.IO.Path.GetFileName(file);
+                        Match match = newRegex.Match(name);
+                        if (!match.Success) match = legacyRegex.Match(name);
+                        if (!match.Success) continue;
+                        if (existingPaths.Contains(file)) continue;
+
+                        string dateStr = match.Groups[1].Value;
+                        string timeStr = match.Groups[2].Value;
+                        if (!DateTime.TryParseExact($"{dateStr}_{timeStr}", "yyyyMMdd_HHmmss",
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            System.Globalization.DateTimeStyles.AssumeLocal,
+                            out DateTime localTime))
+                        {
+                            continue;
+                        }
+                        long startedAt = new DateTimeOffset(localTime, TimeZoneInfo.Local.GetUtcOffset(localTime)).ToUnixTimeSeconds();
+
+                        long fileSize;
+                        try
+                        {
+                            fileSize = new System.IO.FileInfo(file).Length;
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+
+                        using (var insertCmd = new SQLiteCommand(
+                            "INSERT INTO backup_log (started_at, completed_at, pc_name, file_path, " +
+                            "file_size_bytes, status, trigger_type) " +
+                            "VALUES (@started, @completed, @pc, @path, @size, 'success', 'safety')",
+                            connection))
+                        {
+                            insertCmd.Parameters.AddWithValue("@started", startedAt);
+                            insertCmd.Parameters.AddWithValue("@completed", startedAt);
+                            insertCmd.Parameters.AddWithValue("@pc", pcName ?? "");
+                            insertCmd.Parameters.AddWithValue("@path", file);
+                            insertCmd.Parameters.AddWithValue("@size", fileSize);
+                            insertCmd.ExecuteNonQuery();
+                        }
+                        added++;
+                    }
+                }
+                return added;
+            });
+        }
+
+        public List<BackupLogEntry> GetRecent(int limit)
+        {
+            return _conn.ExecuteWithRetry(() =>
+            {
+                var list = new List<BackupLogEntry>();
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    using (var cmd = new SQLiteCommand(
+                        "SELECT id, started_at, completed_at, pc_name, file_path, file_size_bytes, " +
+                        "status, error_message, trigger_type FROM backup_log " +
+                        "ORDER BY started_at DESC LIMIT @limit", connection))
+                    {
+                        cmd.Parameters.AddWithValue("@limit", limit);
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                                list.Add(ReadEntry(reader));
+                        }
+                    }
+                }
+                return list;
+            });
+        }
+
+        private static BackupLogEntry ReadEntry(SQLiteDataReader reader)
+        {
+            return new BackupLogEntry
+            {
+                Id = Convert.ToInt64(reader["id"]),
+                StartedAt = Convert.ToInt64(reader["started_at"]),
+                CompletedAt = reader["completed_at"] is DBNull ? (long?)null : Convert.ToInt64(reader["completed_at"]),
+                PcName = reader["pc_name"] is DBNull ? "" : reader["pc_name"].ToString(),
+                FilePath = reader["file_path"] is DBNull ? "" : reader["file_path"].ToString(),
+                FileSizeBytes = reader["file_size_bytes"] is DBNull ? (long?)null : Convert.ToInt64(reader["file_size_bytes"]),
+                Status = reader["status"].ToString(),
+                ErrorMessage = reader["error_message"] is DBNull ? "" : reader["error_message"].ToString(),
+                TriggerType = reader["trigger_type"].ToString()
+            };
+        }
+    }
+}

--- a/GCTonePrism_Manager/Repositories/SettingsRepository.cs
+++ b/GCTonePrism_Manager/Repositories/SettingsRepository.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Data;
+using System.Data.SQLite;
+
+namespace GCTonePrism.Manager.Repositories
+{
+    /// <summary>
+    /// settings テーブル（key TEXT PRIMARY KEY, value TEXT）への汎用アクセサ
+    /// </summary>
+    public class SettingsRepository
+    {
+        private readonly DatabaseConnection _conn;
+
+        public SettingsRepository(DatabaseConnection conn)
+        {
+            _conn = conn;
+        }
+
+        public string GetString(string key, string defaultValue)
+        {
+            return _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    using (var cmd = new SQLiteCommand("SELECT value FROM settings WHERE key = @key", connection))
+                    {
+                        cmd.Parameters.AddWithValue("@key", key);
+                        var v = cmd.ExecuteScalar();
+                        if (v == null || v == DBNull.Value) return defaultValue;
+                        return v.ToString();
+                    }
+                }
+            });
+        }
+
+        public void SetString(string key, string value)
+        {
+            _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    using (var cmd = new SQLiteCommand(
+                        "INSERT INTO settings (key, value) VALUES (@key, @value) " +
+                        "ON CONFLICT(key) DO UPDATE SET value = @value", connection))
+                    {
+                        cmd.Parameters.AddWithValue("@key", key);
+                        cmd.Parameters.AddWithValue("@value", value ?? "");
+                        cmd.ExecuteNonQuery();
+                    }
+                }
+            });
+        }
+
+        public long GetInt64(string key, long defaultValue)
+        {
+            string s = GetString(key, null);
+            if (string.IsNullOrEmpty(s)) return defaultValue;
+            return long.TryParse(s, out long result) ? result : defaultValue;
+        }
+
+        public void SetInt64(string key, long value)
+        {
+            SetString(key, value.ToString());
+        }
+
+        public int GetInt32(string key, int defaultValue)
+        {
+            string s = GetString(key, null);
+            if (string.IsNullOrEmpty(s)) return defaultValue;
+            return int.TryParse(s, out int result) ? result : defaultValue;
+        }
+
+        public void SetInt32(string key, int value)
+        {
+            SetString(key, value.ToString());
+        }
+
+        /// <summary>
+        /// 自動バックアップ用の lease 取得。
+        /// last_backup_at + intervalSeconds &lt;= now の場合のみ last_backup_at を now に更新して true を返す。
+        /// 競合した場合は片方のみ true を返す（BEGIN IMMEDIATE による排他制御）。
+        /// </summary>
+        public bool TryAcquireBackupLease(long intervalSeconds, long nowUnixSeconds)
+        {
+            return _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithWalMode(connection);
+                    // System.Data.SQLite では IsolationLevel.Serializable が BEGIN IMMEDIATE に対応
+                    using (var tx = connection.BeginTransaction(IsolationLevel.Serializable))
+                    {
+                        long lastBackupAt = 0;
+                        using (var cmd = new SQLiteCommand(
+                            "SELECT value FROM settings WHERE key = 'last_backup_at'", connection, tx))
+                        {
+                            var v = cmd.ExecuteScalar();
+                            if (v != null && v != DBNull.Value)
+                                long.TryParse(v.ToString(), out lastBackupAt);
+                        }
+
+                        if (lastBackupAt + intervalSeconds > nowUnixSeconds)
+                        {
+                            tx.Rollback();
+                            return false;
+                        }
+
+                        using (var cmd = new SQLiteCommand(
+                            "UPDATE settings SET value = @v WHERE key = 'last_backup_at'", connection, tx))
+                        {
+                            cmd.Parameters.AddWithValue("@v", nowUnixSeconds.ToString());
+                            cmd.ExecuteNonQuery();
+                        }
+
+                        tx.Commit();
+                        return true;
+                    }
+                }
+            });
+        }
+    }
+}

--- a/GCTonePrism_Manager/RestoreConfirmForm.Designer.cs
+++ b/GCTonePrism_Manager/RestoreConfirmForm.Designer.cs
@@ -1,0 +1,179 @@
+namespace GCTonePrism.Manager
+{
+    partial class RestoreConfirmForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows フォーム デザイナーで生成されたコード
+
+        private void InitializeComponent()
+        {
+            this.lblWarning = new System.Windows.Forms.Label();
+            this.lblTargetFile = new System.Windows.Forms.Label();
+            this.lblWarningDetail1 = new System.Windows.Forms.Label();
+            this.lblWarningDetail2 = new System.Windows.Forms.Label();
+            this.lblWarningDetail3 = new System.Windows.Forms.Label();
+            this.lblConfirmationCode = new System.Windows.Forms.Label();
+            this.txtConfirmationCode = new System.Windows.Forms.TextBox();
+            this.lblInstruction = new System.Windows.Forms.Label();
+            this.btnConfirm = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            //
+            // lblWarning
+            //
+            this.lblWarning.AutoSize = true;
+            this.lblWarning.Font = new System.Drawing.Font("MS UI Gothic", 12F, System.Drawing.FontStyle.Bold);
+            this.lblWarning.ForeColor = System.Drawing.Color.Red;
+            this.lblWarning.Location = new System.Drawing.Point(20, 20);
+            this.lblWarning.Name = "lblWarning";
+            this.lblWarning.Size = new System.Drawing.Size(420, 20);
+            this.lblWarning.TabIndex = 0;
+            this.lblWarning.Text = "【警告】データベースを復元します";
+            //
+            // lblTargetFile
+            //
+            this.lblTargetFile.AutoEllipsis = true;
+            this.lblTargetFile.Location = new System.Drawing.Point(20, 50);
+            this.lblTargetFile.Name = "lblTargetFile";
+            this.lblTargetFile.Size = new System.Drawing.Size(620, 40);
+            this.lblTargetFile.TabIndex = 1;
+            this.lblTargetFile.Text = "対象: ";
+            //
+            // lblWarningDetail1
+            //
+            this.lblWarningDetail1.AutoSize = true;
+            this.lblWarningDetail1.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblWarningDetail1.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Bold);
+            this.lblWarningDetail1.Location = new System.Drawing.Point(20, 100);
+            this.lblWarningDetail1.Name = "lblWarningDetail1";
+            this.lblWarningDetail1.Size = new System.Drawing.Size(550, 14);
+            this.lblWarningDetail1.TabIndex = 2;
+            this.lblWarningDetail1.Text = "・実行前に、すべての展示PCのLauncherを終了してください";
+            //
+            // lblWarningDetail2
+            //
+            this.lblWarningDetail2.AutoSize = true;
+            this.lblWarningDetail2.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblWarningDetail2.Location = new System.Drawing.Point(20, 120);
+            this.lblWarningDetail2.Name = "lblWarningDetail2";
+            this.lblWarningDetail2.Size = new System.Drawing.Size(560, 14);
+            this.lblWarningDetail2.TabIndex = 3;
+            this.lblWarningDetail2.Text = "・現在のデータベースは安全のため自動的に退避されます (safety_before_restore_*.db)";
+            //
+            // lblWarningDetail3
+            //
+            this.lblWarningDetail3.AutoSize = true;
+            this.lblWarningDetail3.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblWarningDetail3.Location = new System.Drawing.Point(20, 140);
+            this.lblWarningDetail3.Name = "lblWarningDetail3";
+            this.lblWarningDetail3.Size = new System.Drawing.Size(560, 14);
+            this.lblWarningDetail3.TabIndex = 4;
+            this.lblWarningDetail3.Text = "・復元後の状態に問題があれば、退避ファイルから手動で戻すことが可能です";
+            //
+            // lblConfirmationCode
+            //
+            this.lblConfirmationCode.AutoSize = true;
+            this.lblConfirmationCode.Font = new System.Drawing.Font("MS UI Gothic", 10F, System.Drawing.FontStyle.Bold);
+            this.lblConfirmationCode.Location = new System.Drawing.Point(20, 175);
+            this.lblConfirmationCode.Name = "lblConfirmationCode";
+            this.lblConfirmationCode.Size = new System.Drawing.Size(125, 17);
+            this.lblConfirmationCode.TabIndex = 5;
+            this.lblConfirmationCode.Text = "確認コード: XXXX";
+            //
+            // txtConfirmationCode
+            //
+            this.txtConfirmationCode.Font = new System.Drawing.Font("MS UI Gothic", 12F, System.Drawing.FontStyle.Bold);
+            this.txtConfirmationCode.Location = new System.Drawing.Point(20, 200);
+            this.txtConfirmationCode.MaxLength = 10;
+            this.txtConfirmationCode.Name = "txtConfirmationCode";
+            this.txtConfirmationCode.Size = new System.Drawing.Size(150, 27);
+            this.txtConfirmationCode.TabIndex = 6;
+            this.txtConfirmationCode.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            //
+            // lblInstruction
+            //
+            this.lblInstruction.AutoSize = true;
+            this.lblInstruction.Location = new System.Drawing.Point(20, 235);
+            this.lblInstruction.Name = "lblInstruction";
+            this.lblInstruction.Size = new System.Drawing.Size(550, 15);
+            this.lblInstruction.TabIndex = 7;
+            this.lblInstruction.Text = "上記の確認コードを入力してください。コードを間違えると新しいコードが生成されます。";
+            //
+            // btnConfirm
+            //
+            this.btnConfirm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnConfirm.BackColor = System.Drawing.Color.Red;
+            this.btnConfirm.Font = new System.Drawing.Font("MS UI Gothic", 10F, System.Drawing.FontStyle.Bold);
+            this.btnConfirm.ForeColor = System.Drawing.Color.White;
+            this.btnConfirm.Location = new System.Drawing.Point(380, 280);
+            this.btnConfirm.Name = "btnConfirm";
+            this.btnConfirm.Size = new System.Drawing.Size(150, 40);
+            this.btnConfirm.TabIndex = 8;
+            this.btnConfirm.Text = "復元実行";
+            this.btnConfirm.UseVisualStyleBackColor = false;
+            this.btnConfirm.Click += new System.EventHandler(this.btnConfirm_Click);
+            //
+            // btnCancel
+            //
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(540, 280);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(100, 40);
+            this.btnCancel.TabIndex = 9;
+            this.btnCancel.Text = "キャンセル";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            //
+            // RestoreConfirmForm
+            //
+            this.AcceptButton = this.btnConfirm;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(660, 340);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnConfirm);
+            this.Controls.Add(this.lblInstruction);
+            this.Controls.Add(this.txtConfirmationCode);
+            this.Controls.Add(this.lblConfirmationCode);
+            this.Controls.Add(this.lblWarningDetail3);
+            this.Controls.Add(this.lblWarningDetail2);
+            this.Controls.Add(this.lblWarningDetail1);
+            this.Controls.Add(this.lblTargetFile);
+            this.Controls.Add(this.lblWarning);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "RestoreConfirmForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "データベース復元の確認";
+            this.Load += new System.EventHandler(this.RestoreConfirmForm_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblWarning;
+        private System.Windows.Forms.Label lblTargetFile;
+        private System.Windows.Forms.Label lblWarningDetail1;
+        private System.Windows.Forms.Label lblWarningDetail2;
+        private System.Windows.Forms.Label lblWarningDetail3;
+        private System.Windows.Forms.Label lblConfirmationCode;
+        private System.Windows.Forms.TextBox txtConfirmationCode;
+        private System.Windows.Forms.Label lblInstruction;
+        private System.Windows.Forms.Button btnConfirm;
+        private System.Windows.Forms.Button btnCancel;
+    }
+}

--- a/GCTonePrism_Manager/RestoreConfirmForm.cs
+++ b/GCTonePrism_Manager/RestoreConfirmForm.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Windows.Forms;
+using GCTonePrism.Manager.Models;
+
+namespace GCTonePrism.Manager
+{
+    /// <summary>
+    /// データベース復元の確認ダイアログ。確認コード入力で誤操作を防止する。
+    /// </summary>
+    public partial class RestoreConfirmForm : Form
+    {
+        private string _confirmationCode;
+        private readonly Random _random = new Random();
+        private readonly BackupLogEntry _entry;
+
+        public RestoreConfirmForm(BackupLogEntry entry)
+        {
+            InitializeComponent();
+            _entry = entry;
+        }
+
+        private void RestoreConfirmForm_Load(object sender, EventArgs e)
+        {
+            _confirmationCode = GenerateConfirmationCode();
+            lblConfirmationCode.Text = $"確認コード: {_confirmationCode}";
+
+            if (_entry != null)
+            {
+                string sizeStr = _entry.FileSizeBytes.HasValue ? FormatBytes(_entry.FileSizeBytes.Value) : "-";
+                lblTargetFile.Text =
+                    $"対象: {Path.GetFileName(_entry.FilePath ?? "")}\n" +
+                    $"作成日時: {_entry.StartedAtLocal:yyyy/MM/dd HH:mm:ss}\n" +
+                    $"サイズ: {sizeStr}\n" +
+                    $"フルパス: {_entry.FilePath}";
+            }
+        }
+
+        private static string GenerateConfirmationCode()
+        {
+            const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+            var random = new Random();
+            char[] code = new char[4];
+            for (int i = 0; i < 4; i++)
+            {
+                code[i] = chars[random.Next(chars.Length)];
+            }
+            return new string(code);
+        }
+
+        private void btnConfirm_Click(object sender, EventArgs e)
+        {
+            if (txtConfirmationCode.Text.Trim().ToUpper() != _confirmationCode.ToUpper())
+            {
+                MessageBox.Show("確認コードが正しくありません。", "エラー",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                _confirmationCode = GenerateConfirmationCode();
+                lblConfirmationCode.Text = $"確認コード: {_confirmationCode}";
+                txtConfirmationCode.Clear();
+                return;
+            }
+            DialogResult = DialogResult.Yes;
+            Close();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            if (bytes < 1024) return $"{bytes} B";
+            double kb = bytes / 1024.0;
+            if (kb < 1024) return $"{kb:F1} KB";
+            double mb = kb / 1024.0;
+            if (mb < 1024) return $"{mb:F2} MB";
+            double gb = mb / 1024.0;
+            return $"{gb:F2} GB";
+        }
+    }
+}

--- a/GCTonePrism_Manager/SchemaManager.cs
+++ b/GCTonePrism_Manager/SchemaManager.cs
@@ -16,7 +16,7 @@ namespace GCTonePrism.Manager
 
         // 現在のデータベースバージョン
         // 構造変更があるたびにインクリメントする
-        private const int CurrentDbVersion = 8;
+        private const int CurrentDbVersion = 10;
 
         public SchemaManager(DatabaseConnection conn)
         {
@@ -296,6 +296,11 @@ namespace GCTonePrism.Manager
                 command.ExecuteNonQuery();
             }
 
+            // settings テーブルが古いスキーマ（id / color_theme / launcher_settings / filter_settings の単一行型）の場合、
+            // KVS スキーマへ移行する。SPECIFICATION 1.3.1 (2026-02-08) で KVS 化されたが、
+            // 既存DB向けマイグレーションが実装されていなかったため Manager v0.8.0 でフォローする。
+            EnsureSettingsTableIsKvsSchema(connection, transaction);
+
             // store_sectionsテーブル作成
             string createStoreSectionsTable = @"
                 CREATE TABLE IF NOT EXISTS store_sections (
@@ -329,6 +334,128 @@ namespace GCTonePrism.Manager
             using (var command = new SQLiteCommand(createStoreSectionGamesTable, connection, transaction))
             {
                 command.ExecuteNonQuery();
+            }
+
+            // backup_logテーブル作成（v9 で追加）
+            CreateBackupLogTable(connection, transaction);
+
+            // 新規DB向けにバックアップ関連の設定デフォルト値を投入
+            InsertBackupDefaults(connection, transaction);
+        }
+
+        /// <summary>
+        /// settings テーブルが古いスキーマの場合、KVS スキーマへ移行する。
+        /// 古いスキーマ（id / color_theme / launcher_settings / filter_settings 等）には
+        /// 実コードからの読み書きが存在しなかったため、データロスは発生しない。
+        /// 念のため `settings_legacy_v8_or_earlier` としてリネームしてから新規作成する。
+        /// </summary>
+        private void EnsureSettingsTableIsKvsSchema(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // 1. settings テーブルが存在するか
+            bool settingsExists;
+            using (var cmd = new SQLiteCommand(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='settings'",
+                connection, transaction))
+            {
+                long count = (long)cmd.ExecuteScalar();
+                settingsExists = count > 0;
+            }
+            if (!settingsExists)
+            {
+                // 直前の CREATE TABLE IF NOT EXISTS で必ず作成されているはずだが、念のため。
+                return;
+            }
+
+            // 2. 'key' カラムがあるか
+            bool hasKeyColumn = false;
+            using (var cmd = new SQLiteCommand("PRAGMA table_info(settings)", connection, transaction))
+            using (var reader = cmd.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    if (reader["name"].ToString() == "key")
+                    {
+                        hasKeyColumn = true;
+                        break;
+                    }
+                }
+            }
+
+            if (hasKeyColumn) return;
+
+            // 3. 古いスキーマ → リネームして新規作成
+            Console.WriteLine("[DatabaseManager] settings テーブルが古いスキーマです。KVS方式に移行します。");
+
+            // 既に legacy テーブルが残っていたら削除（過去に失敗した移行の残骸を掃除）
+            using (var cmd = new SQLiteCommand(
+                "DROP TABLE IF EXISTS settings_legacy_v8_or_earlier", connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var cmd = new SQLiteCommand(
+                "ALTER TABLE settings RENAME TO settings_legacy_v8_or_earlier", connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var cmd = new SQLiteCommand(
+                "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)", connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            Console.WriteLine("[DatabaseManager] settings テーブルを KVS 方式で再作成しました。" +
+                              "旧データは settings_legacy_v8_or_earlier に保管されています。");
+        }
+
+        /// <summary>
+        /// backup_log テーブルを作成（IF NOT EXISTS で冪等）。
+        /// trigger_type は 'manual' / 'auto' / 'safety' の3種。
+        /// </summary>
+        private void CreateBackupLogTable(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            string sql = @"
+                CREATE TABLE IF NOT EXISTS backup_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    started_at INTEGER NOT NULL,
+                    completed_at INTEGER,
+                    pc_name TEXT NOT NULL,
+                    file_path TEXT,
+                    file_size_bytes INTEGER,
+                    status TEXT NOT NULL CHECK (status IN ('in_progress','success','failed')),
+                    error_message TEXT,
+                    trigger_type TEXT NOT NULL CHECK (trigger_type IN ('manual','auto','safety'))
+                )";
+            using (var command = new SQLiteCommand(sql, connection, transaction))
+            {
+                command.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// settings テーブルにバックアップ関連のデフォルトキーを INSERT OR IGNORE で投入
+        /// </summary>
+        private void InsertBackupDefaults(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            string[][] defaults = new[]
+            {
+                new[] { "last_backup_at", "0" },
+                new[] { "backup_destination_path", "" },
+                new[] { "backup_auto_interval_hours", "24" },
+                new[] { "backup_retention_count", "30" }
+            };
+
+            foreach (var kv in defaults)
+            {
+                using (var command = new SQLiteCommand(
+                    "INSERT OR IGNORE INTO settings (key, value) VALUES (@key, @value)",
+                    connection, transaction))
+                {
+                    command.Parameters.AddWithValue("@key", kv[0]);
+                    command.Parameters.AddWithValue("@value", kv[1]);
+                    command.ExecuteNonQuery();
+                }
             }
         }
 
@@ -527,6 +654,18 @@ namespace GCTonePrism.Manager
                     {
                         MigrateV7ToV8(connection, migTransaction);
                         currentVersion = 8;
+                    }
+
+                    if (currentVersion < 9)
+                    {
+                        MigrateV8ToV9(connection, migTransaction);
+                        currentVersion = 9;
+                    }
+
+                    if (currentVersion < 10)
+                    {
+                        MigrateV9ToV10(connection, migTransaction);
+                        currentVersion = 10;
                     }
 
                     SetDbVersion(connection, CurrentDbVersion, migTransaction);
@@ -913,6 +1052,67 @@ namespace GCTonePrism.Manager
                 // カラムが既に存在する場合はスキップ
                 Console.WriteLine($"[DatabaseManager] Warning adding display_text: {ex.Message}");
             }
+        }
+
+        private void MigrateV8ToV9(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            Console.WriteLine("[DatabaseManager] Executing migration V8 -> V9 (Adding backup_log table and backup-related settings)");
+
+            // backup_log テーブル作成（CreateTables 側でも IF NOT EXISTS で作成されるが、明示的に呼ぶ）
+            CreateBackupLogTable(connection, transaction);
+
+            // バックアップ関連の設定デフォルトを投入
+            InsertBackupDefaults(connection, transaction);
+
+            Console.WriteLine("[DatabaseManager] Migration V8 -> V9 completed.");
+        }
+
+        private void MigrateV9ToV10(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            Console.WriteLine("[DatabaseManager] Executing migration V9 -> V10 (Extending backup_log.trigger_type CHECK to allow 'safety')");
+
+            // SQLite の CHECK 制約は ALTER TABLE で変更できないため、テーブルを作り直す。
+            // 既存行は trigger_type が 'manual' / 'auto' のみなので新CHECKに違反しない。
+            string createNew = @"
+                CREATE TABLE backup_log_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    started_at INTEGER NOT NULL,
+                    completed_at INTEGER,
+                    pc_name TEXT NOT NULL,
+                    file_path TEXT,
+                    file_size_bytes INTEGER,
+                    status TEXT NOT NULL CHECK (status IN ('in_progress','success','failed')),
+                    error_message TEXT,
+                    trigger_type TEXT NOT NULL CHECK (trigger_type IN ('manual','auto','safety'))
+                )";
+            using (var cmd = new SQLiteCommand(createNew, connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            // データを丸ごとコピー（id を維持するため列を明示）
+            using (var cmd = new SQLiteCommand(
+                "INSERT INTO backup_log_new (id, started_at, completed_at, pc_name, file_path, " +
+                "file_size_bytes, status, error_message, trigger_type) " +
+                "SELECT id, started_at, completed_at, pc_name, file_path, " +
+                "file_size_bytes, status, error_message, trigger_type FROM backup_log",
+                connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var cmd = new SQLiteCommand("DROP TABLE backup_log", connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var cmd = new SQLiteCommand(
+                "ALTER TABLE backup_log_new RENAME TO backup_log", connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            Console.WriteLine("[DatabaseManager] Migration V9 -> V10 completed.");
         }
 
         private void CopyDevelopersToVersion(SQLiteConnection connection, SQLiteTransaction transaction, string gameId, int versionId)

--- a/GCTonePrism_Manager/Services/BackupService.cs
+++ b/GCTonePrism_Manager/Services/BackupService.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SQLite;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using GCTonePrism.Manager.Models;
+using GCTonePrism.Manager.Repositories;
+
+namespace GCTonePrism.Manager.Services
+{
+    /// <summary>
+    /// データベースバックアップ機能のドメインロジック。
+    /// SQLite Online Backup API を用いて prism.db のスナップショットを取得し、
+    /// backup_log への記録、世代管理（リテンション）、自動バックアップの lease 取得を担う。
+    /// </summary>
+    public class BackupService
+    {
+        public const string TriggerManual = "manual";
+        public const string TriggerAuto = "auto";
+
+        private readonly DatabaseConnection _conn;
+        private readonly BackupLogRepository _logRepo;
+        private readonly SettingsRepository _settingsRepo;
+
+        public BackupService(DatabaseConnection conn, BackupLogRepository logRepo, SettingsRepository settingsRepo)
+        {
+            _conn = conn;
+            _logRepo = logRepo;
+            _settingsRepo = settingsRepo;
+        }
+
+        /// <summary>
+        /// 自動バックアップを走らせるべきかチェック（参照のみ、副作用なし）。
+        /// 実際の実行時には RunAutoBackupIfDue を使う（lease 取得を含む）。
+        /// </summary>
+        public bool IsAutoBackupDue()
+        {
+            int intervalHours = _settingsRepo.GetInt32("backup_auto_interval_hours", 24);
+            long lastBackupAt = _settingsRepo.GetInt64("last_backup_at", 0);
+            long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            return lastBackupAt + (long)intervalHours * 3600 <= now;
+        }
+
+        /// <summary>
+        /// 設定された保存先パスを返す。空ならデフォルト（DBフォルダ/backups/）を返す。
+        /// </summary>
+        public string GetEffectiveDestinationDirectory()
+        {
+            string configured = _settingsRepo.GetString("backup_destination_path", "");
+            if (!string.IsNullOrWhiteSpace(configured))
+                return configured;
+            string dbDir = Path.GetDirectoryName(_conn.DbPath);
+            return Path.Combine(dbDir, "backups");
+        }
+
+        /// <summary>
+        /// 自動バックアップ実行（lease 取得失敗時はスキップ）
+        /// </summary>
+        public BackupResult RunAutoBackupIfDue(IProgress<ProgressInfo> progress, CancellationToken token)
+        {
+            int intervalHours = _settingsRepo.GetInt32("backup_auto_interval_hours", 24);
+            long intervalSeconds = (long)intervalHours * 3600;
+            long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            if (!_settingsRepo.TryAcquireBackupLease(intervalSeconds, now))
+            {
+                return BackupResult.Skipped("自動バックアップは既に他のManagerで実行されました（または間隔未到達）");
+            }
+            return RunBackupCore(TriggerAuto, progress, token, leaseAlreadyAcquired: true);
+        }
+
+        /// <summary>
+        /// 手動バックアップ実行（lease チェックなし、即時実行）
+        /// </summary>
+        public BackupResult RunManualBackup(IProgress<ProgressInfo> progress, CancellationToken token)
+        {
+            return RunBackupCore(TriggerManual, progress, token, leaseAlreadyAcquired: false);
+        }
+
+        private BackupResult RunBackupCore(string triggerType, IProgress<ProgressInfo> progress, CancellationToken token, bool leaseAlreadyAcquired)
+        {
+            string pcName = Environment.MachineName;
+            long startedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            // ファイルパスを先に確定させ、in_progress 行に最初から記録する。
+            // こうすることで、後で「ファイル存在の有無」で行をリコンサイルできる。
+            string destinationDir = GetEffectiveDestinationDirectory();
+            string fileName = $"prism_{DateTime.Now:yyyyMMdd_HHmmss}.db";
+            string destinationPath = Path.Combine(destinationDir, fileName);
+
+            long logId = _logRepo.InsertInProgress(pcName, triggerType, startedAt, destinationPath);
+
+            try
+            {
+                progress?.Report(new ProgressInfo(0, "バックアップ準備中...", destinationPath));
+
+                if (!Directory.Exists(destinationDir))
+                {
+                    Directory.CreateDirectory(destinationDir);
+                }
+
+                token.ThrowIfCancellationRequested();
+
+                // SQLite Online Backup API でコピー
+                using (var sourceConn = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    sourceConn.Open();
+                    using (var destConn = new SQLiteConnection($"Data Source={destinationPath};Version=3;"))
+                    {
+                        destConn.Open();
+                        sourceConn.BackupDatabase(destConn, "main", "main", -1,
+                            (source, sourceName, dest, destName, pages, remainingPages, totalPages, retry) =>
+                            {
+                                if (token.IsCancellationRequested) return false;
+
+                                int percent = 0;
+                                if (totalPages > 0)
+                                {
+                                    int copied = totalPages - remainingPages;
+                                    percent = (int)(((double)copied / totalPages) * 100);
+                                    if (percent < 0) percent = 0;
+                                    if (percent > 100) percent = 100;
+                                }
+                                progress?.Report(new ProgressInfo(
+                                    percent,
+                                    "バックアップ中...",
+                                    $"{totalPages - remainingPages}/{totalPages} ページ"));
+                                return true;
+                            },
+                            100);
+                    }
+                }
+
+                token.ThrowIfCancellationRequested();
+
+                long fileSize = 0;
+                if (File.Exists(destinationPath))
+                {
+                    fileSize = new FileInfo(destinationPath).Length;
+                }
+
+                long completedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                _logRepo.MarkSuccess(logId, destinationPath, fileSize, completedAt);
+
+                // 手動の場合も last_backup_at を更新（自動バックアップが続けて走らないように）
+                if (!leaseAlreadyAcquired)
+                {
+                    _settingsRepo.SetInt64("last_backup_at", completedAt);
+                }
+
+                // リテンションは成功時のみ適用
+                progress?.Report(new ProgressInfo(95, "古いバックアップを整理中...", ""));
+                ApplyRetention(destinationDir);
+
+                progress?.Report(new ProgressInfo(100, "バックアップ完了", destinationPath));
+                return BackupResult.Success(destinationPath, fileSize);
+            }
+            catch (OperationCanceledException)
+            {
+                long completedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                _logRepo.MarkFailed(logId, "ユーザーによりキャンセルされました", completedAt);
+                // 中途半端なファイルを削除
+                TryDeleteIfExists(destinationPath);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                long completedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                _logRepo.MarkFailed(logId, ex.Message, completedAt);
+                TryDeleteIfExists(destinationPath);
+                return BackupResult.Failed(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// 設定された世代数を超える古いバックアップファイルを削除
+        /// </summary>
+        private void ApplyRetention(string destinationDir)
+        {
+            int retentionCount = _settingsRepo.GetInt32("backup_retention_count", 30);
+            if (retentionCount <= 0) return;
+
+            try
+            {
+                var dir = new DirectoryInfo(destinationDir);
+                if (!dir.Exists) return;
+
+                var oldFiles = dir.GetFiles("prism_*.db")
+                    .OrderByDescending(f => f.CreationTimeUtc)
+                    .Skip(retentionCount)
+                    .ToList();
+
+                foreach (var f in oldFiles)
+                {
+                    try
+                    {
+                        f.Delete();
+                        Console.WriteLine($"[BackupService] 古いバックアップを削除: {f.Name}");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"[BackupService] 削除失敗 {f.Name}: {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[BackupService] リテンション処理失敗: {ex.Message}");
+            }
+        }
+
+        private static void TryDeleteIfExists(string path)
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch { /* ignore */ }
+        }
+
+        /// <summary>
+        /// 旧バージョン（v0.8.0 リリース直前まで）でプロジェクトルート直下に作られていた
+        /// `safety_before_restore_yyyyMMdd_HHmmss.db` ファイルを `backups/safety/` 配下に移動する。
+        /// 既に同名ファイルが移動先にあればスキップ（ファイルシステム的に安全）。
+        /// このメソッドは Manager 起動時に1回呼ぶことを想定（idempotent）。
+        /// </summary>
+        /// <returns>移動した件数</returns>
+        public static int MigrateLegacySafetyFilesToSafetyFolder(string dbDir)
+        {
+            if (string.IsNullOrEmpty(dbDir) || !Directory.Exists(dbDir)) return 0;
+
+            string safetyDir = Path.Combine(dbDir, "backups", "safety");
+            var legacyRegex = new Regex(@"^safety_before_restore_\d{8}_\d{6}\.db$");
+
+            var legacyFiles = new DirectoryInfo(dbDir)
+                .EnumerateFiles("safety_before_restore_*.db")
+                .Where(f => legacyRegex.IsMatch(f.Name))
+                .ToList();
+            if (legacyFiles.Count == 0) return 0;
+
+            if (!Directory.Exists(safetyDir))
+            {
+                Directory.CreateDirectory(safetyDir);
+            }
+
+            int moved = 0;
+            foreach (var file in legacyFiles)
+            {
+                try
+                {
+                    string destPath = Path.Combine(safetyDir, file.Name);
+                    if (File.Exists(destPath))
+                    {
+                        Console.WriteLine($"[BackupService] スキップ（既存）: {file.Name}");
+                        continue;
+                    }
+                    file.MoveTo(destPath);
+                    moved++;
+                    Console.WriteLine($"[BackupService] 退避ファイル移動: {file.Name} → backups/safety/");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[BackupService] 退避ファイル移動失敗 {file.Name}: {ex.Message}");
+                }
+            }
+            return moved;
+        }
+
+        /// <summary>
+        /// 退避（safety）バックアップ用フォルダのフルパスを返す。
+        /// `<DBフォルダ>/backups/safety/` に固定。
+        /// </summary>
+        public string GetSafetyDirectory()
+        {
+            string dbDir = Path.GetDirectoryName(_conn.DbPath);
+            return Path.Combine(dbDir, "backups", "safety");
+        }
+
+        /// <summary>
+        /// バックアップディレクトリ内のファイル一覧（履歴UIから「ディスク上の実体」を見る用）
+        /// </summary>
+        public List<FileInfo> ListBackupFiles()
+        {
+            var dir = new DirectoryInfo(GetEffectiveDestinationDirectory());
+            if (!dir.Exists) return new List<FileInfo>();
+            return dir.GetFiles("prism_*.db")
+                .OrderByDescending(f => f.CreationTimeUtc)
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// バックアップ実行結果
+    /// </summary>
+    public class BackupResult
+    {
+        public enum ResultKind { SuccessKind, SkippedKind, FailedKind }
+
+        public ResultKind Kind { get; private set; }
+        public string FilePath { get; private set; }
+        public long FileSizeBytes { get; private set; }
+        public string Message { get; private set; }
+
+        public bool IsSuccess { get { return Kind == ResultKind.SuccessKind; } }
+        public bool IsSkipped { get { return Kind == ResultKind.SkippedKind; } }
+        public bool IsFailed { get { return Kind == ResultKind.FailedKind; } }
+
+        public static BackupResult Success(string filePath, long fileSizeBytes)
+        {
+            return new BackupResult { Kind = ResultKind.SuccessKind, FilePath = filePath, FileSizeBytes = fileSizeBytes };
+        }
+        public static BackupResult Skipped(string reason)
+        {
+            return new BackupResult { Kind = ResultKind.SkippedKind, Message = reason };
+        }
+        public static BackupResult Failed(string errorMessage)
+        {
+            return new BackupResult { Kind = ResultKind.FailedKind, Message = errorMessage };
+        }
+    }
+}

--- a/GCTonePrism_Manager/Services/RestoreService.cs
+++ b/GCTonePrism_Manager/Services/RestoreService.cs
@@ -22,12 +22,16 @@ namespace GCTonePrism.Manager.Services
         }
 
         /// <summary>
-        /// 指定されたバックアップファイルから prism.db を復元する。
+        /// 指定されたバックアップファイルから prism.db を復元する（atomic 復元）。
         /// 1. 現DBを backups/safety/safety_HHmmss.db として退避（Online Backup API でコピー）
-        /// 2. 全 SQLite 接続プールをクリア
-        /// 3. prism.db / .db-wal / .db-shm を削除
-        /// 4. バックアップファイルを prism.db としてコピー
+        /// 2. バックアップを prism.db.restore-tmp に先にコピー（prism.db はまだ無傷）
+        /// 3. 全 SQLite 接続プールをクリア
+        ///   ─── ここから先はキャンセル不可（中断すると prism.db が一時的に欠落） ───
+        /// 4. 旧 WAL/SHM を削除し、prism.db を tmp で置換（File.Replace で atomic）
         /// 5. backups/safety/ のリテンション適用（古いものから削除）
+        ///
+        /// 利点: コピー失敗・キャンセル発生時に prism.db が消えてしまう事故を回避
+        /// （Codex P1 指摘 "Disallow cancellation after deleting active DB files" 対応）
         /// </summary>
         /// <returns>退避された安全バックアップのフルパス</returns>
         public string Restore(string backupFilePath, IProgress<ProgressInfo> progress, CancellationToken token)
@@ -38,6 +42,7 @@ namespace GCTonePrism.Manager.Services
             string dbPath = _conn.DbPath;
             string dbDir = Path.GetDirectoryName(dbPath);
             string safetyDir = Path.Combine(dbDir, "backups", "safety");
+            string tempPath = dbPath + ".restore-tmp";
 
             progress?.Report(new ProgressInfo(0, "復元の準備...", ""));
             token.ThrowIfCancellationRequested();
@@ -67,25 +72,37 @@ namespace GCTonePrism.Manager.Services
 
             token.ThrowIfCancellationRequested();
 
-            // 2. 全 SQLite 接続プールをクリアし、ハンドルを解放
-            progress?.Report(new ProgressInfo(40, "データベース接続を閉じています...", ""));
+            // 2. バックアップを一時ファイルへ先にコピー（prism.db はまだ無傷）。
+            //    コピー中・コピー後にキャンセル/失敗が起きても prism.db は壊れない。
+            progress?.Report(new ProgressInfo(40, "バックアップを準備中...", backupFilePath));
+            if (File.Exists(tempPath)) File.Delete(tempPath); // 前回失敗時の残骸があれば消す
+            File.Copy(backupFilePath, tempPath, false);
+
+            token.ThrowIfCancellationRequested();
+
+            // 3. 全 SQLite 接続プールをクリアし、ハンドルを解放
+            progress?.Report(new ProgressInfo(60, "データベース接続を閉じています...", ""));
             SQLiteConnection.ClearAllPools();
             GC.Collect();
             GC.WaitForPendingFinalizers();
 
-            token.ThrowIfCancellationRequested();
-
-            // 3. 現DBファイルおよび WAL/SHM を削除
-            progress?.Report(new ProgressInfo(55, "既存ファイルを削除中...", ""));
-            DeleteWithRetry(dbPath);
+            // ─── ここから先はキャンセル不可。中断すると prism.db が一時的に欠落する ───
+            // 4. WAL/SHM を削除し、tmp で prism.db を置換
+            progress?.Report(new ProgressInfo(80, "既存ファイルを置き換え中...", ""));
             DeleteWithRetry(dbPath + "-wal");
             DeleteWithRetry(dbPath + "-shm");
 
-            token.ThrowIfCancellationRequested();
-
-            // 4. バックアップファイルを prism.db としてコピー
-            progress?.Report(new ProgressInfo(75, "バックアップを復元中...", backupFilePath));
-            File.Copy(backupFilePath, dbPath, false);
+            if (File.Exists(dbPath))
+            {
+                // File.Replace は NTFS 上で atomic（ReplaceFile Win32 API）
+                // backupFileName=null で旧 prism.db のバックアップは作らない（safety で既に確保済み）
+                File.Replace(tempPath, dbPath, null);
+            }
+            else
+            {
+                // 新規 DB の場合（通常想定外だが安全対策）
+                File.Move(tempPath, dbPath);
+            }
 
             // 5. 退避フォルダのリテンション適用（最新を残して古いのから削除）
             progress?.Report(new ProgressInfo(95, "退避ファイルの世代管理...", ""));

--- a/GCTonePrism_Manager/Services/RestoreService.cs
+++ b/GCTonePrism_Manager/Services/RestoreService.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace GCTonePrism.Manager.Services
+{
+    /// <summary>
+    /// バックアップファイルから prism.db を復元するサービス。
+    /// 安全のため、復元前に現DBを backups/safety/safety_*.db として退避する。
+    /// </summary>
+    public class RestoreService
+    {
+        public const int DefaultSafetyRetentionCount = 10;
+
+        private readonly DatabaseConnection _conn;
+
+        public RestoreService(DatabaseConnection conn)
+        {
+            _conn = conn;
+        }
+
+        /// <summary>
+        /// 指定されたバックアップファイルから prism.db を復元する。
+        /// 1. 現DBを backups/safety/safety_HHmmss.db として退避（Online Backup API でコピー）
+        /// 2. 全 SQLite 接続プールをクリア
+        /// 3. prism.db / .db-wal / .db-shm を削除
+        /// 4. バックアップファイルを prism.db としてコピー
+        /// 5. backups/safety/ のリテンション適用（古いものから削除）
+        /// </summary>
+        /// <returns>退避された安全バックアップのフルパス</returns>
+        public string Restore(string backupFilePath, IProgress<ProgressInfo> progress, CancellationToken token)
+        {
+            if (!File.Exists(backupFilePath))
+                throw new FileNotFoundException("指定されたバックアップファイルが存在しません", backupFilePath);
+
+            string dbPath = _conn.DbPath;
+            string dbDir = Path.GetDirectoryName(dbPath);
+            string safetyDir = Path.Combine(dbDir, "backups", "safety");
+
+            progress?.Report(new ProgressInfo(0, "復元の準備...", ""));
+            token.ThrowIfCancellationRequested();
+
+            // 退避フォルダを必ず作成
+            if (!Directory.Exists(safetyDir))
+            {
+                Directory.CreateDirectory(safetyDir);
+            }
+
+            // 1. 現DBを安全バックアップ（Online Backup API でライブコピー）
+            string safetyPath = Path.Combine(safetyDir, $"safety_{DateTime.Now:yyyyMMdd_HHmmss}.db");
+            progress?.Report(new ProgressInfo(10, "現在のデータベースを退避中...", safetyPath));
+
+            if (File.Exists(dbPath))
+            {
+                using (var sourceConn = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    sourceConn.Open();
+                    using (var destConn = new SQLiteConnection($"Data Source={safetyPath};Version=3;"))
+                    {
+                        destConn.Open();
+                        sourceConn.BackupDatabase(destConn, "main", "main", -1, null, 0);
+                    }
+                }
+            }
+
+            token.ThrowIfCancellationRequested();
+
+            // 2. 全 SQLite 接続プールをクリアし、ハンドルを解放
+            progress?.Report(new ProgressInfo(40, "データベース接続を閉じています...", ""));
+            SQLiteConnection.ClearAllPools();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            token.ThrowIfCancellationRequested();
+
+            // 3. 現DBファイルおよび WAL/SHM を削除
+            progress?.Report(new ProgressInfo(55, "既存ファイルを削除中...", ""));
+            DeleteWithRetry(dbPath);
+            DeleteWithRetry(dbPath + "-wal");
+            DeleteWithRetry(dbPath + "-shm");
+
+            token.ThrowIfCancellationRequested();
+
+            // 4. バックアップファイルを prism.db としてコピー
+            progress?.Report(new ProgressInfo(75, "バックアップを復元中...", backupFilePath));
+            File.Copy(backupFilePath, dbPath, false);
+
+            // 5. 退避フォルダのリテンション適用（最新を残して古いのから削除）
+            progress?.Report(new ProgressInfo(95, "退避ファイルの世代管理...", ""));
+            ApplySafetyRetention(safetyDir, DefaultSafetyRetentionCount);
+
+            progress?.Report(new ProgressInfo(100, "復元完了", dbPath));
+            return safetyPath;
+        }
+
+        /// <summary>
+        /// safety_*.db を新しい順に count 個まで残し、それより古いものを削除
+        /// </summary>
+        private static void ApplySafetyRetention(string safetyDir, int count)
+        {
+            try
+            {
+                var dir = new DirectoryInfo(safetyDir);
+                if (!dir.Exists) return;
+
+                var oldFiles = dir.GetFiles("safety_*.db")
+                    .OrderByDescending(f => f.CreationTimeUtc)
+                    .Skip(count)
+                    .ToList();
+
+                foreach (var f in oldFiles)
+                {
+                    try
+                    {
+                        f.Delete();
+                        Console.WriteLine($"[RestoreService] 古い退避ファイル削除: {f.Name}");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"[RestoreService] 退避ファイル削除失敗 {f.Name}: {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[RestoreService] 退避リテンション処理失敗: {ex.Message}");
+            }
+        }
+
+        private static void DeleteWithRetry(string path)
+        {
+            if (!File.Exists(path)) return;
+            for (int i = 0; i < 5; i++)
+            {
+                try
+                {
+                    File.Delete(path);
+                    return;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(200);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(200);
+                }
+            }
+            // 5回試して駄目ならもう一度試して例外を伝播
+            File.Delete(path);
+        }
+    }
+}

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -501,6 +501,42 @@
   - システム全体の設定変更
   - 必要に応じて追加される設定項目の管理
 
+#### バックアップ機能
+
+##### 機能12: データベースバックアップ・復元機能
+
+- **説明**: `prism.db` のスナップショットを取得・管理し、障害・破損・操作ミス発生時に過去の状態へ戻せるようにする機能
+- **優先度**: 高（特にプレイ記録・アンケート結果のような再現不可なデータの保全のため）
+- **対応リリース**: Manager v0.8.0
+- **詳細**:
+  - **専用タブ「バックアップ」**を MainForm に追加
+  - **手動バックアップ**: 「今すぐバックアップ」ボタンで即時実行
+  - **自動バックアップ**: Manager 起動時に「前回バックアップから設定間隔（デフォルト 24h）以上経過していたら走らせる」方式
+    - 設置現場の運用上、Manager は常時起動でなく時々開かれる前提のため、起動時チェック方式を採用（cron 型ではない）
+  - **バックアップ方式**: SQLite Online Backup API（`SQLiteConnection.BackupDatabase`）を使用
+    - Launcher が `prism.db` を開いている状態でもライブDBの整合性を保ったコピーが可能
+    - WAL モードのチェックポイント処理も内部で適切に行われる
+  - **マルチPC重複防止**: `settings.last_backup_at` を `BEGIN IMMEDIATE` トランザクションで更新する lease 方式
+    - 運用上は単一Manager前提だが、防衛的な仕組みとして実装
+  - **バックアップ履歴一覧**: `backup_log` テーブルを表示（日時 / 実行PC / トリガ / 状態 / サイズ / ファイルパス）
+  - **保存先設定**: デフォルトは `<DBファイルのフォルダ>/backups/`、設定で任意のフォルダに変更可能
+  - **ファイル名規則**: `prism_YYYYMMDD_HHmmss.db`
+  - **世代管理**: 設定値 `backup_retention_count`（デフォルト 30）を超える古いバックアップは自動削除
+  - **リストア機能**:
+    1. 履歴一覧から復元したいバックアップを選択
+    2. 警告ダイアログ表示（「全Launcher を停止してください」「現DBは退避されます」）
+    3. 4桁の確認コード入力による誤操作防止（`ResetDatabaseConfirmForm` と同じパターン）
+    4. 現在の `prism.db` を `safety_before_restore_HHmmss.db` として Online Backup API で退避
+    5. SQLite 接続プールをクリア
+    6. `prism.db` / `prism.db-wal` / `prism.db-shm` を削除
+    7. 選択されたバックアップを `prism.db` としてコピー
+    8. DB を再初期化、各パネルを再ロード
+- **設定値**（`settings` テーブルに保存）:
+  - `last_backup_at`（UNIX秒）: 最終バックアップ完了時刻、lease で使用
+  - `backup_destination_path`（TEXT）: 保存先フォルダ。空ならデフォルト
+  - `backup_auto_interval_hours`（INTEGER, デフォルト 24）: 自動バックアップ間隔
+  - `backup_retention_count`（INTEGER, デフォルト 30）: 保持する世代数
+
 ### 2.3 監視機能（Monitor - 先生PC向け）
 
 パソコン室内の先生PCで動作し、各展示PCの状態監視とスタッフ呼び出し通知の受信を行う監視ソフトウェア。
@@ -1472,9 +1508,20 @@ prism.db (SQLiteデータベースファイル)
   │    ├─ comment
   │    └─ created_at
 
-  └─ settingsテーブル (システム設定・KVS形式)
-       ├─ key (PRIMARY KEY)
-       └─ value
+  ├─ settingsテーブル (システム設定・KVS形式)
+  │    ├─ key (PRIMARY KEY)
+  │    └─ value
+
+  └─ backup_logテーブル (データベースバックアップ履歴 - v0.8.0で追加)
+       ├─ id (PRIMARY KEY, AUTOINCREMENT)
+       ├─ started_at (UNIX秒)
+       ├─ completed_at (UNIX秒、NULL=進行中)
+       ├─ pc_name
+       ├─ file_path
+       ├─ file_size_bytes
+       ├─ status ('in_progress' | 'success' | 'failed')
+       ├─ error_message
+       └─ trigger_type ('manual' | 'auto')
 ```
 
 ### 7.3 SQLiteデータベース設計
@@ -1645,6 +1692,33 @@ SQLiteデータベースのテーブル設計：
   | favorite_game_id | TEXT | FOREIGN KEY | お気に入りゲームID（games.game_idを参照、ON DELETE SET NULL） |
   | comment | TEXT | | コメント |
   | created_at | TEXT | DEFAULT CURRENT_TIMESTAMP | 回答日時 |
+
+#### テーブル11: backup_log
+
+- **テーブル名**: `backup_log`
+- **説明**: データベースバックアップの実行履歴を格納するテーブル（Manager v0.8.0 / DB スキーマ v9 で追加）
+- **カラム**:
+
+  | カラム名 | データ型 | 制約 | 説明 |
+  | --- | --- | --- | --- |
+  | id | INTEGER | PRIMARY KEY AUTOINCREMENT | 履歴ID |
+  | started_at | INTEGER | NOT NULL | 開始時刻（UNIX秒） |
+  | completed_at | INTEGER | | 完了時刻（UNIX秒、NULL=進行中） |
+  | pc_name | TEXT | NOT NULL | 実行PC名（`Environment.MachineName`） |
+  | file_path | TEXT | | バックアップファイルのフルパス（成功時のみ） |
+  | file_size_bytes | INTEGER | | バックアップファイルサイズ（成功時のみ） |
+  | status | TEXT | NOT NULL CHECK ('in_progress', 'success', 'failed') | 実行状態 |
+  | error_message | TEXT | | エラーメッセージ（失敗時のみ） |
+  | trigger_type | TEXT | NOT NULL CHECK ('manual', 'auto') | 実行トリガ種別 |
+
+  **関連 settings キー**（同テーブル内に保存）:
+
+  | キー | デフォルト | 説明 |
+  | --- | --- | --- |
+  | `last_backup_at` | 0 | 最終バックアップ完了時刻（UNIX秒）。マルチPC実行時の lease で使用 |
+  | `backup_destination_path` | （空文字列） | バックアップ保存先フォルダ。空ならデフォルト（`<DBフォルダ>/backups/`） |
+  | `backup_auto_interval_hours` | 24 | 自動バックアップの間隔（時間） |
+  | `backup_retention_count` | 30 | 保持する世代数（これを超えた古いバックアップは自動削除） |
 
 ### 7.4 リレーション
 
@@ -2128,15 +2202,18 @@ GCTonePrism/
   - ゲーム削除機能
   - データ閲覧・エクスポート機能（CSV、JSON形式）
   - 設定管理機能（カラーテーマ設定、フィルター条件管理など）
+  - **データベースバックアップ・復元機能**（Manager v0.8.0 で先行実装、機能12参照）
   - 管理ソフトUIの改善・完成
 - **達成条件**:
   - 管理ソフトからゲームの編集・削除が可能
   - プレイ記録やアンケート結果の閲覧・エクスポートが可能
   - 設定の変更がランチャーに反映される
+  - バックアップ・復元が手動・自動の両方で動作する
 - **技術的達成項目**:
   - データ編集機能の実装
   - データエクスポート機能の実装
   - 設定管理機能の実装
+  - データベースバックアップ機能の実装（SQLite Online Backup API）
 
 #### マイルストーン13: 完全版リリース
 
@@ -2248,6 +2325,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-07 | 1.8.0 | データベースバックアップ・復元機能（機能12）の仕様追加：2.2 管理機能に手動／自動バックアップ・履歴一覧・リストアの仕様を新設、7.3 SQLite データベース設計にテーブル11 `backup_log` を追加（status / trigger_type / pc_name / file_path 等）、`settings` キー4項目を明記（last_backup_at, backup_destination_path, backup_auto_interval_hours, backup_retention_count）、DB スキーマを v8 → v9 に更新、マイルストーン12 主要機能リストにバックアップ機能を追記。Manager v0.8.0 で先行実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-01 | 1.7.0 | Tools（補助ユーティリティ群）の仕様追加：2.4 セクション新設、`GCTonePrism_Tools/` 配置・C# / .NET Framework 4.8 採用・統合 .sln 構成、Launcher との通信規約（OS.execute / stdout JSON）、Tool 1: WindowProbe（ゲームウィンドウ可視化検知）と Tool 2: PauseOverlay（中断メニュー、将来）の仕様、独立 .exe vs サブコマンド方式の検討事項を記載 | Kenshiro Kuroga & Claude |
 | 2026-03-30 | 1.6.1 | Material Design 3関連の記述を削除：デザインシステムをMD3ベースからダークテーマベースのカスタムデザインに変更、デザインガイドラインからMD3固有の記述（タイポグラフィ・アイコン・コンポーネントのMD3準拠言及）を削除、参考資料からMD3セクションを削除、マイルストーン7のMD3言及を削除 | Kenshiro Kuroga & Claude |
 | 2026-03-28 | 1.6.0 | サービスモード機能（機能23）の仕様追加：診断・テスト7項目、ログ・情報3項目、設定・操作6項目、自動復帰タイマー。ログ基盤仕様（統一ログシステム、ファイル出力、メモリバッファ）追加。機能22を終了制御機能に変更（Alt+F4/×ボタン封印）。画面12（サービスモード画面）追加。マイルストーン10にサービスモード・ログ基盤を追加 | Kenshiro Kuroga & Claude |


### PR DESCRIPTION
## Summary
- prism.db のスナップショット取得・復元機能を Manager に追加 (#96 完了)
- DB スキーマを v8 → v10 へ更新（backup_log テーブル + settings KVS マイグレーション + trigger_type に 'safety' 追加）
- マルチPC 環境向けの lease 方式（BEGIN IMMEDIATE トランザクション）で重複バックアップを防止
- 退避ファイルの自動管理（10 世代まで保持、`backups/safety/` サブフォルダへ自動移動）
- 並行して #99 の進捗バー対応（バックアップ・リストア・ゲーム削除・DB初期化）

詳細は [4116e94](https://github.com/ken1208git/GCTonePrism/commit/4116e94) のコミットメッセージおよび SPECIFICATION.md §2.2 / §7.3 を参照。

## Test plan
- [ ] Manager v0.8.0 起動 → バックアップタブが表示される
- [ ] 「今すぐバックアップ」ボタンで手動バックアップが取得できる
- [ ] 自動バックアップが起動時に走る（前回から24h以上経過時）
- [ ] バックアップ履歴一覧が表示される（成功/失敗/退避が色分け）
- [ ] リストア機能が動作する（確認コード入力 → safety 自動退避 → 上書き → 接続再初期化）
- [ ] BackupSettingsForm で保存先・間隔・世代数が変更できる
- [ ] Launcher 起動中に Manager からバックアップ可能（Online Backup API）
- [ ] マルチPC 環境で同時バックアップが lease で防止される

Closes #96
Related: #99, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)