### PR TITLE
fix(manager): スキーマ drift 修正と起動時 drift 検出機構 (v0.8.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@
 - 新機能を追加する前に、既存ファイルに足すのではなく新しいファイルを作るべきか必ず検討すること。
 - 既存ファイルに関数を追加する際、そのファイルの既存の責務と一致しない場合は別ファイルにすること。
 
+## Database Schema Management
+- **スキーマ変更には必ずマイグレーションを書く**: `GCTonePrism_Manager/SchemaManager.cs` の `CreateTables()` 内のスキーマ定義を変更したら、対応する `MigrateVxToVy` 関数を追加し、`CurrentDbVersion` をインクリメントすること。
+- **`CREATE TABLE IF NOT EXISTS` は新規 DB 用**: 既存テーブルが存在する場合は何もしないため、スキーマ変更には ALTER TABLE / DROP+CREATE+データ移行 を伴う明示的なマイグレーションが必要。
+- **マイグレーション実装後は `tools/sqlite3/sqlite3.exe` で検証**: 変更前後で `PRAGMA table_info(<tableName>);` を実行し、想定通りのスキーマになっているか確認すること。Manager 起動時の `VerifySchema()` でも自動チェックされるが、手動検証も併用する。
+- **過去事例**: SPEC v1.5.1 (2026-03-28) で `surveys` / `play_records` のスキーマを変更したが、マイグレーション未実装のため drift が温存されていた（Manager v0.8.1 の `MigrateV10ToV11` で修正）。
+
 ## Branch Strategy
 - 原則 main ブランチのまま実装せず、大まかな機能単位でブランチを分けること。
 - ブランチ名は `feature/〇〇`（新機能）、`fix/〇〇`（修正）の形式を使うこと。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 - **スキーマ変更には必ずマイグレーションを書く**: `GCTonePrism_Manager/SchemaManager.cs` の `CreateTables()` 内のスキーマ定義を変更したら、対応する `MigrateVxToVy` 関数を追加し、`CurrentDbVersion` をインクリメントすること。
 - **`CREATE TABLE IF NOT EXISTS` は新規 DB 用**: 既存テーブルが存在する場合は何もしないため、スキーマ変更には ALTER TABLE / DROP+CREATE+データ移行 を伴う明示的なマイグレーションが必要。
 - **マイグレーション実装後は `tools/sqlite3/sqlite3.exe` で検証**: 変更前後で `PRAGMA table_info(<tableName>);` を実行し、想定通りのスキーマになっているか確認すること。Manager 起動時の `VerifySchema()` でも自動チェックされるが、手動検証も併用する。
+- **`ExpectedSchema` 辞書 ↔ SPEC §7.3 の同期**: `SchemaManager.cs` 末尾の `ExpectedSchema` 辞書を更新したら、`SPECIFICATION.md` §7.3 のテーブル定義表（およびできれば §7.2 階層図 / §7.4 ER 図）も同時に更新すること。VerifySchema は ExpectedSchema との比較のみで SPEC は読まないため、SPEC 側の drift は人間が見つける必要がある。
 - **過去事例**: SPEC v1.5.1 (2026-03-28) で `surveys` / `play_records` のスキーマを変更したが、マイグレーション未実装のため drift が温存されていた（Manager v0.8.1 の `MigrateV10ToV11` で修正）。
 
 ## Branch Strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,29 @@
 
 ## Manager（管理ソフト）
 
+### [Manager v0.8.1] - 2026-05-10
+
+#### Fixed
+
+- **surveys / play_records スキーマ drift を修正 (`MigrateV10ToV11`)**: SPEC v1.5.1 (2026-03-28) で `surveys`（JSON 形式 → ★評価+コメント）、`play_records`（累計方式 → イベントログ方式）に変更されたが、対応するマイグレーションが書かれていなかったため、`CREATE TABLE IF NOT EXISTS` の仕様により旧スキーマのテーブルが温存されていた。本マイグレーションで修正
+  - 旧スキーマ判定: `surveys` は `submitted_at` 列、`play_records` は `play_count` 列の存在で検出
+  - 行数 0 の場合のみ DROP & CREATE で新スキーマへ置換（データ保護）
+  - 行数あり時は警告ログのみで自動マイグレーションをスキップ（手動対応に委ねる）
+- **`games.version` 列を `CreateTables()` に追加**: 既存 DB では `MigrateGamesTable` の ALTER TABLE で後付けされていたが、`CreateTables()` 側に定義が無く、新規 DB と既存 DB でスキーマ定義が分散していた。`VerifySchema` 初回起動で検出し、本 PR 内で修正（`MigrateGamesTable` の ALTER は古い DB 向けのフォールバックとして残す）
+
+#### Added
+
+- **`VerifySchema()` 起動時スキーマ整合性検証**: `InitializeDatabase` 末尾に組み込み、全 11 テーブルの列名一覧と `ExpectedSchema` 定義を `PRAGMA table_info` 経由で比較。不一致があれば警告ログを出す（drift があってもアプリ動作はそのまま継続）
+- **`MigrateV10ToV11` マイグレーション**: 上記 surveys / play_records drift 修正を担当
+- **マイグレーション機構の helper メソッド**: `CreateSurveysTable` / `CreatePlayRecordsTable`（`CreateTables` と migration の両方から呼ぶ）、`TableHasColumn`、`GetTableRowCount` を追加
+- **`AGENTS.md` に "Database Schema Management" セクションを追加**: スキーマ変更時に必ず対応するマイグレーションを書くこと、`tools/sqlite3/sqlite3.exe` で前後検証することを明文化
+
+#### Technical
+
+- `CurrentDbVersion`: `10` → `11`
+- `CreateTables()` の `surveys` / `play_records` 作成を helper メソッド化（マイグレーションでも再利用するため）
+- `ExpectedSchema` 静的辞書で全テーブルの期待列リストを定義（スキーマ変更時はここも同時更新する規約）
+
 ### [Manager v0.8.0] - 2026-05-07
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,7 +417,7 @@
 - **surveys / play_records スキーマ drift を修正 (`MigrateV10ToV11`)**: SPEC v1.5.1 (2026-03-28) で `surveys`（JSON 形式 → ★評価+コメント）、`play_records`（累計方式 → イベントログ方式）に変更されたが、対応するマイグレーションが書かれていなかったため、`CREATE TABLE IF NOT EXISTS` の仕様により旧スキーマのテーブルが温存されていた。本マイグレーションで修正
   - 旧スキーマ判定: `surveys` は `submitted_at` 列、`play_records` は `play_count` 列の存在で検出
   - 行数 0 の場合のみ DROP & CREATE で新スキーマへ置換（データ保護）
-  - 行数あり時は警告ログのみで自動マイグレーションをスキップ（手動対応に委ねる）
+  - 行数あり時は例外を投げて migration 全体を rollback し `user_version` を 10 のまま保持（Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" 対応）。これにより次回起動でも migration が再試行され、データを失わないまま手動対応を促せる
 - **`games.version` 列を `CreateTables()` に追加**: 既存 DB では `MigrateGamesTable` の ALTER TABLE で後付けされていたが、`CreateTables()` 側に定義が無く、新規 DB と既存 DB でスキーマ定義が分散していた。`VerifySchema` 初回起動で検出し、本 PR 内で修正（`MigrateGamesTable` の ALTER は古い DB 向けのフォールバックとして残す）
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,7 +417,7 @@
 - **surveys / play_records スキーマ drift を修正 (`MigrateV10ToV11`)**: SPEC v1.5.1 (2026-03-28) で `surveys`（JSON 形式 → ★評価+コメント）、`play_records`（累計方式 → イベントログ方式）に変更されたが、対応するマイグレーションが書かれていなかったため、`CREATE TABLE IF NOT EXISTS` の仕様により旧スキーマのテーブルが温存されていた。本マイグレーションで修正
   - 旧スキーマ判定: `surveys` は `submitted_at` 列、`play_records` は `play_count` 列の存在で検出
   - 行数 0 の場合のみ DROP & CREATE で新スキーマへ置換（データ保護）
-  - 行数あり時は例外を投げて migration 全体を rollback し `user_version` を 10 のまま保持（Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" 対応）。これにより次回起動でも migration が再試行され、データを失わないまま手動対応を促せる
+  - 行数あり時は警告ログを出して bool false を返し、`MigrateV10ToV11` が呼び出し側に伝播。`CheckAndMigrateDatabase` は成功した migration のみ `currentVersion` を bump し、`SetDbVersion` には実際に達成した `currentVersion` を書き込むため `user_version` は 10 のまま保持される。これにより次回起動でも migration が再試行されつつ、Manager 自体は正常起動する（Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" + "Avoid hard-failing startup on non-empty drift tables" の両方に対応）
 - **`games.version` 列を `CreateTables()` に追加**: 既存 DB では `MigrateGamesTable` の ALTER TABLE で後付けされていたが、`CreateTables()` 側に定義が無く、新規 DB と既存 DB でスキーマ定義が分散していた。`VerifySchema` 初回起動で検出し、本 PR 内で修正（`MigrateGamesTable` の ALTER は古い DB 向けのフォールバックとして残す）
 
 #### Added

--- a/GCTonePrism_Manager/Properties/AssemblyInfo.cs
+++ b/GCTonePrism_Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.8.0.0")]
-[assembly: AssemblyFileVersion("0.8.0.0")]
+[assembly: AssemblyVersion("0.8.1.0")]
+[assembly: AssemblyFileVersion("0.8.1.0")]

--- a/GCTonePrism_Manager/SchemaManager.cs
+++ b/GCTonePrism_Manager/SchemaManager.cs
@@ -1125,6 +1125,7 @@ namespace GCTonePrism.Manager
         /// <summary>
         /// surveys テーブルが旧 JSON 形式スキーマ（submitted_at / responses 列を持つ）の場合、
         /// 新スキーマ（rating / comment / created_at）へ修正する。
+        /// データが残存している場合は例外を投げる（Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" 対応）。
         /// </summary>
         private void FixSurveysSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
         {
@@ -1142,8 +1143,16 @@ namespace GCTonePrism.Manager
 
             if (rowCount > 0)
             {
-                Console.WriteLine($"[DatabaseManager] WARNING: surveys に {rowCount} 行のデータが存在するため自動マイグレーションをスキップします。手動対応してください。");
-                return;
+                // データを失わずに旧 JSON 形式 → 新 ★評価+コメント形式 へ自動変換するロジックは
+                // 未実装（旧 responses JSON のスキーマが不定でリスクが高いため）。
+                // 例外を投げてマイグレーション全体を rollback し、user_version を 10 のまま保持する。
+                // これにより次回起動時にも migration が再試行される。
+                // ユーザーは tools/sqlite3/sqlite3.exe で旧データを確認・退避してから手動移行すること。
+                throw new InvalidOperationException(
+                    $"surveys テーブルに旧スキーマ（{rowCount} 行のデータ）が残存しています。" +
+                    "データ損失防止のため自動マイグレーションを中止しました。" +
+                    "tools/sqlite3/sqlite3.exe で旧データを確認・退避してから手動で新スキーマへ移行してください。" +
+                    "user_version は 10 のまま保持されるため、対応後の再起動でマイグレーションが再試行されます。");
             }
 
             using (var cmd = new SQLiteCommand("DROP TABLE surveys", connection, transaction))
@@ -1157,6 +1166,7 @@ namespace GCTonePrism.Manager
         /// <summary>
         /// play_records テーブルが旧累計方式スキーマ（play_count / total_play_time 列を持つ）の場合、
         /// 新イベントログ方式スキーマ（start_time / end_time / play_duration / player_count）へ修正する。
+        /// データが残存している場合は例外を投げる（Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" 対応）。
         /// </summary>
         private void FixPlayRecordsSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
         {
@@ -1174,8 +1184,17 @@ namespace GCTonePrism.Manager
 
             if (rowCount > 0)
             {
-                Console.WriteLine($"[DatabaseManager] WARNING: play_records に {rowCount} 行のデータが存在するため自動マイグレーションをスキップします。手動対応してください。");
-                return;
+                // 旧累計方式（1ゲーム1行で play_count / total_play_time を累計）→
+                // 新イベントログ方式（1プレイ1行で start_time / end_time / play_duration）の
+                // 自動変換は元情報が失われているため不可能（累計値から個別プレイの時刻は復元できない）。
+                // 例外を投げてマイグレーション全体を rollback し、user_version を 10 のまま保持する。
+                // これにより次回起動時にも migration が再試行される。
+                // ユーザーは tools/sqlite3/sqlite3.exe で累計値を退避してから手動移行すること。
+                throw new InvalidOperationException(
+                    $"play_records テーブルに旧累計方式スキーマ（{rowCount} 行のデータ）が残存しています。" +
+                    "累計値から個別プレイ記録は復元できないため自動マイグレーションを中止しました。" +
+                    "tools/sqlite3/sqlite3.exe で累計値を退避してから手動で新スキーマへ移行してください。" +
+                    "user_version は 10 のまま保持されるため、対応後の再起動でマイグレーションが再試行されます。");
             }
 
             using (var cmd = new SQLiteCommand("DROP TABLE play_records", connection, transaction))

--- a/GCTonePrism_Manager/SchemaManager.cs
+++ b/GCTonePrism_Manager/SchemaManager.cs
@@ -650,11 +650,19 @@ namespace GCTonePrism.Manager
 
                     if (currentVersion < 11)
                     {
-                        MigrateV10ToV11(connection, migTransaction);
-                        currentVersion = 11;
+                        if (MigrateV10ToV11(connection, migTransaction))
+                        {
+                            currentVersion = 11;
+                        }
+                        // 失敗（データ残存でスキップ）時は currentVersion = 10 のまま。
+                        // SetDbVersion で実際に達成した currentVersion を書き込むため
+                        // user_version は 10 のまま保持され、次回起動時に再試行される。
                     }
 
-                    SetDbVersion(connection, CurrentDbVersion, migTransaction);
+                    // 達成バージョン（CurrentDbVersion ではなく currentVersion）を書き込む。
+                    // 全 migration が成功していれば currentVersion == CurrentDbVersion。
+                    // 部分的にスキップされた場合は、達成した最大バージョンが書き込まれる。
+                    SetDbVersion(connection, currentVersion, migTransaction);
 
                     if (localTransaction)
                     {
@@ -1109,25 +1117,38 @@ namespace GCTonePrism.Manager
         /// 仕様により旧スキーマのテーブルが温存されていた。本マイグレーションで修正。
         ///
         /// データがあるテーブルは破壊しないため、空テーブルのみ DROP & CREATE する。
-        /// データがある場合は警告ログのみ出して手動対応に委ねる（本プロジェクトの
-        /// 実環境では空テーブルのみ確認済み）。
+        /// データがある場合は警告ログを出して false を返し、`user_version` を 10 のまま
+        /// 保持することで次回起動時に再試行する（Manager 自体は正常起動を継続）。
         /// </summary>
-        private void MigrateV10ToV11(SQLiteConnection connection, SQLiteTransaction transaction)
+        /// <returns>全 drift fix が成功（または不要）なら true、データ残存でスキップしたら false</returns>
+        private bool MigrateV10ToV11(SQLiteConnection connection, SQLiteTransaction transaction)
         {
             Console.WriteLine("[DatabaseManager] Executing migration V10 -> V11 (Fix surveys/play_records schema drift from SPEC v1.5.1)");
 
-            FixSurveysSchemaDrift(connection, transaction);
-            FixPlayRecordsSchemaDrift(connection, transaction);
+            bool surveysOk = FixSurveysSchemaDrift(connection, transaction);
+            bool playRecordsOk = FixPlayRecordsSchemaDrift(connection, transaction);
 
-            Console.WriteLine("[DatabaseManager] Migration V10 -> V11 completed.");
+            bool allOk = surveysOk && playRecordsOk;
+            if (allOk)
+            {
+                Console.WriteLine("[DatabaseManager] Migration V10 -> V11 completed.");
+            }
+            else
+            {
+                Console.WriteLine("[DatabaseManager] WARNING: Migration V10 -> V11 partially skipped (data exists in legacy-schema tables). user_version stays at 10. Next startup will retry.");
+            }
+            return allOk;
         }
 
         /// <summary>
         /// surveys テーブルが旧 JSON 形式スキーマ（submitted_at / responses 列を持つ）の場合、
         /// 新スキーマ（rating / comment / created_at）へ修正する。
-        /// データが残存している場合は例外を投げる（Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" 対応）。
+        /// データが残存している場合は警告ログを出して false を返す（Manager 起動は継続）。
+        /// （Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" +
+        /// "Avoid hard-failing startup on non-empty drift tables" 対応）
         /// </summary>
-        private void FixSurveysSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
+        /// <returns>新スキーマ／drift fix 成功なら true、データ残存でスキップなら false</returns>
+        private bool FixSurveysSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
         {
             // 旧スキーマ判定: 'submitted_at' 列が存在するか
             bool isOldSchema = TableHasColumn(connection, transaction, "surveys", "submitted_at");
@@ -1135,7 +1156,7 @@ namespace GCTonePrism.Manager
             if (!isOldSchema)
             {
                 Console.WriteLine("[DatabaseManager] surveys は新スキーマです。マイグレーション不要。");
-                return;
+                return true;
             }
 
             long rowCount = GetTableRowCount(connection, transaction, "surveys");
@@ -1143,16 +1164,14 @@ namespace GCTonePrism.Manager
 
             if (rowCount > 0)
             {
-                // データを失わずに旧 JSON 形式 → 新 ★評価+コメント形式 へ自動変換するロジックは
-                // 未実装（旧 responses JSON のスキーマが不定でリスクが高いため）。
-                // 例外を投げてマイグレーション全体を rollback し、user_version を 10 のまま保持する。
-                // これにより次回起動時にも migration が再試行される。
-                // ユーザーは tools/sqlite3/sqlite3.exe で旧データを確認・退避してから手動移行すること。
-                throw new InvalidOperationException(
-                    $"surveys テーブルに旧スキーマ（{rowCount} 行のデータ）が残存しています。" +
-                    "データ損失防止のため自動マイグレーションを中止しました。" +
-                    "tools/sqlite3/sqlite3.exe で旧データを確認・退避してから手動で新スキーマへ移行してください。" +
-                    "user_version は 10 のまま保持されるため、対応後の再起動でマイグレーションが再試行されます。");
+                // 旧 JSON 形式 → 新 ★評価+コメント形式の自動変換は responses JSON のスキーマが
+                // 不定でリスクが高いため未実装。Manager 起動は継続させ、警告ログで手動対応を促す。
+                // 呼び出し側の MigrateV10ToV11 が false を伝播し、user_version は 10 のまま維持される。
+                // 次回起動時にこの migration が再試行されるため、手動でデータを退避すれば次回 fix される。
+                Console.WriteLine(
+                    $"[DatabaseManager] WARNING: surveys に {rowCount} 行のデータが残存。自動マイグレーションをスキップします。" +
+                    "tools/sqlite3/sqlite3.exe で旧データ（responses 列の JSON）を確認・退避してから手動で新スキーマへ移行してください。");
+                return false;
             }
 
             using (var cmd = new SQLiteCommand("DROP TABLE surveys", connection, transaction))
@@ -1161,14 +1180,18 @@ namespace GCTonePrism.Manager
             }
             CreateSurveysTable(connection, transaction);
             Console.WriteLine("[DatabaseManager] surveys を新スキーマで再作成しました。");
+            return true;
         }
 
         /// <summary>
         /// play_records テーブルが旧累計方式スキーマ（play_count / total_play_time 列を持つ）の場合、
         /// 新イベントログ方式スキーマ（start_time / end_time / play_duration / player_count）へ修正する。
-        /// データが残存している場合は例外を投げる（Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" 対応）。
+        /// データが残存している場合は警告ログを出して false を返す（Manager 起動は継続）。
+        /// （Codex P1 指摘 "Avoid marking DB v11 when drift migration is skipped" +
+        /// "Avoid hard-failing startup on non-empty drift tables" 対応）
         /// </summary>
-        private void FixPlayRecordsSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
+        /// <returns>新スキーマ／drift fix 成功なら true、データ残存でスキップなら false</returns>
+        private bool FixPlayRecordsSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
         {
             // 旧スキーマ判定: 'play_count' 列が存在するか
             bool isOldSchema = TableHasColumn(connection, transaction, "play_records", "play_count");
@@ -1176,7 +1199,7 @@ namespace GCTonePrism.Manager
             if (!isOldSchema)
             {
                 Console.WriteLine("[DatabaseManager] play_records は新スキーマです。マイグレーション不要。");
-                return;
+                return true;
             }
 
             long rowCount = GetTableRowCount(connection, transaction, "play_records");
@@ -1184,17 +1207,13 @@ namespace GCTonePrism.Manager
 
             if (rowCount > 0)
             {
-                // 旧累計方式（1ゲーム1行で play_count / total_play_time を累計）→
-                // 新イベントログ方式（1プレイ1行で start_time / end_time / play_duration）の
-                // 自動変換は元情報が失われているため不可能（累計値から個別プレイの時刻は復元できない）。
-                // 例外を投げてマイグレーション全体を rollback し、user_version を 10 のまま保持する。
-                // これにより次回起動時にも migration が再試行される。
-                // ユーザーは tools/sqlite3/sqlite3.exe で累計値を退避してから手動移行すること。
-                throw new InvalidOperationException(
-                    $"play_records テーブルに旧累計方式スキーマ（{rowCount} 行のデータ）が残存しています。" +
-                    "累計値から個別プレイ記録は復元できないため自動マイグレーションを中止しました。" +
-                    "tools/sqlite3/sqlite3.exe で累計値を退避してから手動で新スキーマへ移行してください。" +
-                    "user_version は 10 のまま保持されるため、対応後の再起動でマイグレーションが再試行されます。");
+                // 旧累計方式 → 新イベントログ方式の自動変換は元情報が失われているため不可能。
+                // Manager 起動は継続させ、警告ログで手動対応を促す。
+                // 呼び出し側の MigrateV10ToV11 が false を伝播し、user_version は 10 のまま維持される。
+                Console.WriteLine(
+                    $"[DatabaseManager] WARNING: play_records に {rowCount} 行のデータが残存。自動マイグレーションをスキップします。" +
+                    "tools/sqlite3/sqlite3.exe で累計値（play_count / total_play_time）を退避してから手動で新スキーマへ移行してください。");
+                return false;
             }
 
             using (var cmd = new SQLiteCommand("DROP TABLE play_records", connection, transaction))
@@ -1203,6 +1222,7 @@ namespace GCTonePrism.Manager
             }
             CreatePlayRecordsTable(connection, transaction);
             Console.WriteLine("[DatabaseManager] play_records を新スキーマで再作成しました。");
+            return true;
         }
 
         /// <summary>

--- a/GCTonePrism_Manager/SchemaManager.cs
+++ b/GCTonePrism_Manager/SchemaManager.cs
@@ -16,7 +16,8 @@ namespace GCTonePrism.Manager
 
         // 現在のデータベースバージョン
         // 構造変更があるたびにインクリメントする
-        private const int CurrentDbVersion = 10;
+        // v11: SPEC v1.5.1 (2026-03-28) で変更された surveys / play_records スキーマの drift 修正（v0.8.1）
+        private const int CurrentDbVersion = 11;
 
         public SchemaManager(DatabaseConnection conn)
         {
@@ -81,6 +82,11 @@ namespace GCTonePrism.Manager
                             MigrateGameVersionsTable(connection, transaction);
                             CheckAndMigrateDatabase(connection, transaction);
 
+                            // 全マイグレーション完了後にスキーマ整合性を検証する。
+                            // drift があった場合でも例外は投げず警告ログのみ。
+                            // （AGENTS.md "Database Schema Management" 参照）
+                            VerifySchema(connection, transaction);
+
                             transaction.Commit();
                         }
                         catch (Exception)
@@ -135,7 +141,8 @@ namespace GCTonePrism.Manager
                     is_visible INTEGER DEFAULT 1,
                     controls TEXT,
                     key_mapping TEXT,
-                    arguments TEXT
+                    arguments TEXT,
+                    version TEXT
                 )";
 
             using (var command = new SQLiteCommand(createGamesTable, connection, transaction))
@@ -235,38 +242,11 @@ namespace GCTonePrism.Manager
                 command.ExecuteNonQuery();
             }
 
