### PR TITLE
fix: prism.db を WAL から DELETE モードへ移行 + busy_timeout=10000 (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 
 ## Launcher（ランチャー本体）
 
+### [Launcher v0.5.15] - 2026-05-10
+
+#### Changed
+
+- **`prism.db` のジャーナルモードを WAL → DELETE へ移行 + `busy_timeout=10000` (#103)**: 学校 SMB ファイルサーバー上で `prism.db` を共有する運用形態において、SQLite 公式が WAL モードの動作を保証外と明言しているため、Manager v0.8.2 と歩調を合わせて `PRAGMA journal_mode=DELETE` に変更
+  - 続けて `PRAGMA busy_timeout=10000` を発行し、書き込み競合時に即時 SQLITE_BUSY を返さず最大 10 秒待機する挙動に
+  - Launcher は実質 Read-Only（アンケート/プレイ記録は drop-folder 経由）のため運用上の体感影響は無い見込み
+- **`config/version` を `0.5.8` → `0.5.15` に同期**: `project.godot` の `config/version` が v0.5.9〜v0.5.14 のリリース時に更新されていなかった drift を本リリースで解消
+
 ### [Launcher v0.5.14] - 2026-05-03
 
 #### Fixed
@@ -409,6 +418,23 @@
 ---
 
 ## Manager（管理ソフト）
+
+### [Manager v0.8.2] - 2026-05-10
+
+#### Changed
+
+- **`prism.db` のジャーナルモードを WAL → DELETE へ移行 (#103)**: 学校 SMB ファイルサーバー上で `prism.db` を共有する運用形態において、SQLite 公式が WAL モードの動作を保証外と明言している（`prism.db-shm` のメモリマップトファイルが SMB で整合性を保証されない）リスクを回避するため、`PRAGMA journal_mode=DELETE` に切り替え
+  - `DatabaseConnection.OpenConnectionWithWalMode` を `OpenConnectionWithJournalMode` にリネームし、呼び出し側 7 ファイル（`SchemaManager.cs` + 6 リポジトリ）を更新
+  - 接続文字列に `Busy Timeout=10000` を追加（System.Data.SQLite ライブラリ側のフォールバック）
+  - 接続オープン時に `PRAGMA busy_timeout=10000` を実行し、書き込み競合時は SQLite 内部で最大 10 秒待機する「書き込み待機列」として動作させる
+
+#### Operations
+
+- **既存環境の移行手順（一度きり）**:
+  1. 全 PC で Launcher / Manager を停止
+  2. CLI で `tools\sqlite3\sqlite3.exe <prism.db のパス> "PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;"`
+  3. `prism.db-wal` / `prism.db-shm` が削除されたことを確認
+  4. v0.8.2 の Manager と v0.5.15 以降の Launcher を全 PC に配布
 
 ### [Manager v0.8.1] - 2026-05-10
 

--- a/GCTonePrism_Launcher/project.godot
+++ b/GCTonePrism_Launcher/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="GCTonePrism_Launcher"
-config/version="0.5.8"
+config/version="0.5.15"
 run/main_scene="res://scenes/screensaver.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"

--- a/GCTonePrism_Launcher/scripts/database_manager.gd
+++ b/GCTonePrism_Launcher/scripts/database_manager.gd
@@ -40,8 +40,10 @@ func open() -> bool:
 
 	print("[DatabaseManager] データベースを開きました: ", db_path)
 
-	# WALモードを有効化（同時書き込み対策）
-	db.query("PRAGMA journal_mode=WAL;")
+	# SMB ネットワーク共有上での運用安全性のため DELETE モードを使用 (#103)
+	# busy_timeout で書き込み競合時の待機列を確保（10000ms）
+	db.query("PRAGMA journal_mode=DELETE;")
+	db.query("PRAGMA busy_timeout=10000;")
 
 	# データベースのバージョンチェックとマイグレーション
 	_check_and_migrate_db()

--- a/GCTonePrism_Manager/DatabaseConnection.cs
+++ b/GCTonePrism_Manager/DatabaseConnection.cs
@@ -19,7 +19,9 @@ namespace GCTonePrism.Manager
         public DatabaseConnection()
         {
             dbPath = PathManager.DatabasePath;
-            connectionString = $"Data Source={dbPath};Version=3;";
+            // SMB ネットワーク共有上での運用安全性のため journal_mode=DELETE を使用 (#103)
+            // Busy Timeout はライブラリ側にもフォールバックとして指定する
+            connectionString = $"Data Source={dbPath};Version=3;Busy Timeout=10000;";
         }
 
         public bool DatabaseExists()
@@ -28,13 +30,19 @@ namespace GCTonePrism.Manager
         }
 
         /// <summary>
-        /// WALモードを有効にして接続を開く
+        /// ジャーナルモードと PRAGMA を設定して接続を開く
+        /// SMB 共有上では WAL モードが動作保証外のため DELETE モードを使用 (#103)
         /// </summary>
-        public void OpenConnectionWithWalMode(SQLiteConnection connection)
+        public void OpenConnectionWithJournalMode(SQLiteConnection connection)
         {
             connection.Open();
 
-            using (var command = new SQLiteCommand("PRAGMA journal_mode=WAL;", connection))
+            using (var command = new SQLiteCommand("PRAGMA journal_mode=DELETE;", connection))
+            {
+                command.ExecuteNonQuery();
+            }
+
+            using (var command = new SQLiteCommand("PRAGMA busy_timeout=10000;", connection))
             {
                 command.ExecuteNonQuery();
             }

--- a/GCTonePrism_Manager/Properties/AssemblyInfo.cs
+++ b/GCTonePrism_Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.8.1.0")]
-[assembly: AssemblyFileVersion("0.8.1.0")]
+[assembly: AssemblyVersion("0.8.2.0")]
+[assembly: AssemblyFileVersion("0.8.2.0")]

--- a/GCTonePrism_Manager/Repositories/BackupLogRepository.cs
+++ b/GCTonePrism_Manager/Repositories/BackupLogRepository.cs
@@ -29,7 +29,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var cmd = new SQLiteCommand(
                         "INSERT INTO backup_log (started_at, pc_name, status, trigger_type, file_path) " +
                         "VALUES (@started_at, @pc_name, 'in_progress', @trigger_type, @file_path)", connection))
@@ -51,7 +51,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var cmd = new SQLiteCommand(
                         "UPDATE backup_log SET status = 'success', file_path = @file_path, " +
                         "file_size_bytes = @file_size, completed_at = @completed_at WHERE id = @id", connection))
@@ -72,7 +72,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var cmd = new SQLiteCommand(
                         "UPDATE backup_log SET status = 'failed', error_message = @err, " +
                         "completed_at = @completed_at WHERE id = @id", connection))
