### PR TITLE
fix(manager): DeleteGameConfirmForm レビュー指摘の反映 (#111 followup)

### DIFF
--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -278,6 +278,15 @@ namespace GCTonePrism.Manager.Controls
             var selectedGame = dgvGames.SelectedRows[0].DataBoundItem as GameInfo;
             if (selectedGame == null) return;
 
+            // GameId が空だと PathManager.GetGameFolder("") が GamesFolder 自体を返し、
+            // Directory.Delete(folder, true) で全ゲームフォルダが消える致命バグになる。防御。
+            if (string.IsNullOrWhiteSpace(selectedGame.GameId))
+            {
+                MessageBox.Show(this.FindForm(), "ゲームIDが不正です。削除できません。",
+                    "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
             string gameFolder = PathManager.GetGameFolder(selectedGame.GameId);
 
             bool deleteFolder;
@@ -354,12 +363,12 @@ namespace GCTonePrism.Manager.Controls
 
             if (folderWarning != null)
             {
-                MessageBox.Show(folderWarning, "ゲームフォルダ削除の警告",
+                MessageBox.Show(this.FindForm(), folderWarning, "ゲームフォルダ削除の警告",
                     MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             else
             {
-                MessageBox.Show(
+                MessageBox.Show(this.FindForm(),
                     deleteFolder ? "ゲームと関連フォルダを削除しました。" : "ゲームを削除しました。",
                     "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }

--- a/GCTonePrism_Manager/DeleteGameConfirmForm.Designer.cs
+++ b/GCTonePrism_Manager/DeleteGameConfirmForm.Designer.cs
@@ -19,10 +19,14 @@ namespace GCTonePrism.Manager
         {
             this.lblTitle = new System.Windows.Forms.Label();
             this.lblGameId = new System.Windows.Forms.Label();
-            this.lblWarning = new System.Windows.Forms.Label();
-            this.lblFolderHeader = new System.Windows.Forms.Label();
+            this.lblHeader = new System.Windows.Forms.Label();
+            this.lblItem1Title = new System.Windows.Forms.Label();
+            this.lblItem1Detail = new System.Windows.Forms.Label();
+            this.lblItem2Title = new System.Windows.Forms.Label();
+            this.lblItem2Note1 = new System.Windows.Forms.Label();
+            this.lblItem2Note2 = new System.Windows.Forms.Label();
             this.txtFolderPath = new System.Windows.Forms.TextBox();
-            this.lblFolderStatus = new System.Windows.Forms.Label();
+            this.lblFinalWarning = new System.Windows.Forms.Label();
             this.btnDelete = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.SuspendLayout();
@@ -33,7 +37,6 @@ namespace GCTonePrism.Manager
             this.lblTitle.Font = new System.Drawing.Font("MS UI Gothic", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.lblTitle.Location = new System.Drawing.Point(20, 20);
             this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(0, 18);
             this.lblTitle.TabIndex = 0;
             //
             // lblGameId
@@ -42,44 +45,74 @@ namespace GCTonePrism.Manager
             this.lblGameId.ForeColor = System.Drawing.Color.DimGray;
             this.lblGameId.Location = new System.Drawing.Point(20, 50);
             this.lblGameId.Name = "lblGameId";
-            this.lblGameId.Size = new System.Drawing.Size(0, 15);
             this.lblGameId.TabIndex = 1;
             //
-            // lblWarning
+            // lblHeader
             //
-            this.lblWarning.AutoSize = true;
-            this.lblWarning.ForeColor = System.Drawing.Color.DarkRed;
-            this.lblWarning.Location = new System.Drawing.Point(20, 80);
-            this.lblWarning.Name = "lblWarning";
-            this.lblWarning.Size = new System.Drawing.Size(289, 15);
-            this.lblWarning.TabIndex = 2;
-            this.lblWarning.Text = "DB からゲーム情報・関連レコードが削除されます。";
+            this.lblHeader.AutoSize = true;
+            this.lblHeader.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.lblHeader.Location = new System.Drawing.Point(20, 80);
+            this.lblHeader.Name = "lblHeader";
+            this.lblHeader.TabIndex = 2;
             //
-            // lblFolderHeader
+            // lblItem1Title
             //
-            this.lblFolderHeader.AutoSize = true;
-            this.lblFolderHeader.Location = new System.Drawing.Point(20, 110);
-            this.lblFolderHeader.Name = "lblFolderHeader";
-            this.lblFolderHeader.Size = new System.Drawing.Size(0, 15);
-            this.lblFolderHeader.TabIndex = 3;
+            this.lblItem1Title.AutoSize = true;
+            this.lblItem1Title.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblItem1Title.Location = new System.Drawing.Point(20, 105);
+            this.lblItem1Title.Name = "lblItem1Title";
+            this.lblItem1Title.TabIndex = 3;
+            //
+            // lblItem1Detail
+            //
+            this.lblItem1Detail.AutoSize = true;
+            this.lblItem1Detail.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblItem1Detail.Location = new System.Drawing.Point(20, 122);
+            this.lblItem1Detail.Name = "lblItem1Detail";
+            this.lblItem1Detail.TabIndex = 4;
+            //
+            // lblItem2Title
+            //
+            this.lblItem2Title.AutoSize = true;
+            this.lblItem2Title.Location = new System.Drawing.Point(20, 150);
+            this.lblItem2Title.Name = "lblItem2Title";
+            this.lblItem2Title.TabIndex = 5;
+            //
+            // lblItem2Note1
+            //
+            this.lblItem2Note1.AutoSize = true;
+            this.lblItem2Note1.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblItem2Note1.Location = new System.Drawing.Point(20, 167);
+            this.lblItem2Note1.Name = "lblItem2Note1";
+            this.lblItem2Note1.TabIndex = 6;
+            //
+            // lblItem2Note2
+            //
+            this.lblItem2Note2.AutoSize = true;
+            this.lblItem2Note2.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblItem2Note2.Location = new System.Drawing.Point(20, 184);
+            this.lblItem2Note2.Name = "lblItem2Note2";
+            this.lblItem2Note2.TabIndex = 7;
             //
             // txtFolderPath
             //
             this.txtFolderPath.Font = new System.Drawing.Font("Consolas", 9F);
-            this.txtFolderPath.Location = new System.Drawing.Point(20, 132);
+            this.txtFolderPath.Location = new System.Drawing.Point(40, 210);
             this.txtFolderPath.Name = "txtFolderPath";
             this.txtFolderPath.ReadOnly = true;
-            this.txtFolderPath.Size = new System.Drawing.Size(560, 22);
-            this.txtFolderPath.TabIndex = 4;
+            this.txtFolderPath.Size = new System.Drawing.Size(540, 22);
+            this.txtFolderPath.TabIndex = 8;
             this.txtFolderPath.BackColor = System.Drawing.SystemColors.Control;
             //
-            // lblFolderStatus
+            // lblFinalWarning
             //
-            this.lblFolderStatus.AutoSize = true;
-            this.lblFolderStatus.Location = new System.Drawing.Point(20, 160);
-            this.lblFolderStatus.Name = "lblFolderStatus";
-            this.lblFolderStatus.Size = new System.Drawing.Size(0, 15);
-            this.lblFolderStatus.TabIndex = 5;
+            this.lblFinalWarning.AutoSize = true;
+            this.lblFinalWarning.Font = new System.Drawing.Font("MS UI Gothic", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.lblFinalWarning.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblFinalWarning.Location = new System.Drawing.Point(20, 250);
+            this.lblFinalWarning.Name = "lblFinalWarning";
+            this.lblFinalWarning.TabIndex = 9;
+            this.lblFinalWarning.Text = "この操作は取り消せません。";
             //
             // btnDelete
             //
@@ -87,10 +120,10 @@ namespace GCTonePrism.Manager
             this.btnDelete.BackColor = System.Drawing.Color.IndianRed;
             this.btnDelete.Font = new System.Drawing.Font("MS UI Gothic", 9.5F, System.Drawing.FontStyle.Bold);
             this.btnDelete.ForeColor = System.Drawing.Color.White;
-            this.btnDelete.Location = new System.Drawing.Point(360, 200);
+            this.btnDelete.Location = new System.Drawing.Point(360, 295);
             this.btnDelete.Name = "btnDelete";
             this.btnDelete.Size = new System.Drawing.Size(110, 35);
-            this.btnDelete.TabIndex = 6;
+            this.btnDelete.TabIndex = 10;
             this.btnDelete.Text = "削除する";
             this.btnDelete.UseVisualStyleBackColor = false;
             this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
@@ -99,27 +132,29 @@ namespace GCTonePrism.Manager
             //
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(480, 200);
+            this.btnCancel.Location = new System.Drawing.Point(480, 295);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(100, 35);
-            this.btnCancel.TabIndex = 7;
+            this.btnCancel.TabIndex = 11;
             this.btnCancel.Text = "キャンセル";
             this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             //
             // DeleteGameConfirmForm
             //
-            this.AcceptButton = this.btnCancel;
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(610, 255);
+            this.ClientSize = new System.Drawing.Size(610, 350);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnDelete);
-            this.Controls.Add(this.lblFolderStatus);
+            this.Controls.Add(this.lblFinalWarning);
             this.Controls.Add(this.txtFolderPath);
-            this.Controls.Add(this.lblFolderHeader);
-            this.Controls.Add(this.lblWarning);
+            this.Controls.Add(this.lblItem2Note2);
+            this.Controls.Add(this.lblItem2Note1);
+            this.Controls.Add(this.lblItem2Title);
+            this.Controls.Add(this.lblItem1Detail);
+            this.Controls.Add(this.lblItem1Title);
+            this.Controls.Add(this.lblHeader);
             this.Controls.Add(this.lblGameId);
             this.Controls.Add(this.lblTitle);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
@@ -137,10 +172,14 @@ namespace GCTonePrism.Manager
 
         private System.Windows.Forms.Label lblTitle;
         private System.Windows.Forms.Label lblGameId;
-        private System.Windows.Forms.Label lblWarning;
-        private System.Windows.Forms.Label lblFolderHeader;
+        private System.Windows.Forms.Label lblHeader;
+        private System.Windows.Forms.Label lblItem1Title;
+        private System.Windows.Forms.Label lblItem1Detail;
+        private System.Windows.Forms.Label lblItem2Title;
+        private System.Windows.Forms.Label lblItem2Note1;
+        private System.Windows.Forms.Label lblItem2Note2;
         private System.Windows.Forms.TextBox txtFolderPath;
-        private System.Windows.Forms.Label lblFolderStatus;
+        private System.Windows.Forms.Label lblFinalWarning;
         private System.Windows.Forms.Button btnDelete;
         private System.Windows.Forms.Button btnCancel;
     }

--- a/GCTonePrism_Manager/DeleteGameConfirmForm.cs
+++ b/GCTonePrism_Manager/DeleteGameConfirmForm.cs
@@ -8,7 +8,8 @@ namespace GCTonePrism.Manager
     /// ゲーム削除確認フォーム。
     /// 削除実行時は常に「DB レコード + games/{gameId}/ フォルダ」をセットで削除する設計。
     /// フォルダが存在しない場合（手動削除済み等）は DB のみ削除する。
-    /// 削除は不可逆操作のため、フォルダパスを表示して何が消えるかを明示する。
+    /// 部員が見ても何が消えるか（特に「自分の開発フォルダは無事か」）を判断できるよう、
+    /// 専門用語を避けて 1.〜 2. のリスト形式で明示する。
     /// </summary>
     public partial class DeleteGameConfirmForm : Form
     {
@@ -34,35 +35,43 @@ namespace GCTonePrism.Manager
         private void DeleteGameConfirmForm_Load(object sender, EventArgs e)
         {
             lblTitle.Text = $"ゲーム「{_gameTitle}」を削除しますか？";
-            lblGameId.Text = $"Game ID: {_gameId}";
+            lblGameId.Text = $"ゲームID: {_gameId}";
 
             txtFolderPath.Text = _gameFolderPath;
 
+            // 1 番目（DB 側）の文言は状態によらず固定
+            lblItem1Title.Text = "1. ゲーム情報・プレイ記録・アンケート回答";
+            lblItem1Detail.Text = "    (製作者情報・バージョン情報も含む)";
+
             if (_folderExists)
             {
-                lblFolderHeader.Text = "次のゲームフォルダもディスクから物理的に削除されます:";
-                lblFolderHeader.ForeColor = System.Drawing.Color.DarkRed;
-                lblFolderStatus.Text = "（この操作は取り消せません）";
-                lblFolderStatus.ForeColor = System.Drawing.Color.DarkRed;
+                lblHeader.Text = "以下の 2 つが削除されます:";
+                lblHeader.ForeColor = System.Drawing.Color.DarkRed;
+
+                lblItem2Title.Text = "2. ゲームファイル (実行ファイル・サムネイル・背景画像など)";
+                lblItem2Title.ForeColor = System.Drawing.Color.DarkRed;
+
+                lblItem2Note1.Visible = true;
+                lblItem2Note2.Visible = true;
+                lblItem2Note1.Text = "    ※ Manager にゲームを追加した際にコピーされたものです。";
+                lblItem2Note2.Text = "       部員の開発フォルダには影響しません。";
             }
             else
             {
-                lblFolderHeader.Text = "ゲームフォルダの想定パス:";
-                lblFolderHeader.ForeColor = System.Drawing.Color.DimGray;
-                lblFolderStatus.Text = "（フォルダが見つからないため、DB のみ削除します）";
-                lblFolderStatus.ForeColor = System.Drawing.Color.Gray;
+                lblHeader.Text = "削除されるもの:";
+                lblHeader.ForeColor = System.Drawing.Color.DimGray;
+
+                lblItem2Title.Text = "2. ゲームファイル — 既に手動削除済み (DB のみ削除します)";
+                lblItem2Title.ForeColor = System.Drawing.Color.DimGray;
+
+                lblItem2Note1.Visible = false;
+                lblItem2Note2.Visible = false;
             }
         }
 
         private void btnDelete_Click(object sender, EventArgs e)
         {
             DialogResult = DialogResult.Yes;
-            Close();
-        }
-
-        private void btnCancel_Click(object sender, EventArgs e)
-        {
-            DialogResult = DialogResult.Cancel;
             Close();
         }
     }

--- a/GCTonePrism_Manager/DeleteGameConfirmForm.resx
+++ b/GCTonePrism_Manager/DeleteGameConfirmForm.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GCTonePrism_Manager/GCTonePrism_Manager.csproj
+++ b/GCTonePrism_Manager/GCTonePrism_Manager.csproj
@@ -196,6 +196,9 @@
     <EmbeddedResource Include="ResetDatabaseConfirmForm.resx">
       <DependentUpon>ResetDatabaseConfirmForm.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="DeleteGameConfirmForm.resx">
+      <DependentUpon>DeleteGameConfirmForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="EditGameForm.resx">
       <DependentUpon>EditGameForm.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
PR [#117](https://github.com/ken1208git/GCTonePrism/pull/117) (#111) のレビュー指摘事項を反映する followup PR。

## Summary

- 🔴 **GameId 空文字ガード追加**: 致命バグ予防（`GamesFolder` 全削除リスク）
- 🟡 **`DeleteGameConfirmForm` 文言を部員向けに刷新**: 「2 つが削除されます」のリスト形式 + 開発フォルダ不影響を明示
- 🟡 **`MessageBox` の親ウィンドウ指定**: マルチモニタ環境で迷子防止
- 🟡 **`AcceptButton = null` に変更**: Enter キーで何も起きない（より安全）
- 🟡 **冗長な `btnCancel_Click` ハンドラ削除**: `btnCancel.DialogResult=Cancel` で automatic close
- 🟡 **「Game ID」→「ゲームID」日本語化**: 他ラベルとの一貫性
- 🟢 **`DeleteGameConfirmForm.resx` 追加**: 他 Form と一貫性、Visual Studio Designer で開いても安全

## バージョン

- Manager v0.8.3 のまま（PR #117 と同じ機能の品質改善のみで、挙動の本筋は変わらない）

## コミット構成

1. `fix(manager): GameId 空文字ガード + MessageBox 親ウィンドウ指定 (#111)`
2. `refactor(manager): DeleteGameConfirmForm 文言を部員向けに刷新 (#111)`
3. `chore(manager): DeleteGameConfirmForm.resx を追加 (#111)`

## 新ダイアログのレイアウト（フォルダあり時）

```
┌── ゲーム削除確認 ──────────────────────────────────┐
│                                                    │
│  ゲーム「ぷよぷよテトリス」を削除しますか？        │
│                                                    │
│  ゲームID: pyo-tet-001                             │
│                                                    │
│  以下の 2 つが削除されます:                        │
│                                                    │
│    1. ゲーム情報・プレイ記録・アンケート回答       │
│       (製作者情報・バージョン情報も含む)           │
│                                                    │
│    2. ゲームファイル (実行ファイル・サムネイル・   │
│       背景画像など)                                │
│       ※ Manager にゲームを追加した際にコピーされた │
│         ものです。                                 │
│         部員の開発フォルダには影響しません。       │
│                                                    │
│       [ \school-server\share\games\pyo-tet-001 ] │
│                                                    │
│  この操作は取り消せません。                        │
│                                                    │
│                            [削除する]  [キャンセル]│
└────────────────────────────────────────────────────┘
```

## フォルダ不在時の表示切り替え

| 要素 | フォルダあり | フォルダなし |
|---|---|---|
| ヘッダー | 「以下の 2 つが削除されます:」DarkRed | 「削除されるもの:」DimGray |
| 2. の文言 | 「ゲームファイル (実行ファイル・…)」DarkRed | 「ゲームファイル — 既に手動削除済み (DB のみ削除します)」DimGray |
| 補足ノート | 表示 | 非表示 |

## Test plan

- [ ] Manager 起動 → ゲーム削除 → 新ダイアログのレイアウト・文言確認
- [ ] フォルダあり時のフロー: 削除実行 → DB 削除 + フォルダ削除確認
- [ ] フォルダなし時のフロー: 「既に手動削除済み」表示が出る → DB 削除のみ実行
- [ ] Enter キーで何も起きない（AcceptButton 解除確認）
- [ ] ESC キーでキャンセル動作（CancelButton は維持）
- [ ] 警告 MessageBox が親ウィンドウの中央に出る

## ビルド検証

- Manager の MSBuild リビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)