-            // play_recordsテーブル作成
-            string createPlayRecordsTable = @"
-                CREATE TABLE IF NOT EXISTS play_records (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    game_id TEXT,
-                    start_time TEXT,
-                    end_time TEXT,
-                    play_duration INTEGER,
-                    player_count INTEGER,
-                    FOREIGN KEY(game_id) REFERENCES games(game_id) ON DELETE CASCADE
-                )";
+            // play_recordsテーブル作成（MigrateV10ToV11 でも再利用するため helper メソッド化）
+            CreatePlayRecordsTable(connection, transaction);
 
-            using (var command = new SQLiteCommand(createPlayRecordsTable, connection, transaction))
-            {
-                command.ExecuteNonQuery();
-            }
-
-            // surveysテーブル作成
-            string createSurveysTable = @"
-                CREATE TABLE IF NOT EXISTS surveys (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    game_id TEXT,
-                    rating INTEGER CHECK(rating BETWEEN 1 AND 5),
-                    comment TEXT,
-                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                    FOREIGN KEY(game_id) REFERENCES games(game_id) ON DELETE CASCADE
-                )";
-
-            using (var command = new SQLiteCommand(createSurveysTable, connection, transaction))
-            {
-                command.ExecuteNonQuery();
-            }
+            // surveysテーブル作成（MigrateV10ToV11 でも再利用するため helper メソッド化）
+            CreateSurveysTable(connection, transaction);
 
             // launcher_surveysテーブル作成
             string createLauncherSurveysTable = @"
