### PR TITLE
feat(manager): ゲーム削除を DB + フォルダのセット削除に統一 (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,6 +419,19 @@
 
 ## Manager（管理ソフト）
 
+### [Manager v0.8.3] - 2026-05-10
+
+#### Added
+
+- **ゲーム削除時に「ゲームフォルダも一緒に削除」オプションを実装 (#111)**: SPEC §2.2 で 2 つの削除オプション (DB のみ / DB + ゲームフォルダ) が記載されていたが従来は DB 削除しか実装されておらず、`games/{game_id}/` がディスクに残り続ける問題を解消
+  - 新規 `DeleteGameConfirmForm` を追加。チェックボックス「ゲームフォルダ（games/{game_id}/）も一緒に削除する」は **デフォルト OFF**（誤操作で物理削除しないため）。フォルダパスを表示して何が消えるかを明示
+  - チェックされている場合は最終確認ダイアログ（MessageBox）を追加表示してから削除実行
+  - フォルダが存在しない場合（手動削除済み等）はチェックボックスを disable + 「フォルダが見つかりません」を表示し、DB 削除のみ実行
+  - `Enter` キーで誤って削除されないよう `AcceptButton` をキャンセルに割り当て
+  - 削除処理は既存の `ProcessingDialog` (Marquee モード) 内で DB 削除に続けて `Directory.Delete(folder, true)` を実行
+  - `IOException` (Launcher など他プロセスがロック中)・`UnauthorizedAccessException` を個別捕捉し、DB 削除は成功した上で「フォルダ削除に失敗、手動削除してください」の警告に切り替える非破壊運用
+  - 関連実装: `Controls/GameSectionPanel.cs` の `btnDeleteGame_Click`、`PathManager.GetGameFolder(gameId)` を再利用
+
 ### [Manager v0.8.2] - 2026-05-10
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,13 +421,12 @@
 
 ### [Manager v0.8.3] - 2026-05-10
 
-#### Added
+#### Changed
 
-- **ゲーム削除時に「ゲームフォルダも一緒に削除」オプションを実装 (#111)**: SPEC §2.2 で 2 つの削除オプション (DB のみ / DB + ゲームフォルダ) が記載されていたが従来は DB 削除しか実装されておらず、`games/{game_id}/` がディスクに残り続ける問題を解消
-  - 新規 `DeleteGameConfirmForm` を追加。チェックボックス「ゲームフォルダ（games/{game_id}/）も一緒に削除する」は **デフォルト OFF**（誤操作で物理削除しないため）。フォルダパスを表示して何が消えるかを明示
-  - チェックされている場合は最終確認ダイアログ（MessageBox）を追加表示してから削除実行
-  - フォルダが存在しない場合（手動削除済み等）はチェックボックスを disable + 「フォルダが見つかりません」を表示し、DB 削除のみ実行
-  - `Enter` キーで誤って削除されないよう `AcceptButton` をキャンセルに割り当て
+- **ゲーム削除時に DB レコードに加えて `games/{game_id}/` フォルダも常に削除するよう変更 (#111)**: 従来は DB 削除のみだったため `games/{game_id}/` フォルダがディスクに残り続けていた。SPEC §2.2 にあった「DB のみ / DB + フォルダ」のオプション分岐は廃止し、削除実行 = DB + フォルダのセット削除に統一
+  - 新規 `DeleteGameConfirmForm` を追加。何が消えるかを明確化するため、フォルダパスをダイアログ内に表示（`Consolas` モノスペース、ReadOnly）し、警告色で「ディスクから物理的に削除されます」と明示
+  - フォルダが存在しない場合（手動削除済み等）は表示を「フォルダが見つかりません。DB のみ削除します」に切り替えて DB 削除のみ実行（無害）
+  - `Enter` キーで誤って削除が走らないよう `AcceptButton` をキャンセルに割り当て
   - 削除処理は既存の `ProcessingDialog` (Marquee モード) 内で DB 削除に続けて `Directory.Delete(folder, true)` を実行
   - `IOException` (Launcher など他プロセスがロック中)・`UnauthorizedAccessException` を個別捕捉し、DB 削除は成功した上で「フォルダ削除に失敗、手動削除してください」の警告に切り替える非破壊運用
   - 関連実装: `Controls/GameSectionPanel.cs` の `btnDeleteGame_Click`、`PathManager.GetGameFolder(gameId)` を再利用

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -284,13 +284,14 @@ namespace GCTonePrism.Manager.Controls
             using (var confirm = new DeleteGameConfirmForm(selectedGame.Title, selectedGame.GameId, gameFolder))
             {
                 if (confirm.ShowDialog(this.FindForm()) != DialogResult.Yes) return;
+                // フォルダが存在すれば常に削除、不在ならスキップ (#111)
                 deleteFolder = confirm.DeleteFolder;
             }
 
             // CASCADE で developers / game_versions / game_genres / play_records /
             // surveys / store_section_games が削除される。共有フォルダ越しでは
             // 数秒かかるケースもあるので Marquee 進捗を表示する。
-            // チェックされていれば DB 削除後に games/{game_id}/ も削除する (#111)。
+            // 削除実行は DB レコード + games/{game_id}/ フォルダのセット (#111)。
             Exception caught = null;
             string folderWarning = null;
             using (var dialog = new ProcessingDialog((progress, token) =>

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -278,16 +278,21 @@ namespace GCTonePrism.Manager.Controls
             var selectedGame = dgvGames.SelectedRows[0].DataBoundItem as GameInfo;
             if (selectedGame == null) return;
 
-            var result = MessageBox.Show(
-                $"ゲーム「{selectedGame.Title}」を削除しますか？\nこの操作は取り消せません。",
-                "削除確認", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+            string gameFolder = PathManager.GetGameFolder(selectedGame.GameId);
 
-            if (result != DialogResult.Yes) return;
+            bool deleteFolder;
+            using (var confirm = new DeleteGameConfirmForm(selectedGame.Title, selectedGame.GameId, gameFolder))
+            {
+                if (confirm.ShowDialog(this.FindForm()) != DialogResult.Yes) return;
+                deleteFolder = confirm.DeleteFolder;
+            }
 
             // CASCADE で developers / game_versions / game_genres / play_records /
             // surveys / store_section_games が削除される。共有フォルダ越しでは
             // 数秒かかるケースもあるので Marquee 進捗を表示する。
+            // チェックされていれば DB 削除後に games/{game_id}/ も削除する (#111)。
             Exception caught = null;
+            string folderWarning = null;
             using (var dialog = new ProcessingDialog((progress, token) =>
             {
                 try
@@ -295,6 +300,30 @@ namespace GCTonePrism.Manager.Controls
                     progress?.Report(new ProgressInfo(-1, "ゲームを削除中...",
                         $"「{selectedGame.Title}」と関連レコードをデータベースから削除しています"));
                     _dbManager.DeleteGame(selectedGame.GameId);
+
+                    if (deleteFolder && Directory.Exists(gameFolder))
+                    {
+                        progress?.Report(new ProgressInfo(-1, "ゲームフォルダを削除中...",
+                            gameFolder));
+                        try
+                        {
+                            Directory.Delete(gameFolder, true);
+                        }
+                        catch (IOException ioEx)
+                        {
+                            // ファイルがロックされている (Launcher 起動中など) / 一部削除済み等
+                            folderWarning = $"ゲームフォルダの削除中に問題が発生しました。\n\n" +
+                                $"{ioEx.Message}\n\n" +
+                                $"Launcher など他のプロセスがファイルを使用していないか確認し、" +
+                                $"必要に応じて手動で削除してください:\n  {gameFolder}";
+                        }
+                        catch (UnauthorizedAccessException uaEx)
+                        {
+                            folderWarning = $"ゲームフォルダへのアクセスが拒否されました。\n\n" +
+                                $"{uaEx.Message}\n\n" +
+                                $"フォルダのアクセス権限を確認してください:\n  {gameFolder}";
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -322,8 +351,17 @@ namespace GCTonePrism.Manager.Controls
                 }
             }
 
-            MessageBox.Show("ゲームを削除しました。", "成功",
-                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            if (folderWarning != null)
+            {
+                MessageBox.Show(folderWarning, "ゲームフォルダ削除の警告",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+            else
+            {
+                MessageBox.Show(
+                    deleteFolder ? "ゲームと関連フォルダを削除しました。" : "ゲームを削除しました。",
+                    "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
             LoadGames();
         }
 

--- a/GCTonePrism_Manager/DeleteGameConfirmForm.Designer.cs
+++ b/GCTonePrism_Manager/DeleteGameConfirmForm.Designer.cs
@@ -1,0 +1,149 @@
+namespace GCTonePrism.Manager
+{
+    partial class DeleteGameConfirmForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows フォーム デザイナーで生成されたコード
+
+        private void InitializeComponent()
+        {
+            this.lblTitle = new System.Windows.Forms.Label();
+            this.lblGameId = new System.Windows.Forms.Label();
+            this.lblWarning = new System.Windows.Forms.Label();
+            this.chkDeleteFolder = new System.Windows.Forms.CheckBox();
+            this.txtFolderPath = new System.Windows.Forms.TextBox();
+            this.lblFolderStatus = new System.Windows.Forms.Label();
+            this.btnDelete = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            //
+            // lblTitle
+            //
+            this.lblTitle.AutoSize = true;
+            this.lblTitle.Font = new System.Drawing.Font("MS UI Gothic", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.lblTitle.Location = new System.Drawing.Point(20, 20);
+            this.lblTitle.Name = "lblTitle";
+            this.lblTitle.Size = new System.Drawing.Size(0, 18);
+            this.lblTitle.TabIndex = 0;
+            //
+            // lblGameId
+            //
+            this.lblGameId.AutoSize = true;
+            this.lblGameId.ForeColor = System.Drawing.Color.DimGray;
+            this.lblGameId.Location = new System.Drawing.Point(20, 50);
+            this.lblGameId.Name = "lblGameId";
+            this.lblGameId.Size = new System.Drawing.Size(0, 15);
+            this.lblGameId.TabIndex = 1;
+            //
+            // lblWarning
+            //
+            this.lblWarning.AutoSize = true;
+            this.lblWarning.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblWarning.Location = new System.Drawing.Point(20, 80);
+            this.lblWarning.Name = "lblWarning";
+            this.lblWarning.Size = new System.Drawing.Size(289, 15);
+            this.lblWarning.TabIndex = 2;
+            this.lblWarning.Text = "DB からゲーム情報・関連レコードが削除されます。この操作は取り消せません。";
+            //
+            // chkDeleteFolder
+            //
+            this.chkDeleteFolder.AutoSize = true;
+            this.chkDeleteFolder.Location = new System.Drawing.Point(20, 115);
+            this.chkDeleteFolder.Name = "chkDeleteFolder";
+            this.chkDeleteFolder.Size = new System.Drawing.Size(225, 19);
+            this.chkDeleteFolder.TabIndex = 3;
+            this.chkDeleteFolder.Text = "ゲームフォルダ（games/{game_id}/）も一緒に削除する";
+            this.chkDeleteFolder.UseVisualStyleBackColor = true;
+            //
+            // txtFolderPath
+            //
+            this.txtFolderPath.Font = new System.Drawing.Font("Consolas", 9F);
+            this.txtFolderPath.Location = new System.Drawing.Point(40, 140);
+            this.txtFolderPath.Name = "txtFolderPath";
+            this.txtFolderPath.ReadOnly = true;
+            this.txtFolderPath.Size = new System.Drawing.Size(540, 22);
+            this.txtFolderPath.TabIndex = 4;
+            this.txtFolderPath.BackColor = System.Drawing.SystemColors.Control;
+            //
+            // lblFolderStatus
+            //
+            this.lblFolderStatus.AutoSize = true;
+            this.lblFolderStatus.Location = new System.Drawing.Point(40, 168);
+            this.lblFolderStatus.Name = "lblFolderStatus";
+            this.lblFolderStatus.Size = new System.Drawing.Size(0, 15);
+            this.lblFolderStatus.TabIndex = 5;
+            //
+            // btnDelete
+            //
+            this.btnDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnDelete.BackColor = System.Drawing.Color.IndianRed;
+            this.btnDelete.Font = new System.Drawing.Font("MS UI Gothic", 9.5F, System.Drawing.FontStyle.Bold);
+            this.btnDelete.ForeColor = System.Drawing.Color.White;
+            this.btnDelete.Location = new System.Drawing.Point(360, 210);
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(110, 35);
+            this.btnDelete.TabIndex = 6;
+            this.btnDelete.Text = "削除する";
+            this.btnDelete.UseVisualStyleBackColor = false;
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
+            //
+            // btnCancel
+            //
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(480, 210);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(100, 35);
+            this.btnCancel.TabIndex = 7;
+            this.btnCancel.Text = "キャンセル";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            //
+            // DeleteGameConfirmForm
+            //
+            this.AcceptButton = this.btnCancel;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(610, 265);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnDelete);
+            this.Controls.Add(this.lblFolderStatus);
+            this.Controls.Add(this.txtFolderPath);
+            this.Controls.Add(this.chkDeleteFolder);
+            this.Controls.Add(this.lblWarning);
+            this.Controls.Add(this.lblGameId);
+            this.Controls.Add(this.lblTitle);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "DeleteGameConfirmForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "ゲーム削除確認";
+            this.Load += new System.EventHandler(this.DeleteGameConfirmForm_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblTitle;
+        private System.Windows.Forms.Label lblGameId;
+        private System.Windows.Forms.Label lblWarning;
+        private System.Windows.Forms.CheckBox chkDeleteFolder;
+        private System.Windows.Forms.TextBox txtFolderPath;
+        private System.Windows.Forms.Label lblFolderStatus;
+        private System.Windows.Forms.Button btnDelete;
+        private System.Windows.Forms.Button btnCancel;
+    }
+}

--- a/GCTonePrism_Manager/DeleteGameConfirmForm.Designer.cs
+++ b/GCTonePrism_Manager/DeleteGameConfirmForm.Designer.cs
@@ -20,7 +20,7 @@ namespace GCTonePrism.Manager
             this.lblTitle = new System.Windows.Forms.Label();
             this.lblGameId = new System.Windows.Forms.Label();
             this.lblWarning = new System.Windows.Forms.Label();
-            this.chkDeleteFolder = new System.Windows.Forms.CheckBox();
+            this.lblFolderHeader = new System.Windows.Forms.Label();
             this.txtFolderPath = new System.Windows.Forms.TextBox();
             this.lblFolderStatus = new System.Windows.Forms.Label();
             this.btnDelete = new System.Windows.Forms.Button();
@@ -53,32 +53,30 @@ namespace GCTonePrism.Manager
             this.lblWarning.Name = "lblWarning";
             this.lblWarning.Size = new System.Drawing.Size(289, 15);
             this.lblWarning.TabIndex = 2;
-            this.lblWarning.Text = "DB からゲーム情報・関連レコードが削除されます。この操作は取り消せません。";
+            this.lblWarning.Text = "DB からゲーム情報・関連レコードが削除されます。";
             //
-            // chkDeleteFolder
+            // lblFolderHeader
             //
-            this.chkDeleteFolder.AutoSize = true;
-            this.chkDeleteFolder.Location = new System.Drawing.Point(20, 115);
-            this.chkDeleteFolder.Name = "chkDeleteFolder";
-            this.chkDeleteFolder.Size = new System.Drawing.Size(225, 19);
-            this.chkDeleteFolder.TabIndex = 3;
-            this.chkDeleteFolder.Text = "ゲームフォルダ（games/{game_id}/）も一緒に削除する";
-            this.chkDeleteFolder.UseVisualStyleBackColor = true;
+            this.lblFolderHeader.AutoSize = true;
+            this.lblFolderHeader.Location = new System.Drawing.Point(20, 110);
+            this.lblFolderHeader.Name = "lblFolderHeader";
+            this.lblFolderHeader.Size = new System.Drawing.Size(0, 15);
+            this.lblFolderHeader.TabIndex = 3;
             //
             // txtFolderPath
             //
             this.txtFolderPath.Font = new System.Drawing.Font("Consolas", 9F);
-            this.txtFolderPath.Location = new System.Drawing.Point(40, 140);
+            this.txtFolderPath.Location = new System.Drawing.Point(20, 132);
             this.txtFolderPath.Name = "txtFolderPath";
             this.txtFolderPath.ReadOnly = true;
-            this.txtFolderPath.Size = new System.Drawing.Size(540, 22);
+            this.txtFolderPath.Size = new System.Drawing.Size(560, 22);
             this.txtFolderPath.TabIndex = 4;
             this.txtFolderPath.BackColor = System.Drawing.SystemColors.Control;
             //
             // lblFolderStatus
             //
             this.lblFolderStatus.AutoSize = true;
-            this.lblFolderStatus.Location = new System.Drawing.Point(40, 168);
+            this.lblFolderStatus.Location = new System.Drawing.Point(20, 160);
             this.lblFolderStatus.Name = "lblFolderStatus";
             this.lblFolderStatus.Size = new System.Drawing.Size(0, 15);
             this.lblFolderStatus.TabIndex = 5;
@@ -89,7 +87,7 @@ namespace GCTonePrism.Manager
             this.btnDelete.BackColor = System.Drawing.Color.IndianRed;
             this.btnDelete.Font = new System.Drawing.Font("MS UI Gothic", 9.5F, System.Drawing.FontStyle.Bold);
             this.btnDelete.ForeColor = System.Drawing.Color.White;
-            this.btnDelete.Location = new System.Drawing.Point(360, 210);
+            this.btnDelete.Location = new System.Drawing.Point(360, 200);
             this.btnDelete.Name = "btnDelete";
             this.btnDelete.Size = new System.Drawing.Size(110, 35);
             this.btnDelete.TabIndex = 6;
@@ -101,7 +99,7 @@ namespace GCTonePrism.Manager
             //
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(480, 210);
+            this.btnCancel.Location = new System.Drawing.Point(480, 200);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(100, 35);
             this.btnCancel.TabIndex = 7;
@@ -115,12 +113,12 @@ namespace GCTonePrism.Manager
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(610, 265);
+            this.ClientSize = new System.Drawing.Size(610, 255);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnDelete);
             this.Controls.Add(this.lblFolderStatus);
             this.Controls.Add(this.txtFolderPath);
-            this.Controls.Add(this.chkDeleteFolder);
+            this.Controls.Add(this.lblFolderHeader);
             this.Controls.Add(this.lblWarning);
             this.Controls.Add(this.lblGameId);
             this.Controls.Add(this.lblTitle);
@@ -140,7 +138,7 @@ namespace GCTonePrism.Manager
         private System.Windows.Forms.Label lblTitle;
         private System.Windows.Forms.Label lblGameId;
         private System.Windows.Forms.Label lblWarning;
-        private System.Windows.Forms.CheckBox chkDeleteFolder;
+        private System.Windows.Forms.Label lblFolderHeader;
         private System.Windows.Forms.TextBox txtFolderPath;
         private System.Windows.Forms.Label lblFolderStatus;
         private System.Windows.Forms.Button btnDelete;

--- a/GCTonePrism_Manager/DeleteGameConfirmForm.cs
+++ b/GCTonePrism_Manager/DeleteGameConfirmForm.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace GCTonePrism.Manager
+{
+    /// <summary>
+    /// ゲーム削除確認フォーム。
+    /// DB 削除のみ / DB + games/{gameId}/ フォルダ削除 を選択させる。
+    /// チェックボックスはデフォルト OFF（誤操作で物理削除しないため）。
+    /// </summary>
+    public partial class DeleteGameConfirmForm : Form
+    {
+        private readonly string _gameTitle;
+        private readonly string _gameId;
+        private readonly string _gameFolderPath;
+        private readonly bool _folderExists;
+
+        public bool DeleteFolder { get; private set; }
+
+        public DeleteGameConfirmForm(string gameTitle, string gameId, string gameFolderPath)
+        {
+            InitializeComponent();
+            _gameTitle = gameTitle ?? string.Empty;
+            _gameId = gameId ?? string.Empty;
+            _gameFolderPath = gameFolderPath ?? string.Empty;
+            _folderExists = !string.IsNullOrEmpty(gameFolderPath) && Directory.Exists(gameFolderPath);
+        }
+
+        private void DeleteGameConfirmForm_Load(object sender, EventArgs e)
+        {
+            lblTitle.Text = $"ゲーム「{_gameTitle}」を削除しますか？";
+            lblGameId.Text = $"Game ID: {_gameId}";
+
+            chkDeleteFolder.Checked = false;
+            txtFolderPath.Text = _gameFolderPath;
+
+            if (_folderExists)
+            {
+                chkDeleteFolder.Enabled = true;
+                lblFolderStatus.Text = "（このフォルダ内のファイルがディスクから物理的に削除されます）";
+                lblFolderStatus.ForeColor = System.Drawing.Color.DarkRed;
+            }
+            else
+            {
+                chkDeleteFolder.Enabled = false;
+                lblFolderStatus.Text = "（フォルダが見つかりません。DB のみ削除します）";
+                lblFolderStatus.ForeColor = System.Drawing.Color.Gray;
+            }
+        }
+
+        private void btnDelete_Click(object sender, EventArgs e)
+        {
+            DeleteFolder = _folderExists && chkDeleteFolder.Checked;
+
+            if (DeleteFolder)
+            {
+                var result = MessageBox.Show(
+                    $"ゲームフォルダ\n  {_gameFolderPath}\nをディスクから完全に削除します。\n\nこの操作は取り消せません。本当に実行してよろしいですか？",
+                    "最終確認", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                if (result != DialogResult.Yes)
+                {
+                    return;
+                }
+            }
+
+            DialogResult = DialogResult.Yes;
+            Close();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+    }
+}

--- a/GCTonePrism_Manager/DeleteGameConfirmForm.cs
+++ b/GCTonePrism_Manager/DeleteGameConfirmForm.cs
@@ -6,8 +6,9 @@ namespace GCTonePrism.Manager
 {
     /// <summary>
     /// ゲーム削除確認フォーム。
-    /// DB 削除のみ / DB + games/{gameId}/ フォルダ削除 を選択させる。
-    /// チェックボックスはデフォルト OFF（誤操作で物理削除しないため）。
+    /// 削除実行時は常に「DB レコード + games/{gameId}/ フォルダ」をセットで削除する設計。
+    /// フォルダが存在しない場合（手動削除済み等）は DB のみ削除する。
+    /// 削除は不可逆操作のため、フォルダパスを表示して何が消えるかを明示する。
     /// </summary>
     public partial class DeleteGameConfirmForm : Form
     {
@@ -16,7 +17,10 @@ namespace GCTonePrism.Manager
         private readonly string _gameFolderPath;
         private readonly bool _folderExists;
 
-        public bool DeleteFolder { get; private set; }
+        /// <summary>
+        /// 呼び出し側がフォルダ削除を実行すべきか。フォルダ存在時は true、不在時は false。
+        /// </summary>
+        public bool DeleteFolder => _folderExists;
 
         public DeleteGameConfirmForm(string gameTitle, string gameId, string gameFolderPath)
         {
@@ -32,38 +36,26 @@ namespace GCTonePrism.Manager
             lblTitle.Text = $"ゲーム「{_gameTitle}」を削除しますか？";
             lblGameId.Text = $"Game ID: {_gameId}";
 
-            chkDeleteFolder.Checked = false;
             txtFolderPath.Text = _gameFolderPath;
 
             if (_folderExists)
             {
-                chkDeleteFolder.Enabled = true;
-                lblFolderStatus.Text = "（このフォルダ内のファイルがディスクから物理的に削除されます）";
+                lblFolderHeader.Text = "次のゲームフォルダもディスクから物理的に削除されます:";
+                lblFolderHeader.ForeColor = System.Drawing.Color.DarkRed;
+                lblFolderStatus.Text = "（この操作は取り消せません）";
                 lblFolderStatus.ForeColor = System.Drawing.Color.DarkRed;
             }
             else
             {
-                chkDeleteFolder.Enabled = false;
-                lblFolderStatus.Text = "（フォルダが見つかりません。DB のみ削除します）";
+                lblFolderHeader.Text = "ゲームフォルダの想定パス:";
+                lblFolderHeader.ForeColor = System.Drawing.Color.DimGray;
+                lblFolderStatus.Text = "（フォルダが見つからないため、DB のみ削除します）";
                 lblFolderStatus.ForeColor = System.Drawing.Color.Gray;
             }
         }
 
         private void btnDelete_Click(object sender, EventArgs e)
         {
-            DeleteFolder = _folderExists && chkDeleteFolder.Checked;
-
-            if (DeleteFolder)
-            {
-                var result = MessageBox.Show(
-                    $"ゲームフォルダ\n  {_gameFolderPath}\nをディスクから完全に削除します。\n\nこの操作は取り消せません。本当に実行してよろしいですか？",
-                    "最終確認", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-                if (result != DialogResult.Yes)
-                {
-                    return;
-                }
-            }
-
             DialogResult = DialogResult.Yes;
             Close();
         }

--- a/GCTonePrism_Manager/GCTonePrism_Manager.csproj
+++ b/GCTonePrism_Manager/GCTonePrism_Manager.csproj
@@ -84,6 +84,12 @@
     <Compile Include="ResetDatabaseConfirmForm.Designer.cs">
       <DependentUpon>ResetDatabaseConfirmForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="DeleteGameConfirmForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="DeleteGameConfirmForm.Designer.cs">
+      <DependentUpon>DeleteGameConfirmForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="EditGameForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GCTonePrism_Manager/Properties/AssemblyInfo.cs
+++ b/GCTonePrism_Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.8.2.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
+[assembly: AssemblyVersion("0.8.3.0")]
+[assembly: AssemblyFileVersion("0.8.3.0")]

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -402,11 +402,14 @@
 - **優先度**: 高
 - **詳細**:
   - ゲームの削除
-  - **削除オプション**:
-    - データベースからの削除のみ
-    - データベースとゲームフォルダの両方を削除
-  - 削除前の確認ダイアログを表示
-  - 関連データ（プレイ記録、アンケート結果など）の削除オプション
+  - **削除オプション**（Manager v0.8.3 で実装、`DeleteGameConfirmForm`）:
+    - **データベースからの削除のみ**（デフォルト）: `games` 行と CASCADE で削除される関連レコード（developers / game_versions / game_genres / play_records / surveys / store_section_games）のみ削除。`games/{game_id}/` フォルダはディスクに残る
+    - **データベースとゲームフォルダの両方を削除**: 上記 DB 削除に加えて `games/{game_id}/` フォルダを `Directory.Delete(folder, true)` で物理削除
+  - 削除前の確認ダイアログを表示。「ゲームフォルダも一緒に削除する」チェックボックスは **デフォルト OFF**（誤操作で物理削除しないため）
+  - チェックされている場合は最終確認 MessageBox を追加表示してから削除実行
+  - フォルダが存在しない場合（手動削除済み等）はチェックボックスを disable し、「フォルダが見つかりません」と表示して DB 削除のみ実行
+  - 削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、DB 削除は成功した上で「フォルダ削除に失敗、手動削除してください」の警告に切り替える非破壊運用
+  - 関連データ（プレイ記録、アンケート結果など）は CASCADE 制約により DB 削除と同時に削除される
 
 ##### 機能3: ゲーム情報編集機能
 
@@ -2498,6 +2501,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-10 | 1.9.4 | ゲーム削除機能（機能2）に「ゲームフォルダも一緒に削除」オプションを実装 (#111)：従来は SPEC §2.2 に「DB のみ / DB + フォルダ削除」の 2 オプションが記載されていたが Manager は DB 削除しか実装しておらず、`games/{game_id}/` フォルダがディスクに残る運用上の問題があった。新規 `DeleteGameConfirmForm` でチェックボックス（デフォルト OFF）を提示し、ON 時は最終確認 MessageBox を経て `Directory.Delete(folder, true)` を実行。フォルダ不在時はチェックボックス disable、ファイルロック / 権限エラー時は「DB 削除は成功・フォルダは手動削除を」の警告に切り替える非破壊運用。SPEC §2.2 機能2 の記述を実装に合わせて詳細化。Manager v0.8.3 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.3 | `prism.db` のジャーナルモードを WAL → DELETE へ移行し、`busy_timeout=10000` を追加（#103）：6.5 データの整合性を「DELETE モード + busy_timeout による同時アクセス対応」に書き換え、SMB 共有上で WAL モードが SQLite 公式により動作保証外である旨と DELETE モード採用の理由（`prism.db-shm` のメモリマップ整合性不全リスクの回避）、`busy_timeout=10000` を「書き込み待機列」として 10 秒待機させる挙動を明記。リトライ機構の記述を実装に合わせて「最大 3 回・固定 100ms 間隔」に修正（従来の「指数バックオフ 50/100/200ms」記載は実装と齟齬していた）。Manager v0.8.2 / Launcher v0.5.9 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.2 | PR #113 のレビュー段階で実施したスキーマ整合性 audit の結果を SPEC に反映：7.3 テーブル3 play_records とテーブル4 surveys を「現行スキーマ（Manager v0.8.1 / DB v11 時点）」と「drop-folder 設計（#35 実装時に v11 → v12 で移行予定）」の併記形式に変更（現行は SchemaManager.cs の `CreateTables()` と一致する 5/6 列、将来形は v1.9.0 で記載した 9 列構成を保持）。VerifySchema が比較する `ExpectedSchema` は現行スキーマと同期、drop-folder 設計は #35 実装時に v11 → v12 マイグレーションとして反映する流れを明記。テーブル10 launcher_surveys に「廃止までの暫定」として現行 5 列カラム表を追記。テーブル11 backup_log の `trigger_type` CHECK 制約に v10 で追加された `'safety'` を反映（§7.3 表 / §7.2 階層図）。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.1 | スキーマ drift 修正・検出機構を Manager v0.8.1 として実装した内容を SPEC に反映：7.3 テーブル1 games の定義に既存の `arguments` / `version` 列が抜けていたため追記（実 DB と SPEC の整合性回復）、7.3 階層図 / ER 図にも反映、テーブル11 backup_log の説明に v9 → v10（`trigger_type` への `'safety'` 追加）の経緯を補足。マイグレーション機構について、`SchemaManager.cs` の `CreateTables()` を変更したら必ず対応する `MigrateVxToVy` を書くべきこと、`tools/sqlite3/` を使ったマイグレーション前後検証を行うことを `AGENTS.md` に明文化（同 PR で追記）。CurrentDbVersion を v10 → v11 に更新し、SPEC v1.5.1 (2026-03-28) で変更されたが対応マイグレーション未実装だった `surveys` / `play_records` の drift を修正（空テーブルのみ DROP & CREATE 対応）。Manager 起動時の `VerifySchema()` で全テーブルのスキーマ整合性を自動検証する仕組みを追加。 | Kenshiro Kuroga & Claude |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -401,15 +401,13 @@
 - **説明**: 登録されているゲームをシステムから削除する機能
 - **優先度**: 高
 - **詳細**:
-  - ゲームの削除
-  - **削除オプション**（Manager v0.8.3 で実装、`DeleteGameConfirmForm`）:
-    - **データベースからの削除のみ**（デフォルト）: `games` 行と CASCADE で削除される関連レコード（developers / game_versions / game_genres / play_records / surveys / store_section_games）のみ削除。`games/{game_id}/` フォルダはディスクに残る
-    - **データベースとゲームフォルダの両方を削除**: 上記 DB 削除に加えて `games/{game_id}/` フォルダを `Directory.Delete(folder, true)` で物理削除
-  - 削除前の確認ダイアログを表示。「ゲームフォルダも一緒に削除する」チェックボックスは **デフォルト OFF**（誤操作で物理削除しないため）
-  - チェックされている場合は最終確認 MessageBox を追加表示してから削除実行
-  - フォルダが存在しない場合（手動削除済み等）はチェックボックスを disable し、「フォルダが見つかりません」と表示して DB 削除のみ実行
+  - 削除実行は **DB レコード + `games/{game_id}/` フォルダのセット削除**（Manager v0.8.3 で実装、`DeleteGameConfirmForm`）。「DB のみ削除」のオプション分岐は持たない
+    - DB 側は `games` 行と CASCADE で削除される関連レコード（developers / game_versions / game_genres / play_records / surveys / store_section_games）
+    - フォルダ側は `Directory.Delete(folder, true)` で物理削除
+  - 削除前の確認ダイアログ（`DeleteGameConfirmForm`）に削除対象のフォルダパスを表示し、ディスクから物理的に消える旨を警告色で明示
+  - `Enter` キー誤操作を防ぐため `AcceptButton` はキャンセルに割り当て
+  - フォルダが存在しない場合（手動削除済み等）は表示を「フォルダが見つかりません。DB のみ削除します」に切り替えて DB 削除のみ実行（無害）
   - 削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、DB 削除は成功した上で「フォルダ削除に失敗、手動削除してください」の警告に切り替える非破壊運用
-  - 関連データ（プレイ記録、アンケート結果など）は CASCADE 制約により DB 削除と同時に削除される
 
 ##### 機能3: ゲーム情報編集機能
 
@@ -2501,7 +2499,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
-| 2026-05-10 | 1.9.4 | ゲーム削除機能（機能2）に「ゲームフォルダも一緒に削除」オプションを実装 (#111)：従来は SPEC §2.2 に「DB のみ / DB + フォルダ削除」の 2 オプションが記載されていたが Manager は DB 削除しか実装しておらず、`games/{game_id}/` フォルダがディスクに残る運用上の問題があった。新規 `DeleteGameConfirmForm` でチェックボックス（デフォルト OFF）を提示し、ON 時は最終確認 MessageBox を経て `Directory.Delete(folder, true)` を実行。フォルダ不在時はチェックボックス disable、ファイルロック / 権限エラー時は「DB 削除は成功・フォルダは手動削除を」の警告に切り替える非破壊運用。SPEC §2.2 機能2 の記述を実装に合わせて詳細化。Manager v0.8.3 で実装。 | Kenshiro Kuroga & Claude |
+| 2026-05-10 | 1.9.4 | ゲーム削除機能（機能2）の挙動を「DB レコード + `games/{game_id}/` フォルダのセット削除」に統一 (#111)：従来は SPEC §2.2 に「DB のみ / DB + フォルダ削除」の 2 オプションが記載されていたが、運用要望としては削除実行 = 両方削除が常に望ましく、Manager は DB 削除しか実装していなかったため `games/{game_id}/` フォルダがディスクに残る運用上の問題があった。オプション分岐は廃止し、新規 `DeleteGameConfirmForm` で削除対象のフォルダパスを表示して何が消えるかを明示した上で、削除実行時に常に `Directory.Delete(folder, true)` を呼び出す設計に変更。フォルダ不在時は表示を切り替えて DB 削除のみ実行（無害）、ファイルロック / 権限エラー時は「DB 削除は成功・フォルダは手動削除を」の警告に切り替える非破壊運用。SPEC §2.2 機能2 の記述を実装に合わせて書き直し。Manager v0.8.3 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.3 | `prism.db` のジャーナルモードを WAL → DELETE へ移行し、`busy_timeout=10000` を追加（#103）：6.5 データの整合性を「DELETE モード + busy_timeout による同時アクセス対応」に書き換え、SMB 共有上で WAL モードが SQLite 公式により動作保証外である旨と DELETE モード採用の理由（`prism.db-shm` のメモリマップ整合性不全リスクの回避）、`busy_timeout=10000` を「書き込み待機列」として 10 秒待機させる挙動を明記。リトライ機構の記述を実装に合わせて「最大 3 回・固定 100ms 間隔」に修正（従来の「指数バックオフ 50/100/200ms」記載は実装と齟齬していた）。Manager v0.8.2 / Launcher v0.5.9 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.2 | PR #113 のレビュー段階で実施したスキーマ整合性 audit の結果を SPEC に反映：7.3 テーブル3 play_records とテーブル4 surveys を「現行スキーマ（Manager v0.8.1 / DB v11 時点）」と「drop-folder 設計（#35 実装時に v11 → v12 で移行予定）」の併記形式に変更（現行は SchemaManager.cs の `CreateTables()` と一致する 5/6 列、将来形は v1.9.0 で記載した 9 列構成を保持）。VerifySchema が比較する `ExpectedSchema` は現行スキーマと同期、drop-folder 設計は #35 実装時に v11 → v12 マイグレーションとして反映する流れを明記。テーブル10 launcher_surveys に「廃止までの暫定」として現行 5 列カラム表を追記。テーブル11 backup_log の `trigger_type` CHECK 制約に v10 で追加された `'safety'` を反映（§7.3 表 / §7.2 階層図）。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.1 | スキーマ drift 修正・検出機構を Manager v0.8.1 として実装した内容を SPEC に反映：7.3 テーブル1 games の定義に既存の `arguments` / `version` 列が抜けていたため追記（実 DB と SPEC の整合性回復）、7.3 階層図 / ER 図にも反映、テーブル11 backup_log の説明に v9 → v10（`trigger_type` への `'safety'` 追加）の経緯を補足。マイグレーション機構について、`SchemaManager.cs` の `CreateTables()` を変更したら必ず対応する `MigrateVxToVy` を書くべきこと、`tools/sqlite3/` を使ったマイグレーション前後検証を行うことを `AGENTS.md` に明文化（同 PR で追記）。CurrentDbVersion を v10 → v11 に更新し、SPEC v1.5.1 (2026-03-28) で変更されたが対応マイグレーション未実装だった `surveys` / `play_records` の drift を修正（空テーブルのみ DROP & CREATE 対応）。Manager 起動時の `VerifySchema()` で全テーブルのスキーマ整合性を自動検証する仕組みを追加。 | Kenshiro Kuroga & Claude |


### PR DESCRIPTION
Closes #111

## Summary

- ゲーム削除を **常に DB レコード + `games/{game_id}/` フォルダのセット削除** に変更（オプションのチェックボックスは取りやめ）
- 削除前に専用ダイアログ `DeleteGameConfirmForm` で対象フォルダパスを表示し、何が消えるかを明示
- フォルダ不在時は「フォルダが見つかりません。DB のみ削除します」表示で DB 削除のみ実行（無害）
- ファイルロック / 権限エラー時は「DB 削除は成功・フォルダは手動削除を」の警告に切り替える非破壊運用

## バージョン bump

- Manager: v0.8.2 → **v0.8.3**

## 主な変更点

### 新規 (`GCTonePrism_Manager/DeleteGameConfirmForm.cs` + `.Designer.cs`)
- 専用確認ダイアログ。`MessageBox.YesNo` ではフォルダパスを見やすく表示できないため Form 化
- フォルダパスを `txtFolderPath` で表示（ReadOnly、Consolas モノスペース）
- フォルダ存在時: ヘッダーラベルを警告色 (DarkRed) で「次のゲームフォルダもディスクから物理的に削除されます:」に
- フォルダ不在時: ヘッダーラベルを Gray + 「フォルダが見つからないため、DB のみ削除します」表示に切り替え
- `AcceptButton = btnCancel` で `Enter` キー誤操作の物理削除を防止
- `public bool DeleteFolder { get; }` はフォルダ存在の有無を返すだけのシンプルなプロパティ

### 既存修正 (`GCTonePrism_Manager/Controls/GameSectionPanel.cs`)
- `btnDeleteGame_Click` の `MessageBox.YesNo` を `DeleteGameConfirmForm` に置換
- 既存の `ProcessingDialog`（Marquee モード）内で DB 削除に続けて
  ```csharp
  if (deleteFolder && Directory.Exists(gameFolder)) { Directory.Delete(gameFolder, true); }
  ```
  を実行（`deleteFolder` はフォルダ存在時に常に true）
- `IOException` (Launcher など他プロセスのロック)・`UnauthorizedAccessException` を個別捕捉し `folderWarning` 文字列に積む。DB 削除が成功している以上、警告ダイアログのみ表示して `LoadGames()` は実行
- `PathManager.GetGameFolder(gameId)` を再利用

### ドキュメント
- `SPECIFICATION.md` §2.2 機能2: オプション分岐記述を削除し、「削除実行 = DB + フォルダのセット削除」に書き直し
- `SPECIFICATION.md` 変更履歴: v1.9.4 として追記（同方針）
- `CHANGELOG.md`: Manager v0.8.3 のエントリを追加（Changed カテゴリ）

## Test plan

- [ ] フォルダあり → 確認ダイアログでフォルダパスを確認 → 削除実行 → DB 削除 + `games/{game_id}/` 削除を確認
- [ ] フォルダなし（手動で先に消したケース）→ ダイアログが「フォルダが見つかりません」表示 → 削除実行 → DB 削除のみ実行されることを確認
- [ ] Launcher でそのゲームを起動中に削除 → 警告ダイアログが表示され、DB 削除は成功することを確認
- [ ] `Enter` キー連打しても誤って削除されないこと（`AcceptButton` がキャンセル）
- [ ] 削除直後に DataGridView が再読み込みされ、当該ゲームが消えること

## ビルド検証

- Manager の MSBuild リビルド成功

## 注意

- UI 動作確認は本 PR では未実施（CLI 環境でビルドのみ確認）。マージ前に Manager を起動して上記 Test plan を手動確認推奨
- フォルダ削除は不可逆操作のため、運用環境で試す前にバックアップ機能 (#96 / v0.8.0) で `prism.db` のスナップショットを取得することを推奨

## レビュー履歴

- 当初はチェックボックスでオプション化する設計だったが、レビュー指摘で「削除を押すと最初から両方消える想定」との合意があったため、追加コミット `98fe60c` で「常に両方削除」設計に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)