@@ -114,7 +114,7 @@ namespace GCTonePrism.Manager.Repositories
 
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     // 対象行を取得
                     var inProgressTargets = new List<(long id, string filePath)>();
@@ -218,7 +218,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var cmd = new SQLiteCommand(
                         "SELECT id, started_at, completed_at, pc_name, file_path, file_size_bytes, " +
                         "status, error_message, trigger_type FROM backup_log " +
@@ -273,7 +273,7 @@ namespace GCTonePrism.Manager.Repositories
                 int recovered = 0;
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     // file_path が空の failed 行を取得
                     var targets = new List<(long id, long startedAt)>();
@@ -336,7 +336,7 @@ namespace GCTonePrism.Manager.Repositories
                 int added = 0;
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     // 既に登録済みの safety 行の file_path をセットに集める
                     var existingPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -411,7 +411,7 @@ namespace GCTonePrism.Manager.Repositories
                 var list = new List<BackupLogEntry>();
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var cmd = new SQLiteCommand(
                         "SELECT id, started_at, completed_at, pc_name, file_path, file_size_bytes, " +
                         "status, error_message, trigger_type FROM backup_log " +

--- a/GCTonePrism_Manager/Repositories/DeveloperRepository.cs
+++ b/GCTonePrism_Manager/Repositories/DeveloperRepository.cs
@@ -25,7 +25,7 @@ namespace GCTonePrism.Manager.Repositories
 
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = "SELECT id, game_id, last_name, first_name, grade FROM developers WHERE game_id = @gameId AND version_id IS NULL ORDER BY id ASC";
 

--- a/GCTonePrism_Manager/Repositories/GameRepository.cs
+++ b/GCTonePrism_Manager/Repositories/GameRepository.cs
@@ -28,7 +28,7 @@ namespace GCTonePrism.Manager.Repositories
 
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = @"
                         SELECT
@@ -64,7 +64,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = @"
                         SELECT
@@ -100,7 +100,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var command = new SQLiteCommand("SELECT MIN(display_order) FROM games", connection))
                     {
                         var result = command.ExecuteScalar();
@@ -116,7 +116,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     using (var transaction = connection.BeginTransaction())
                     {
@@ -161,7 +161,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     using (var transaction = connection.BeginTransaction())
                     {
@@ -225,7 +225,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string deleteGame = "DELETE FROM games WHERE game_id = @gameId";
 
@@ -244,7 +244,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     // 重複チェック（トランザクション前）
                     using (var cmd = new SQLiteCommand("SELECT COUNT(*) FROM games WHERE game_id = @newId", connection))

--- a/GCTonePrism_Manager/Repositories/SettingsRepository.cs
+++ b/GCTonePrism_Manager/Repositories/SettingsRepository.cs
@@ -22,7 +22,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var cmd = new SQLiteCommand("SELECT value FROM settings WHERE key = @key", connection))
                     {
                         cmd.Parameters.AddWithValue("@key", key);
@@ -40,7 +40,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     using (var cmd = new SQLiteCommand(
                         "INSERT INTO settings (key, value) VALUES (@key, @value) " +
                         "ON CONFLICT(key) DO UPDATE SET value = @value", connection))
@@ -88,7 +88,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     // System.Data.SQLite では IsolationLevel.Serializable が BEGIN IMMEDIATE に対応
                     using (var tx = connection.BeginTransaction(IsolationLevel.Serializable))
                     {

--- a/GCTonePrism_Manager/Repositories/StoreSectionRepository.cs
+++ b/GCTonePrism_Manager/Repositories/StoreSectionRepository.cs
@@ -25,7 +25,7 @@ namespace GCTonePrism.Manager.Repositories
 
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = @"
                         SELECT section_id, title, section_type, section_source,
@@ -55,7 +55,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = @"
                         SELECT section_id, title, section_type, section_source,
@@ -89,7 +89,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     using (var transaction = connection.BeginTransaction())
                     {
@@ -132,7 +132,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     using (var transaction = connection.BeginTransaction())
                     {
@@ -186,7 +186,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string deleteSql = "DELETE FROM store_sections WHERE section_id = @sectionId";
                     using (var command = new SQLiteCommand(deleteSql, connection))
@@ -204,7 +204,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = "SELECT COALESCE(MAX(display_order), -1) FROM store_sections";
                     using (var command = new SQLiteCommand(query, connection))

--- a/GCTonePrism_Manager/Repositories/VersionRepository.cs
+++ b/GCTonePrism_Manager/Repositories/VersionRepository.cs
@@ -26,7 +26,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = @"
                         INSERT INTO game_versions (
@@ -75,7 +75,7 @@ namespace GCTonePrism.Manager.Repositories
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     using (var transaction = connection.BeginTransaction())
                     {
@@ -140,7 +140,7 @@ namespace GCTonePrism.Manager.Repositories
 
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     string query = @"
                         SELECT *

--- a/GCTonePrism_Manager/SchemaManager.cs
+++ b/GCTonePrism_Manager/SchemaManager.cs
@@ -35,7 +35,7 @@ namespace GCTonePrism.Manager
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
                     return GetDbVersion(connection);
                 }
             });
@@ -49,7 +49,7 @@ namespace GCTonePrism.Manager
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     using (var command = new SQLiteCommand(
                         "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='games'",
@@ -68,7 +68,7 @@ namespace GCTonePrism.Manager
             {
                 using (var connection = new SQLiteConnection(_conn.ConnectionString))
                 {
-                    _conn.OpenConnectionWithWalMode(connection);
+                    _conn.OpenConnectionWithJournalMode(connection);
 
                     using (var transaction = connection.BeginTransaction())
                     {

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1408,16 +1408,16 @@ graph TB
 
 ### 6.5 データの整合性
 
-- **WALモードによる同時アクセス対応**:
-  - SQLiteのWAL（Write-Ahead Logging）モードを使用して、ランチャーと管理ソフトの同時アクセスを可能にする
-  - ランチャー起動中でも管理ソフトでデータベース操作（ゲーム追加・編集・削除など）が可能
-  - 接続時に自動的にWALモードを有効化し、既存データベースにも適用される
-  - 接続文字列に`Journal Mode=WAL`と`Busy Timeout=5000`を設定
+- **DELETE モード + busy_timeout による同時アクセス対応** (#103):
+  - `prism.db` は学校 SMB ファイルサーバー上で共有運用するため、SQLite 公式が動作保証外と明言している WAL モード（`prism.db-shm` のメモリマップトファイルが SMB で整合性を保証されない）を避け、**`journal_mode=DELETE`** を採用する
+  - 接続時に `PRAGMA journal_mode=DELETE` / `PRAGMA busy_timeout=10000` / `PRAGMA synchronous=NORMAL` / `PRAGMA foreign_keys=ON` を実行し、既存データベースにも適用される
+  - 接続文字列にも `Busy Timeout=10000` を併設（System.Data.SQLite ライブラリ側のフォールバック）
+  - `busy_timeout=10000` により書き込み競合時は SQLite 内部で最大 10 秒待機する「書き込み待機列」として動作し、即時 SQLITE_BUSY を返さない。学校 SMB の遅延を考慮した値
+  - 書き込み中は他プロセスからの読み取りもブロックされるが、Manager は時々の操作・Launcher は実質 Read-Only（アンケート/プレイ記録は drop-folder 経由）のため運用上問題ない
 
 - **リトライ機構**:
-  - ネットワークドライブ経由での一時的なロックエラーに対して自動リトライ機能を実装
-  - 最大3回リトライ、指数バックオフ（50ms, 100ms, 200ms）で待機
-  - 学校サーバー経由での使用に最適化
+  - busy_timeout を超える本物のデッドロック対策として、Manager `DatabaseConnection.ExecuteWithRetry` が `Busy/Locked` 例外を**最大 3 回・固定 100ms 間隔**で再試行する
+  - 学校サーバー経由での使用に最適化（busy_timeout が主防衛線、ExecuteWithRetry が二重防衛層）
 
 - **エラーハンドリング**:
   - SQLiteExceptionを具体的に処理し、ユーザーに分かりやすいエラーメッセージを表示
@@ -2498,6 +2498,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-10 | 1.9.3 | `prism.db` のジャーナルモードを WAL → DELETE へ移行し、`busy_timeout=10000` を追加（#103）：6.5 データの整合性を「DELETE モード + busy_timeout による同時アクセス対応」に書き換え、SMB 共有上で WAL モードが SQLite 公式により動作保証外である旨と DELETE モード採用の理由（`prism.db-shm` のメモリマップ整合性不全リスクの回避）、`busy_timeout=10000` を「書き込み待機列」として 10 秒待機させる挙動を明記。リトライ機構の記述を実装に合わせて「最大 3 回・固定 100ms 間隔」に修正（従来の「指数バックオフ 50/100/200ms」記載は実装と齟齬していた）。Manager v0.8.2 / Launcher v0.5.9 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.2 | PR #113 のレビュー段階で実施したスキーマ整合性 audit の結果を SPEC に反映：7.3 テーブル3 play_records とテーブル4 surveys を「現行スキーマ（Manager v0.8.1 / DB v11 時点）」と「drop-folder 設計（#35 実装時に v11 → v12 で移行予定）」の併記形式に変更（現行は SchemaManager.cs の `CreateTables()` と一致する 5/6 列、将来形は v1.9.0 で記載した 9 列構成を保持）。VerifySchema が比較する `ExpectedSchema` は現行スキーマと同期、drop-folder 設計は #35 実装時に v11 → v12 マイグレーションとして反映する流れを明記。テーブル10 launcher_surveys に「廃止までの暫定」として現行 5 列カラム表を追記。テーブル11 backup_log の `trigger_type` CHECK 制約に v10 で追加された `'safety'` を反映（§7.3 表 / §7.2 階層図）。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.1 | スキーマ drift 修正・検出機構を Manager v0.8.1 として実装した内容を SPEC に反映：7.3 テーブル1 games の定義に既存の `arguments` / `version` 列が抜けていたため追記（実 DB と SPEC の整合性回復）、7.3 階層図 / ER 図にも反映、テーブル11 backup_log の説明に v9 → v10（`trigger_type` への `'safety'` 追加）の経緯を補足。マイグレーション機構について、`SchemaManager.cs` の `CreateTables()` を変更したら必ず対応する `MigrateVxToVy` を書くべきこと、`tools/sqlite3/` を使ったマイグレーション前後検証を行うことを `AGENTS.md` に明文化（同 PR で追記）。CurrentDbVersion を v10 → v11 に更新し、SPEC v1.5.1 (2026-03-28) で変更されたが対応マイグレーション未実装だった `surveys` / `play_records` の drift を修正（空テーブルのみ DROP & CREATE 対応）。Manager 起動時の `VerifySchema()` で全テーブルのスキーマ整合性を自動検証する仕組みを追加。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.0 | アンケート・プレイ記録の保存方式を drop-folder 方式に変更し、運用補助ツールを同梱：6.4 データアクセスパターンに Launcher が SQLite を直接書き込まない方針を明記、6.5 データの整合性に「Launcher 書き込みの drop-folder 方式」サブセクションを新設（atomic write / 3-state folder 構成 pending・imported・failed / 2-phase 取り込み（取り込みフェーズ + バックアップフェーズ）/ トリガ別動作マトリクス / 重複 INSERT 防止のための source_uuid + INSERT OR IGNORE / 任意フィールドの NULL 扱い等）、7.3 SQLite データベース設計でテーブル4 surveys を「ゲーム個別+ランチャー全体」を `trigger` 列で統合する形にスキーマ刷新（source_uuid / trigger / source_pc / imported_at 追加、created_at を INTEGER UNIX秒に変更）、テーブル3 play_records も同方式採用＋ INTEGER 化（source_uuid / source_pc / imported_at 追加）、テーブル10 launcher_surveys を廃止予定として記載。7.5.3 として `responses/` フォルダの 3-state 構成を追記、7.5.4 として `tools/sqlite3/` 開発・運用補助ツール（sqlite3.exe 等の SQLite CLI）の同梱を追記（#109 closes）。機能10 アンケート機能・機能11 プレイ記録機能の記述を保存方式変更に合わせて更新。新規追加テーブルのタイムスタンプは INTEGER (UNIX秒) で統一する方針を明文化（既存テーブルは段階的移行）。スキーマ実装は #35 の実装時に v10 → v11 マイグレーションとして対応予定。 | Kenshiro Kuroga & Claude |


### PR DESCRIPTION
Closes #103

## Summary

- 学校 SMB ファイルサーバー上で `prism.db` を共有する運用形態において、SQLite 公式が WAL モードの動作を保証外と明言している (`prism.db-shm` のメモリマップトファイルが SMB で整合性を保証されない) リスクを回避するため、`PRAGMA journal_mode=WAL` → `DELETE` に変更
- 書き込み競合時のために `PRAGMA busy_timeout=10000` を Manager / Launcher 両方に追加 (SQLite 内部で最大 10 秒待機する「書き込み待機列」として動作)
- ドキュメント (SPECIFICATION.md §6.5 / CHANGELOG.md) も DELETE モード前提に修正、既存の「指数バックオフ 50/100/200ms」記述が実装 (固定 100ms × 3 回) と齟齬していた点も同時に解消

## バージョン bump

- Manager: v0.8.1 → **v0.8.2**
- Launcher: project.godot v0.5.8 → **v0.5.15** (CHANGELOG 上の最新 v0.5.14 に対して project.godot が v0.5.9〜v0.5.14 リリース時に更新されていなかった drift も同時に解消)

## 主な変更点

### Manager (`GCTonePrism_Manager/`)
- `DatabaseConnection.cs`
  - `OpenConnectionWithWalMode` → `OpenConnectionWithJournalMode` にリネーム
  - `PRAGMA journal_mode=DELETE` / `busy_timeout=10000` / `synchronous=NORMAL` / `foreign_keys=ON` を発行
  - 接続文字列に `Busy Timeout=10000` をフォールバックとして併設
- 呼び出し側 7 ファイル (SchemaManager + 6 Repository) を rename 追従

### Launcher (`GCTonePrism_Launcher/`)
- `scripts/database_manager.gd`: `journal_mode=DELETE` に変更 + `busy_timeout=10000` を追加
- `project.godot`: `config/version` を v0.5.15 に同期

### ドキュメント
- `SPECIFICATION.md` §6.5「データの整合性」: 「DELETE モード + busy_timeout による同時アクセス対応」に書き換え。リトライ機構の説明を実装に合わせて修正
- `SPECIFICATION.md` 変更履歴: v1.9.3 として追記
- `CHANGELOG.md`: Manager v0.8.2 / Launcher v0.5.15 のエントリを追加。既存環境の移行手順も記載

## Phase 1 診断結果

| 項目 | 結果 |
|---|---|
| ローカル prism.db `PRAGMA integrity_check` | `ok` |
| ローカル prism.db `PRAGMA journal_mode` | `wal` (旧) |
| ローカル prism.db `PRAGMA user_version` | `11` |
| Launcher 過去ログ (Godot `user://logs/`) の WAL 起因エラー検索 | 0 件 (`database is locked` / `disk I/O error` / `corrupt` 全てヒットなし) |
| Manager 過去ログ | ファイルログ機構未実装のため確認不可 (別 Issue 化候補) |
| 学校 SMB 上の prism.db 診断 | 運用環境で別途実施推奨 (手順は §運用 参照) |

実害の証拠は得られなかったため、本変更は **予防的措置** として実装しています。

## ローカル検証 (`tools/sqlite3/sqlite3.exe` で DB ファイルコピーに対して実施)

- `PRAGMA journal_mode=DELETE` → 永続化されることを確認
- `PRAGMA busy_timeout=10000` → 接続スコープ (Manager コードで毎接続時に発行する設計と整合)
- DELETE モードでは `-wal` / `-shm` ファイルが生成されないことを確認
- 変更後も `integrity_check=ok` を維持
- Manager `MSBuild` リビルド成功

## Test plan

- [ ] 単一 PC (ローカル prism.db) で Manager 起動 → ゲーム追加・編集・削除 → 終了 → CLI で `PRAGMA integrity_check` (期待: ok) / `PRAGMA journal_mode` (期待: delete) 確認
- [ ] Launcher 単体起動 → ゲーム選択 → 終了 → 同上の PRAGMA 確認
- [ ] 学校 SMB 環境 1 PC で本番 prism.db を v0.8.0 機能でバックアップ取得後に同検証
- [ ] 2 PC 同時アクセス: PC-A で Launcher 起動 + ゲーム選択操作中、PC-B で Manager から編集 → エラーなく完了するか
- [ ] チェックポイント確認: 操作後に `-wal` / `-shm` ファイルが残らないこと
- [ ] busy_timeout 動作確認: 意図的にロック競合を起こして即時 `SQLITE_BUSY` ではなく待機後に成功するか確認

## 運用 — 既存環境の移行手順 (一度きり)

1. 全 PC で Launcher / Manager を停止
2. CLI で:
   ```
   tools\sqlite3\sqlite3.exe <prism.db のパス> "PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;"
   ```
3. `prism.db-wal` / `prism.db-shm` が削除されたことを確認
4. **v0.8.2 の Manager と v0.5.15 以降の Launcher を全 PC に同時配布** (片方が古いバージョンのまま起動すると WAL に戻る)

## 将来の再評価ポイント

#35 アンケート機能の Launcher 側書き込みが drop-folder 経由ではなく直接 SQLite に書く設計に変わった場合は、DELETE モードの「書き込み中は読み取りもブロック」特性で UI が固まる可能性があるため、再度 WAL 復帰検討 or 書き込み別スレッド退避の設計が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)