@@ -666,6 +646,12 @@ namespace GCTonePrism.Manager
                     {
                         MigrateV9ToV10(connection, migTransaction);
                         currentVersion = 10;
+                    }
+
+                    if (currentVersion < 11)
+                    {
+                        MigrateV10ToV11(connection, migTransaction);
+                        currentVersion = 11;
                     }
 
                     SetDbVersion(connection, CurrentDbVersion, migTransaction);
@@ -1115,6 +1101,159 @@ namespace GCTonePrism.Manager
             Console.WriteLine("[DatabaseManager] Migration V9 -> V10 completed.");
         }
 
+        /// <summary>
+        /// V10 -> V11: surveys / play_records スキーマ drift 修正
+        /// SPEC v1.5.1 (2026-03-28) で surveys（JSON 形式 → ★評価+コメント）、
+        /// play_records（累計方式 → イベントログ方式）に変更されたが、対応する
+        /// マイグレーションが書かれていなかったため、CREATE TABLE IF NOT EXISTS の
+        /// 仕様により旧スキーマのテーブルが温存されていた。本マイグレーションで修正。
+        ///
+        /// データがあるテーブルは破壊しないため、空テーブルのみ DROP & CREATE する。
+        /// データがある場合は警告ログのみ出して手動対応に委ねる（本プロジェクトの
+        /// 実環境では空テーブルのみ確認済み）。
+        /// </summary>
+        private void MigrateV10ToV11(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            Console.WriteLine("[DatabaseManager] Executing migration V10 -> V11 (Fix surveys/play_records schema drift from SPEC v1.5.1)");
+
+            FixSurveysSchemaDrift(connection, transaction);
+            FixPlayRecordsSchemaDrift(connection, transaction);
+
+            Console.WriteLine("[DatabaseManager] Migration V10 -> V11 completed.");
+        }
+
+        /// <summary>
+        /// surveys テーブルが旧 JSON 形式スキーマ（submitted_at / responses 列を持つ）の場合、
+        /// 新スキーマ（rating / comment / created_at）へ修正する。
+        /// </summary>
+        private void FixSurveysSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // 旧スキーマ判定: 'submitted_at' 列が存在するか
+            bool isOldSchema = TableHasColumn(connection, transaction, "surveys", "submitted_at");
+
+            if (!isOldSchema)
+            {
+                Console.WriteLine("[DatabaseManager] surveys は新スキーマです。マイグレーション不要。");
+                return;
+            }
+
+            long rowCount = GetTableRowCount(connection, transaction, "surveys");
+            Console.WriteLine($"[DatabaseManager] surveys に旧スキーマを検出 (行数: {rowCount})");
+
+            if (rowCount > 0)
+            {
+                Console.WriteLine($"[DatabaseManager] WARNING: surveys に {rowCount} 行のデータが存在するため自動マイグレーションをスキップします。手動対応してください。");
+                return;
+            }
+
+            using (var cmd = new SQLiteCommand("DROP TABLE surveys", connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+            CreateSurveysTable(connection, transaction);
+            Console.WriteLine("[DatabaseManager] surveys を新スキーマで再作成しました。");
+        }
+
+        /// <summary>
+        /// play_records テーブルが旧累計方式スキーマ（play_count / total_play_time 列を持つ）の場合、
+        /// 新イベントログ方式スキーマ（start_time / end_time / play_duration / player_count）へ修正する。
+        /// </summary>
+        private void FixPlayRecordsSchemaDrift(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // 旧スキーマ判定: 'play_count' 列が存在するか
+            bool isOldSchema = TableHasColumn(connection, transaction, "play_records", "play_count");
+
+            if (!isOldSchema)
+            {
+                Console.WriteLine("[DatabaseManager] play_records は新スキーマです。マイグレーション不要。");
+                return;
+            }
+
+            long rowCount = GetTableRowCount(connection, transaction, "play_records");
+            Console.WriteLine($"[DatabaseManager] play_records に旧スキーマを検出 (行数: {rowCount})");
+
+            if (rowCount > 0)
+            {
+                Console.WriteLine($"[DatabaseManager] WARNING: play_records に {rowCount} 行のデータが存在するため自動マイグレーションをスキップします。手動対応してください。");
+                return;
+            }
+
+            using (var cmd = new SQLiteCommand("DROP TABLE play_records", connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+            CreatePlayRecordsTable(connection, transaction);
+            Console.WriteLine("[DatabaseManager] play_records を新スキーマで再作成しました。");
+        }
+
+        /// <summary>
+        /// surveys テーブル作成（CreateTables / MigrateV10ToV11 共通）
+        /// </summary>
+        private static void CreateSurveysTable(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            string sql = @"
+                CREATE TABLE IF NOT EXISTS surveys (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    game_id TEXT,
+                    rating INTEGER CHECK(rating BETWEEN 1 AND 5),
+                    comment TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(game_id) REFERENCES games(game_id) ON DELETE CASCADE
+                )";
+            using (var cmd = new SQLiteCommand(sql, connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// play_records テーブル作成（CreateTables / MigrateV10ToV11 共通）
+        /// </summary>
+        private static void CreatePlayRecordsTable(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            string sql = @"
+                CREATE TABLE IF NOT EXISTS play_records (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    game_id TEXT,
+                    start_time TEXT,
+                    end_time TEXT,
+                    play_duration INTEGER,
+                    player_count INTEGER,
+                    FOREIGN KEY(game_id) REFERENCES games(game_id) ON DELETE CASCADE
+                )";
+            using (var cmd = new SQLiteCommand(sql, connection, transaction))
+            {
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// 指定テーブルに指定列が存在するかチェック（PRAGMA table_info 経由）
+        /// </summary>
+        private static bool TableHasColumn(SQLiteConnection connection, SQLiteTransaction transaction, string tableName, string columnName)
+        {
+            using (var cmd = new SQLiteCommand($"PRAGMA table_info({tableName})", connection, transaction))
+            using (var reader = cmd.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    if (reader["name"].ToString() == columnName) return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// 指定テーブルの行数を取得（COUNT(*)）
+        /// </summary>
+        private static long GetTableRowCount(SQLiteConnection connection, SQLiteTransaction transaction, string tableName)
+        {
+            using (var cmd = new SQLiteCommand($"SELECT COUNT(*) FROM {tableName}", connection, transaction))
+            {
+                return Convert.ToInt64(cmd.ExecuteScalar());
+            }
+        }
+
         private void CopyDevelopersToVersion(SQLiteConnection connection, SQLiteTransaction transaction, string gameId, int versionId)
         {
             string insertSql = @"
@@ -1129,6 +1268,104 @@ namespace GCTonePrism.Manager
                 command.Parameters.AddWithValue("@versionId", versionId);
                 command.ExecuteNonQuery();
             }
+        }
+
+        /// <summary>
+        /// 各テーブルが持つべき列名一覧（VerifySchema で使用）。
+        /// SchemaManager.CreateTables() および各 MigrateVxToVy で作る最終形と一致させること。
+        /// スキーマ変更時はこの定義も同時に更新する（AGENTS.md "Database Schema Management" 参照）。
+        /// </summary>
+        private static readonly Dictionary<string, string[]> ExpectedSchema = new Dictionary<string, string[]>
+        {
+            { "games", new[] { "game_id", "title", "description", "release_year", "genre", "min_players", "max_players", "difficulty", "play_time", "controller_support", "supported_connection", "thumbnail_path", "background_path", "executable_path", "display_order", "is_visible", "controls", "key_mapping", "arguments", "version" } },
+            { "game_versions", new[] { "id", "game_id", "version", "executable_path", "arguments", "description", "title", "genre", "min_players", "max_players", "difficulty", "play_time", "controller_support", "supported_connection", "thumbnail_path", "background_path", "update_note", "registered_at" } },
+            { "developers", new[] { "id", "game_id", "last_name", "first_name", "grade", "version_id" } },
+            { "game_genres", new[] { "id", "game_id", "genre" } },
+            { "play_records", new[] { "id", "game_id", "start_time", "end_time", "play_duration", "player_count" } },
+            { "surveys", new[] { "id", "game_id", "rating", "comment", "created_at" } },
+            { "launcher_surveys", new[] { "id", "rating", "favorite_game_id", "comment", "created_at" } },
+            { "settings", new[] { "key", "value" } },
+            { "store_sections", new[] { "section_id", "title", "section_type", "section_source", "display_order", "max_display_count", "is_visible" } },
+            { "store_section_games", new[] { "id", "section_id", "game_id", "display_order", "display_text" } },
+            { "backup_log", new[] { "id", "started_at", "completed_at", "pc_name", "file_path", "file_size_bytes", "status", "error_message", "trigger_type" } },
+        };
+
+        /// <summary>
+        /// 全テーブルのスキーマが ExpectedSchema と一致するか検証し、不一致があればログ出力する。
+        /// CreateTables() / マイグレーション完了後に呼び出すことを想定（InitializeDatabase 末尾）。
+        /// drift があった場合でも例外は投げず、警告ログのみ。アプリ動作はそのまま継続する。
+        /// </summary>
+        /// <returns>すべてのテーブルが期待通り = true、1 つでも drift があれば false</returns>
+        private bool VerifySchema(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            int driftCount = 0;
+            foreach (var pair in ExpectedSchema)
+            {
+                if (!VerifyTableColumns(connection, transaction, pair.Key, pair.Value))
+                {
+                    driftCount++;
+                }
+            }
+
+            if (driftCount > 0)
+            {
+                Console.WriteLine($"[VerifySchema] {driftCount} 個のテーブルでスキーマ drift を検出しました。AGENTS.md の Database Schema Management セクションを参照して対応してください。");
+                return false;
+            }
+
+            Console.WriteLine($"[VerifySchema] 全 {ExpectedSchema.Count} テーブルのスキーマ整合性 OK");
+            return true;
+        }
+
+        /// <summary>
+        /// 指定テーブルの列名一覧が期待値と一致するか検証する。
+        /// 不足列・余分列があればログ出力する。
+        /// </summary>
+        private static bool VerifyTableColumns(SQLiteConnection connection, SQLiteTransaction transaction, string tableName, string[] expectedColumns)
+        {
+            var actualColumns = new HashSet<string>();
+            using (var cmd = new SQLiteCommand($"PRAGMA table_info({tableName})", connection, transaction))
+            using (var reader = cmd.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    actualColumns.Add(reader["name"].ToString());
+                }
+            }
+
+            if (actualColumns.Count == 0)
+            {
+                Console.WriteLine($"[VerifySchema] WARNING: テーブル '{tableName}' が存在しません。");
+                return false;
+            }
+
+            var expectedSet = new HashSet<string>(expectedColumns);
+            var missing = new List<string>();
+            foreach (var col in expectedColumns)
+            {
+                if (!actualColumns.Contains(col)) missing.Add(col);
+            }
+            var extra = new List<string>();
+            foreach (var col in actualColumns)
+            {
+                if (!expectedSet.Contains(col)) extra.Add(col);
+            }
+
+            if (missing.Count == 0 && extra.Count == 0)
+            {
+                return true;
+            }
+
+            Console.WriteLine($"[VerifySchema] WARNING: テーブル '{tableName}' のスキーマが期待値と一致しません");
+            if (missing.Count > 0)
+            {
+                Console.WriteLine($"  期待されるが存在しない列: {string.Join(", ", missing)}");
+            }
+            if (extra.Count > 0)
+            {
+                Console.WriteLine($"  期待されない余分な列: {string.Join(", ", extra)}");
+            }
+            return false;
         }
     }
 }

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1552,7 +1552,9 @@ prism.db (SQLiteデータベースファイル)
        ├─ display_order
        ├─ is_visible
        ├─ controls (JSON形式)
-       └─ key_mapping (JSON形式)
+       ├─ key_mapping (JSON形式)
+       ├─ arguments
+       └─ version
 
   ├─ developersテーブル (製作者情報)
   │    ├─ id (PRIMARY KEY, AUTOINCREMENT)
@@ -1631,6 +1633,8 @@ SQLiteデータベースのテーブル設計：
   | is_visible | INTEGER | DEFAULT 1 | 表示/非表示（0=false=非表示、1=true=表示） |
   | controls | TEXT | | 操作説明（JSON形式） |
   | key_mapping | TEXT | | キーマッピング設定（JSON形式、NULL可） |
+  | arguments | TEXT | | ゲーム実行ファイルへの起動引数（任意） |
+  | version | TEXT | | 現行バージョン文字列（`game_versions.version` を参照する代表値、NULL 可） |
 
 #### テーブル2: developers
 
@@ -1773,7 +1777,7 @@ SQLiteデータベースのテーブル設計：
 #### テーブル11: backup_log
 
 - **テーブル名**: `backup_log`
-- **説明**: データベースバックアップの実行履歴を格納するテーブル（Manager v0.8.0 / DB スキーマ v9 で追加）
+- **説明**: データベースバックアップの実行履歴を格納するテーブル（Manager v0.8.0 / DB スキーマ v9 で追加。v10 で `trigger_type` の CHECK 制約に `'safety'` を追加）
 - **カラム**:
 
   | カラム名 | データ型 | 制約 | 説明 |
@@ -1837,6 +1841,7 @@ erDiagram
         TEXT controls
         TEXT key_mapping
         TEXT arguments
+        TEXT version
     }
     game_versions {
         INTEGER id PK
@@ -2452,6 +2457,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-10 | 1.9.1 | スキーマ drift 修正・検出機構を Manager v0.8.1 として実装した内容を SPEC に反映：7.3 テーブル1 games の定義に既存の `arguments` / `version` 列が抜けていたため追記（実 DB と SPEC の整合性回復）、7.3 階層図 / ER 図にも反映、テーブル11 backup_log の説明に v9 → v10（`trigger_type` への `'safety'` 追加）の経緯を補足。マイグレーション機構について、`SchemaManager.cs` の `CreateTables()` を変更したら必ず対応する `MigrateVxToVy` を書くべきこと、`tools/sqlite3/` を使ったマイグレーション前後検証を行うことを `AGENTS.md` に明文化（同 PR で追記）。CurrentDbVersion を v10 → v11 に更新し、SPEC v1.5.1 (2026-03-28) で変更されたが対応マイグレーション未実装だった `surveys` / `play_records` の drift を修正（空テーブルのみ DROP & CREATE 対応）。Manager 起動時の `VerifySchema()` で全テーブルのスキーマ整合性を自動検証する仕組みを追加。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.0 | アンケート・プレイ記録の保存方式を drop-folder 方式に変更し、運用補助ツールを同梱：6.4 データアクセスパターンに Launcher が SQLite を直接書き込まない方針を明記、6.5 データの整合性に「Launcher 書き込みの drop-folder 方式」サブセクションを新設（atomic write / 3-state folder 構成 pending・imported・failed / 2-phase 取り込み（取り込みフェーズ + バックアップフェーズ）/ トリガ別動作マトリクス / 重複 INSERT 防止のための source_uuid + INSERT OR IGNORE / 任意フィールドの NULL 扱い等）、7.3 SQLite データベース設計でテーブル4 surveys を「ゲーム個別+ランチャー全体」を `trigger` 列で統合する形にスキーマ刷新（source_uuid / trigger / source_pc / imported_at 追加、created_at を INTEGER UNIX秒に変更）、テーブル3 play_records も同方式採用＋ INTEGER 化（source_uuid / source_pc / imported_at 追加）、テーブル10 launcher_surveys を廃止予定として記載。7.5.3 として `responses/` フォルダの 3-state 構成を追記、7.5.4 として `tools/sqlite3/` 開発・運用補助ツール（sqlite3.exe 等の SQLite CLI）の同梱を追記（#109 closes）。機能10 アンケート機能・機能11 プレイ記録機能の記述を保存方式変更に合わせて更新。新規追加テーブルのタイムスタンプは INTEGER (UNIX秒) で統一する方針を明文化（既存テーブルは段階的移行）。スキーマ実装は #35 の実装時に v10 → v11 マイグレーションとして対応予定。 | Kenshiro Kuroga & Claude |
 | 2026-05-07 | 1.8.0 | データベースバックアップ・復元機能（機能12）の仕様追加：2.2 管理機能に手動／自動バックアップ・履歴一覧・リストアの仕様を新設、7.3 SQLite データベース設計にテーブル11 `backup_log` を追加（status / trigger_type / pc_name / file_path 等）、`settings` キー4項目を明記（last_backup_at, backup_destination_path, backup_auto_interval_hours, backup_retention_count）、DB スキーマを v8 → v9 に更新、マイルストーン12 主要機能リストにバックアップ機能を追記。Manager v0.8.0 で先行実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-01 | 1.7.0 | Tools（補助ユーティリティ群）の仕様追加：2.4 セクション新設、`GCTonePrism_Tools/` 配置・C# / .NET Framework 4.8 採用・統合 .sln 構成、Launcher との通信規約（OS.execute / stdout JSON）、Tool 1: WindowProbe（ゲームウィンドウ可視化検知）と Tool 2: PauseOverlay（中断メニュー、将来）の仕様、独立 .exe vs サブコマンド方式の検討事項を記載 | Kenshiro Kuroga & Claude |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1600,7 +1600,7 @@ prism.db (SQLiteデータベースファイル)
        ├─ file_size_bytes
        ├─ status ('in_progress' | 'success' | 'failed')
        ├─ error_message
-       └─ trigger_type ('manual' | 'auto')
+       └─ trigger_type ('manual' | 'auto' | 'safety')
 ```
 
 ### 7.3 SQLiteデータベース設計
@@ -1654,8 +1654,24 @@ SQLiteデータベースのテーブル設計：
 #### テーブル3: play_records
 
 - **テーブル名**: `play_records`
-- **説明**: プレイ記録を格納するテーブル（イベントログ方式：プレイごとに1行記録）。Launcher が JSON として `responses/` フォルダに出力 → Manager が取り込む（drop-folder 方式 / §6.5 参照）
-- **カラム**:
+- **説明**: プレイ記録を格納するテーブル（イベントログ方式：プレイごとに1行記録）
+
+##### 現行スキーマ（Manager v0.8.1 / DB v11 時点）
+
+`MigrateV10ToV11` で SPEC v1.5.1 (2026-03-28) 由来の旧累計方式 drift を修正済み。Launcher は現状 SELECT のみ（書き込みは未実装）。
+
+  | カラム名 | データ型 | 制約 | 説明 |
+  | --- | --- | --- | --- |
+  | id | INTEGER | PRIMARY KEY AUTOINCREMENT | レコードID |
+  | game_id | TEXT | FOREIGN KEY | ゲームID（games.game_idを参照、ON DELETE CASCADE） |
+  | start_time | TEXT | | プレイ開始日時（ISO8601 文字列） |
+  | end_time | TEXT | | プレイ終了日時（ISO8601 文字列） |
+  | play_duration | INTEGER | | プレイ時間（秒） |
+  | player_count | INTEGER | | プレイヤー数 |
+
+##### drop-folder 設計（#35 実装時に v11 → v12 で移行予定）
+
+Launcher が JSON として `responses/` フォルダに出力 → Manager が取り込む方式（§6.5 参照）。現行スキーマからの主な変更点: タイムスタンプを INTEGER (UNIX秒) に統一、`source_uuid` で重複 INSERT 防止、`source_pc` / `imported_at` で取り込みメタデータを保持。
 
   | カラム名 | データ型 | 制約 | 説明 |
   | --- | --- | --- | --- |
@@ -1672,8 +1688,23 @@ SQLiteデータベースのテーブル設計：
 #### テーブル4: surveys
 
 - **テーブル名**: `surveys`
-- **説明**: アンケート結果を格納するテーブル（★評価+コメント形式）。ゲーム個別アンケートとランチャー全体アンケートを `trigger` 列で区別する統合テーブル。Launcher が JSON として `responses/` フォルダに出力 → Manager が取り込む（drop-folder 方式 / §6.5 参照）
-- **カラム**:
+- **説明**: アンケート結果を格納するテーブル（★評価+コメント形式）
+
+##### 現行スキーマ（Manager v0.8.1 / DB v11 時点）
+
+`MigrateV10ToV11` で SPEC v1.5.1 (2026-03-28) 由来の旧 JSON 形式 drift を修正済み。ゲーム個別アンケート用のシンプルな構造。Launcher は書き込み未実装（現状ゼロ件）。
+
+  | カラム名 | データ型 | 制約 | 説明 |
+  | --- | --- | --- | --- |
+  | id | INTEGER | PRIMARY KEY AUTOINCREMENT | アンケートID |
+  | game_id | TEXT | FOREIGN KEY | ゲームID（games.game_idを参照、ON DELETE CASCADE） |
+  | rating | INTEGER | CHECK(rating BETWEEN 1 AND 5) | ★評価（1〜5段階） |
+  | comment | TEXT | | コメント |
+  | created_at | TEXT | DEFAULT CURRENT_TIMESTAMP | 回答日時 |
+
+##### drop-folder 設計（#35 実装時に v11 → v12 で移行予定）
+
+ゲーム個別アンケートとランチャー全体アンケートを `trigger` 列で区別する統合テーブルへ。Launcher が JSON として `responses/` フォルダに出力 → Manager が取り込む（§6.5 参照）。`launcher_surveys` テーブルはこの設計移行時に廃止される。
 
   | カラム名 | データ型 | 制約 | 説明 |
   | --- | --- | --- | --- |
@@ -1770,7 +1801,17 @@ SQLiteデータベースのテーブル設計：
 #### テーブル10: launcher_surveys（**廃止予定**）
 
 - **テーブル名**: `launcher_surveys`
-- **状態**: **#35 アンケート機能の実装と同時に廃止予定**
+- **状態**: **#35 アンケート機能の実装（drop-folder 設計移行）と同時に廃止予定**
+- **現行スキーマ（Manager v0.8.1 / DB v11 時点、廃止までの暫定）**:
+
+  | カラム名 | データ型 | 制約 | 説明 |
+  | --- | --- | --- | --- |
+  | id | INTEGER | PRIMARY KEY AUTOINCREMENT | アンケートID |
+  | rating | INTEGER | CHECK(rating BETWEEN 1 AND 5) | ★評価（1〜5段階） |
+  | favorite_game_id | TEXT | FOREIGN KEY | お気に入りゲームID（games.game_idを参照、ON DELETE SET NULL） |
+  | comment | TEXT | | コメント |
+  | created_at | TEXT | DEFAULT CURRENT_TIMESTAMP | 回答日時 |
+
 - **廃止理由**: ランチャー全体アンケートを `surveys` テーブルに統合し、`trigger` 列（`'launcher_end'`）で区別する設計に変更したため。「最も気に入ったゲーム」（旧 `favorite_game_id`）は、ゲーム個別アンケート（`trigger='game_end'`）の評価平均から算出可能なため不要と判断
 - **マイグレーション**: 既存データが存在する場合は、`surveys` テーブルへ移行（`trigger='launcher_end'`, `game_id=NULL`, `rating`/`comment`/`created_at` を移送、`favorite_game_id` は破棄）してからテーブルを DROP する
 
@@ -1790,7 +1831,7 @@ SQLiteデータベースのテーブル設計：
   | file_size_bytes | INTEGER | | バックアップファイルサイズ（成功時のみ） |
   | status | TEXT | NOT NULL CHECK ('in_progress', 'success', 'failed') | 実行状態 |
   | error_message | TEXT | | エラーメッセージ（失敗時のみ） |
-  | trigger_type | TEXT | NOT NULL CHECK ('manual', 'auto') | 実行トリガ種別 |
+  | trigger_type | TEXT | NOT NULL CHECK ('manual', 'auto', 'safety') | 実行トリガ種別（v10 で 'safety' を追加。リストア前の自動退避） |
 
   **関連 settings キー**（同テーブル内に保存）:
 
@@ -2457,6 +2498,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-10 | 1.9.2 | PR #113 のレビュー段階で実施したスキーマ整合性 audit の結果を SPEC に反映：7.3 テーブル3 play_records とテーブル4 surveys を「現行スキーマ（Manager v0.8.1 / DB v11 時点）」と「drop-folder 設計（#35 実装時に v11 → v12 で移行予定）」の併記形式に変更（現行は SchemaManager.cs の `CreateTables()` と一致する 5/6 列、将来形は v1.9.0 で記載した 9 列構成を保持）。VerifySchema が比較する `ExpectedSchema` は現行スキーマと同期、drop-folder 設計は #35 実装時に v11 → v12 マイグレーションとして反映する流れを明記。テーブル10 launcher_surveys に「廃止までの暫定」として現行 5 列カラム表を追記。テーブル11 backup_log の `trigger_type` CHECK 制約に v10 で追加された `'safety'` を反映（§7.3 表 / §7.2 階層図）。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.1 | スキーマ drift 修正・検出機構を Manager v0.8.1 として実装した内容を SPEC に反映：7.3 テーブル1 games の定義に既存の `arguments` / `version` 列が抜けていたため追記（実 DB と SPEC の整合性回復）、7.3 階層図 / ER 図にも反映、テーブル11 backup_log の説明に v9 → v10（`trigger_type` への `'safety'` 追加）の経緯を補足。マイグレーション機構について、`SchemaManager.cs` の `CreateTables()` を変更したら必ず対応する `MigrateVxToVy` を書くべきこと、`tools/sqlite3/` を使ったマイグレーション前後検証を行うことを `AGENTS.md` に明文化（同 PR で追記）。CurrentDbVersion を v10 → v11 に更新し、SPEC v1.5.1 (2026-03-28) で変更されたが対応マイグレーション未実装だった `surveys` / `play_records` の drift を修正（空テーブルのみ DROP & CREATE 対応）。Manager 起動時の `VerifySchema()` で全テーブルのスキーマ整合性を自動検証する仕組みを追加。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.0 | アンケート・プレイ記録の保存方式を drop-folder 方式に変更し、運用補助ツールを同梱：6.4 データアクセスパターンに Launcher が SQLite を直接書き込まない方針を明記、6.5 データの整合性に「Launcher 書き込みの drop-folder 方式」サブセクションを新設（atomic write / 3-state folder 構成 pending・imported・failed / 2-phase 取り込み（取り込みフェーズ + バックアップフェーズ）/ トリガ別動作マトリクス / 重複 INSERT 防止のための source_uuid + INSERT OR IGNORE / 任意フィールドの NULL 扱い等）、7.3 SQLite データベース設計でテーブル4 surveys を「ゲーム個別+ランチャー全体」を `trigger` 列で統合する形にスキーマ刷新（source_uuid / trigger / source_pc / imported_at 追加、created_at を INTEGER UNIX秒に変更）、テーブル3 play_records も同方式採用＋ INTEGER 化（source_uuid / source_pc / imported_at 追加）、テーブル10 launcher_surveys を廃止予定として記載。7.5.3 として `responses/` フォルダの 3-state 構成を追記、7.5.4 として `tools/sqlite3/` 開発・運用補助ツール（sqlite3.exe 等の SQLite CLI）の同梱を追記（#109 closes）。機能10 アンケート機能・機能11 プレイ記録機能の記述を保存方式変更に合わせて更新。新規追加テーブルのタイムスタンプは INTEGER (UNIX秒) で統一する方針を明文化（既存テーブルは段階的移行）。スキーマ実装は #35 の実装時に v10 → v11 マイグレーションとして対応予定。 | Kenshiro Kuroga & Claude |
 | 2026-05-07 | 1.8.0 | データベースバックアップ・復元機能（機能12）の仕様追加：2.2 管理機能に手動／自動バックアップ・履歴一覧・リストアの仕様を新設、7.3 SQLite データベース設計にテーブル11 `backup_log` を追加（status / trigger_type / pc_name / file_path 等）、`settings` キー4項目を明記（last_backup_at, backup_destination_path, backup_auto_interval_hours, backup_retention_count）、DB スキーマを v8 → v9 に更新、マイルストーン12 主要機能リストにバックアップ機能を追記。Manager v0.8.0 で先行実装。 | Kenshiro Kuroga & Claude |


### PR DESCRIPTION
## Summary
- **MigrateV10ToV11**: SPEC v1.5.1 (2026-03-28) で変更されたが対応マイグレーション未実装だった `surveys` / `play_records` の drift を修正（空テーブルのみ DROP & CREATE）
- **VerifySchema()**: 全 11 テーブルのスキーマ整合性を起動時自動検証する仕組みを追加。今回の実装で **既存の `games.version` 列が `CreateTables()` から抜けていた drift を検出 → 同 PR 内で修正**
- **AGENTS.md "Database Schema Management"**: 「スキーマ変更時は必ずマイグレーションを書く」「`tools/sqlite3/sqlite3.exe` で前後検証する」規約を明文化
- マイグレーション機構の helper メソッド抽出（`CreateSurveysTable` / `CreatePlayRecordsTable` / `TableHasColumn` / `GetTableRowCount`）

## 背景

#103 (WAL × ネットワーク共有) の調査で実 DB を `PRAGMA table_info` 確認したら以下の drift が発覚:
- `surveys`: 旧 JSON 形式 (`id TEXT`, `submitted_at`, `responses`)
- `play_records`: 旧累計方式 (`play_count`, `total_play_time`, `last_played_at`)

SPEC v1.5.1 で定義は変更されたが対応マイグレーションが未実装で、`CREATE TABLE IF NOT EXISTS` の仕様により旧テーブルが温存されていた。

## DB / Manager version bump
- `CurrentDbVersion`: 10 → **11**
- Manager: 0.8.0 → **0.8.1**

## SPEC v1.9.1 反映
- §7.3 テーブル1 games の定義に既存の `arguments` / `version` 列が抜けていたため追記
- §7.3 階層図 / ER 図にも反映
- テーブル11 backup_log の説明に v9 → v10（`trigger_type` への `'safety'` 追加）の経緯を補足

## VerifySchema が早速仕事した話

初回実装でいきなり `games.version` 列の drift を検出。`MigrateGamesTable` の ALTER TABLE で後付けされていたが `CreateTables()` 側に定義が無く、新規 DB と既存 DB でスキーマ定義が分散していた。本 PR で `CreateTables()` 側にも追加して定義を一元化（`MigrateGamesTable` の ALTER は古い DB 向けフォールバックとして残す）。

## Test plan

- [x] ローカル prism.db (v10, drift あり) で Manager 起動 → migration V10 → V11 が走る
- [x] surveys / play_records が新スキーマで再作成される
- [x] `tools/sqlite3/sqlite3.exe prism.db "PRAGMA table_info(surveys)"` で新スキーマを確認
- [x] 再起動 → migration 不要、VerifySchema が「全 11 テーブルのスキーマ整合性 OK」を出力
- [ ] 学校サーバー上の prism.db でも同様のフローを実行（運用時）
- [ ] バックアップ → リストア → migration 経由でも v0.8.0 機能が壊れないことを確認

## 関連
- 前提: PR #112 (SPEC v1.9.0 + tools/sqlite3 同梱) — マージ済み
- 派生: #103 (WAL → DELETE 移行) — 次のブランチで対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)