### PR TITLE
feat(manager): フォルダ削除失敗時の再試行 UI を追加 (#122 Group C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,7 +423,7 @@
 
 #### Added
 
-- **フォルダ削除失敗時の再試行 UI を追加 (#122)**: ゲーム削除や DB リセットでフォルダ削除に失敗した場合、従来は「警告 MessageBox 表示 → ユーザーが手動でなんとかする」だったが、専用ダイアログ `FolderDeletionFailureDialog` で「再試行」「諦める (手動削除)」を選べるように改善
+- **フォルダ削除失敗時の再試行 UI を追加 (#122)**: ゲーム削除や DB リセットでフォルダ削除に失敗した場合、従来は「警告 MessageBox 表示 → ユーザーが手動でなんとかする」だったが、専用ダイアログ `FolderDeletionFailureDialog` で「再試行」「諦める」を選べるように改善
   - 主因は **Launcher が起動中ゲームの実行ファイルを掴んでいる** ケース。ユーザーが Launcher を閉じてから「再試行」を押すだけで解消する
   - ダイアログには対象フォルダパス、エラー詳細 (Exception.Message)、対処手順 (Launcher を閉じてから再試行) を表示
   - `AcceptButton = btnRetry` で Enter で再試行 (再試行は何度押しても安全)、`CancelButton = btnGiveUp` で ESC で諦める
@@ -436,6 +436,7 @@
 - **`DatabaseManager.ResetDatabase()` の wrapper signature 更新**: 同様に `Result` を返す形に
 - **`SettingsSectionPanel.btnResetDatabase_Click`**: 退避フォルダ削除失敗時に `FolderDeletionFailureDialog` を表示する再試行ループに変更。「諦める」を選んだ場合のみ警告 MessageBox を表示 (#122)
 - **`GameSectionPanel.btnDeleteGame_Click`**: フォルダ削除を `ProcessingDialog` の外に出して再試行ループ化。`folderWarning` 文字列方式を廃止し、失敗時は `FolderDeletionFailureDialog` で対応 (#122)
+- **削除順序を「フォルダ → DB」に入れ替え**: 旧実装は「DB 削除 → フォルダ削除 (失敗時警告)」だったため、フォルダ削除を諦めると「DB から消えたのにファイルだけ残る」中途半端状態になっていた。新実装はリセットの rename rollback と同じ思想で、フォルダ削除を先にやって失敗時は DB を温存する。「諦める」を選んだ場合はゲーム削除全体を中止し、ユーザーに「Launcher を閉じてから再度削除」を案内する
 
 #### Scope out (将来 Issue 候補)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,6 +419,30 @@
 
 ## Manager（管理ソフト）
 
+### [Manager v0.8.5] - 2026-05-10
+
+#### Added
+
+- **フォルダ削除失敗時の再試行 UI を追加 (#122)**: ゲーム削除や DB リセットでフォルダ削除に失敗した場合、従来は「警告 MessageBox 表示 → ユーザーが手動でなんとかする」だったが、専用ダイアログ `FolderDeletionFailureDialog` で「再試行」「諦める (手動削除)」を選べるように改善
+  - 主因は **Launcher が起動中ゲームの実行ファイルを掴んでいる** ケース。ユーザーが Launcher を閉じてから「再試行」を押すだけで解消する
+  - ダイアログには対象フォルダパス、エラー詳細 (Exception.Message)、対処手順 (Launcher を閉じてから再試行) を表示
+  - `AcceptButton = btnRetry` で Enter で再試行 (再試行は何度押しても安全)、`CancelButton = btnGiveUp` で ESC で諦める
+- **新規 `Services/FolderDeletionService.cs`**: フォルダ削除のリトライ機構を共通化 (5 回 × 200ms、`RestoreService.DeleteWithRetry` と同じパターン)。`IOException` / `UnauthorizedAccessException` のみリトライ対象、それ以外は throw
+- **新規 `FolderDeletionFailureDialog.cs` + `.Designer.cs` + `.resx`**: 上記再試行 UI のカスタム Form
+
+#### Changed
+
+- **`SchemaManager.ResetDatabase()` の戻り値を `string` → `FolderDeletionService.Result` に変更**: 退避フォルダ削除の Path / Exception を呼び出し側に渡せるようにし、再試行時に同じ path を使えるように構造化 (#122)
+- **`DatabaseManager.ResetDatabase()` の wrapper signature 更新**: 同様に `Result` を返す形に
+- **`SettingsSectionPanel.btnResetDatabase_Click`**: 退避フォルダ削除失敗時に `FolderDeletionFailureDialog` を表示する再試行ループに変更。「諦める」を選んだ場合のみ警告 MessageBox を表示 (#122)
+- **`GameSectionPanel.btnDeleteGame_Click`**: フォルダ削除を `ProcessingDialog` の外に出して再試行ループ化。`folderWarning` 文字列方式を廃止し、失敗時は `FolderDeletionFailureDialog` で対応 (#122)
+
+#### Scope out (将来 Issue 候補)
+
+- **ロックしてるプロセス特定 UI** (Restart Manager API 利用): 大規模で P/Invoke 必要、別 Issue として検討
+- **ファイルログ機構**: Issue [#116](https://github.com/ken1208git/GCTonePrism/issues/116) に依存
+- **「フォルダをエクスプローラで開く」ボタン**: ロック中はエクスプローラから消そうとしても同じく失敗するため、本質的解決にならず削除
+
 ### [Manager v0.8.4] - 2026-05-10
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,7 +436,11 @@
 - **`DatabaseManager.ResetDatabase()` の wrapper signature 更新**: 同様に `Result` を返す形に
 - **`SettingsSectionPanel.btnResetDatabase_Click`**: 退避フォルダ削除失敗時に `FolderDeletionFailureDialog` を表示する再試行ループに変更。「諦める」を選んだ場合のみ警告 MessageBox を表示 (#122)
 - **`GameSectionPanel.btnDeleteGame_Click`**: フォルダ削除を `ProcessingDialog` の外に出して再試行ループ化。`folderWarning` 文字列方式を廃止し、失敗時は `FolderDeletionFailureDialog` で対応 (#122)
-- **削除順序を「フォルダ → DB」に入れ替え**: 旧実装は「DB 削除 → フォルダ削除 (失敗時警告)」だったため、フォルダ削除を諦めると「DB から消えたのにファイルだけ残る」中途半端状態になっていた。新実装はリセットの rename rollback と同じ思想で、フォルダ削除を先にやって失敗時は DB を温存する。「諦める」を選んだ場合はゲーム削除全体を中止し、ユーザーに「Launcher を閉じてから再度削除」を案内する
+- **ゲーム削除を rename rollback パターンに刷新**: リセットと同じ 3 フェーズ「(1) `games/{gameId}/` を `.pending-delete-{guid}/` に rename で退避 → (2) DB 削除 → (3) 退避フォルダ物理削除」に統一 (Codex P1 #122 への対応)。これにより:
+  - フォルダ物理削除前に DB 削除が走るので、DB 削除失敗時 (SQLiteException 等) はフォルダを rename で戻して**何も変わらない状態にロールバック**でき、永続的データロストを排除
+  - (1) 失敗時 (Launcher ロック中など) は再試行 UI、諦めたら全体中止で DB 無事
+  - (3) 失敗時は DB 削除済みなのでゴミ退避フォルダだけ残るパターン (リセットと同じ)
+- 旧実装の「フォルダ物理削除 → DB 削除」順は、DB 失敗時にフォルダだけ消えて戻せない問題があった (PR #117 以来の負債)。本変更で完全解消
 
 #### Scope out (将来 Issue 候補)
 

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -301,8 +301,8 @@ namespace GCTonePrism.Manager.Controls
             // surveys / store_section_games が削除される。共有フォルダ越しでは
             // 数秒かかるケースもあるので Marquee 進捗を表示する。
             // 削除実行は DB レコード + games/{game_id}/ フォルダのセット (#111)。
+            // フォルダ削除は ProcessingDialog の外で行い、失敗時は再試行 UI を出す (#122)。
             Exception caught = null;
-            string folderWarning = null;
             using (var dialog = new ProcessingDialog((progress, token) =>
             {
                 try
@@ -310,30 +310,6 @@ namespace GCTonePrism.Manager.Controls
                     progress?.Report(new ProgressInfo(-1, "ゲームを削除中...",
                         $"「{selectedGame.Title}」と関連レコードをデータベースから削除しています"));
                     _dbManager.DeleteGame(selectedGame.GameId);
-
-                    if (deleteFolder && Directory.Exists(gameFolder))
-                    {
-                        progress?.Report(new ProgressInfo(-1, "ゲームフォルダを削除中...",
-                            gameFolder));
-                        try
-                        {
-                            Directory.Delete(gameFolder, true);
-                        }
-                        catch (IOException ioEx)
-                        {
-                            // ファイルがロックされている (Launcher 起動中など) / 一部削除済み等
-                            folderWarning = $"ゲームフォルダの削除中に問題が発生しました。\n\n" +
-                                $"{ioEx.Message}\n\n" +
-                                $"Launcher など他のプロセスがファイルを使用していないか確認し、" +
-                                $"必要に応じて手動で削除してください:\n  {gameFolder}";
-                        }
-                        catch (UnauthorizedAccessException uaEx)
-                        {
-                            folderWarning = $"ゲームフォルダへのアクセスが拒否されました。\n\n" +
-                                $"{uaEx.Message}\n\n" +
-                                $"フォルダのアクセス権限を確認してください:\n  {gameFolder}";
-                        }
-                    }
                 }
                 catch (Exception ex)
                 {
@@ -352,7 +328,7 @@ namespace GCTonePrism.Manager.Controls
                 {
                     if (caught is System.Data.SQLite.SQLiteException sqEx)
                     {
-                        MessageBox.Show(
+                        MessageBox.Show(this.FindForm(),
                             $"ゲームの削除に失敗しました。\n\n{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}",
                             "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     }
@@ -361,10 +337,35 @@ namespace GCTonePrism.Manager.Controls
                 }
             }
 
-            if (folderWarning != null)
+            // ここまで来た = DB 削除は成功。フォルダ削除を再試行ループで実行 (#122)
+            // 失敗時は FolderDeletionFailureDialog を出してユーザーに「再試行」or「諦める」を選ばせる
+            bool folderGivenUp = false;
+            if (deleteFolder && Directory.Exists(gameFolder))
             {
-                MessageBox.Show(this.FindForm(), folderWarning, "ゲームフォルダ削除の警告",
-                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                while (true)
+                {
+                    var result = FolderDeletionService.TryDelete(gameFolder);
+                    if (result.Success) break;
+
+                    using (var failDialog = new FolderDeletionFailureDialog(gameFolder, result.LastError))
+                    {
+                        var dr = failDialog.ShowDialog(this.FindForm());
+                        if (dr != DialogResult.Retry)
+                        {
+                            folderGivenUp = true;
+                            break;
+                        }
+                        // Retry の場合はループ継続 (再度 TryDelete を試す)
+                    }
+                }
+            }
+
+            if (folderGivenUp)
+            {
+                MessageBox.Show(this.FindForm(),
+                    "ゲームのデータベース削除は完了しましたが、フォルダの削除を諦めました。\n" +
+                    "後で手動削除してください:\n  " + gameFolder,
+                    "ゲームフォルダ削除の警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             else
             {

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -297,55 +297,53 @@ namespace GCTonePrism.Manager.Controls
                 deleteFolder = confirm.DeleteFolder;
             }
 
-            // 削除順序: フォルダ削除 → DB 削除 (#122 順序見直し)
-            // 旧: DB 削除 → フォルダ削除 だと、フォルダ削除を「諦める」した時に
-            //     「DB から消えたのにファイルだけ残る」中途半端状態になっていた。
-            // 新: フォルダを先に消して、失敗時は DB を温存 (リセットの rename rollback と同じ思想)。
-            //     フォルダ削除成功 (or 元から不在) なら DB を削除する。
+            // 削除フローは rename rollback パターン (リセットと同じ思想、Codex P1 #122):
+            //   (1) games/{gameId}/ を games/{gameId}.pending-delete-{guid}/ に rename で退避
+            //       失敗 = Launcher 等がファイルロック中 → 再試行 UI、諦めたら全体中止
+            //   (2) DB 削除 (CASCADE 含む)
+            //       失敗 = (1) の rename を戻して「何も変わらない」状態にロールバック → throw
+            //   (3) 退避フォルダを物理削除
+            //       失敗 = DB は消えたので戻れない、再試行 UI で対処 (諦めたらゴミ残るが Manager は普通に動く)
+            // これでフォルダ物理削除前に DB 削除が走るので、永続的なデータロストの可能性を排除。
 
-            // フェーズ 1: フォルダ削除 (失敗時は再試行ループ、諦めたら全体中止)
+            string pendingDeleteFolder = gameFolder + ".pending-delete-" + Guid.NewGuid().ToString("N");
+            bool gamesRenamed = false;
+
+            // フェーズ 1: フォルダ rename で退避 (失敗時は再試行ループ、諦めたら全体中止)
             if (deleteFolder && Directory.Exists(gameFolder))
             {
                 while (true)
                 {
-                    FolderDeletionService.Result result = null;
-                    using (var dialog = new ProcessingDialog((progress, token) =>
+                    Exception renameError = null;
+                    try
                     {
-                        progress?.Report(new ProgressInfo(-1, "ゲームフォルダを削除中...", gameFolder));
-                        result = FolderDeletionService.TryDelete(gameFolder);
-                    })
-                    {
-                        Text = "ゲーム削除中",
-                        MarqueeMode = true,
-                        AllowCancel = false
-                    })
-                    {
-                        dialog.ShowDialog(this.FindForm());
+                        Directory.Move(gameFolder, pendingDeleteFolder);
+                        gamesRenamed = true;
+                        break;
                     }
+                    catch (IOException ex) { renameError = ex; }
+                    catch (UnauthorizedAccessException ex) { renameError = ex; }
 
-                    if (result != null && result.Success) break;
-
-                    using (var failDialog = new FolderDeletionFailureDialog(gameFolder, result?.LastError))
+                    using (var failDialog = new FolderDeletionFailureDialog(gameFolder, renameError))
                     {
                         var dr = failDialog.ShowDialog(this.FindForm());
                         if (dr != DialogResult.Retry)
                         {
-                            // 諦めた → DB は触らずに中止 (フォルダもそのまま残る)
                             MessageBox.Show(this.FindForm(),
-                                "フォルダを削除できなかったため、ゲーム削除を中止しました。\n" +
+                                "フォルダを退避できなかったため、ゲーム削除を中止しました。\n" +
                                 "Launcher を閉じてから再度「削除」をお試しください。",
                                 "中止", MessageBoxButtons.OK, MessageBoxIcon.Information);
                             return;
                         }
-                        // Retry の場合はループ継続
                     }
                 }
             }
 
             // フェーズ 2: DB 削除 (CASCADE で developers / game_versions / game_genres /
             //   play_records / surveys / store_section_games も削除される)
-            //   ここまで来た = フォルダ削除成功 (または元から不在)、DB を消すフェーズ
+            //   失敗時は (1) で退避したフォルダを games/{gameId}/ に戻して全体ロールバック
             Exception caught = null;
+            DialogResult dbDr;
             using (var dialog = new ProcessingDialog((progress, token) =>
             {
                 try
@@ -357,6 +355,11 @@ namespace GCTonePrism.Manager.Controls
                 catch (Exception ex)
                 {
                     caught = ex;
+                    // ロールバック: 退避フォルダを games/{gameId}/ に戻す
+                    if (gamesRenamed && Directory.Exists(pendingDeleteFolder) && !Directory.Exists(gameFolder))
+                    {
+                        try { Directory.Move(pendingDeleteFolder, gameFolder); } catch { /* best effort */ }
+                    }
                     throw;
                 }
             })
@@ -366,27 +369,58 @@ namespace GCTonePrism.Manager.Controls
                 AllowCancel = false
             })
             {
-                var dr = dialog.ShowDialog(this.FindForm());
-                if (dr != DialogResult.OK)
+                dbDr = dialog.ShowDialog(this.FindForm());
+            }
+
+            if (dbDr != DialogResult.OK)
+            {
+                if (caught is System.Data.SQLite.SQLiteException sqEx)
                 {
-                    // フォルダは既に消えてしまっているがロールバック不能。
-                    // ユーザーに「DB 削除失敗、再度削除ボタンで DB だけ消えます」と通知
-                    if (caught is System.Data.SQLite.SQLiteException sqEx)
+                    MessageBox.Show(this.FindForm(),
+                        $"データベースからの削除に失敗しました。フォルダは元に戻されています。\n\n{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}",
+                        "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+                // それ以外は ProcessingDialog 内で MessageBox 表示済み
+                LoadGames();
+                return;
+            }
+
+            // フェーズ 3: 退避フォルダを物理削除 (失敗時は再試行 UI)
+            //   ここまで来た = DB 削除成功。退避フォルダ物理削除に失敗してもゴミとして残るだけで
+            //   Manager は普通に動く (リセットの Step 4 と同じ位置付け)。
+            bool pendingGivenUp = false;
+            if (gamesRenamed)
+            {
+                while (true)
+                {
+                    var result = FolderDeletionService.TryDelete(pendingDeleteFolder);
+                    if (result.Success) break;
+
+                    using (var failDialog = new FolderDeletionFailureDialog(pendingDeleteFolder, result.LastError))
                     {
-                        MessageBox.Show(this.FindForm(),
-                            $"ゲームフォルダは削除されましたが、データベース削除に失敗しました。\n" +
-                            $"再度「削除」を実行するとデータベースから消えます。\n\n" +
-                            $"{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}",
-                            "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        var dr = failDialog.ShowDialog(this.FindForm());
+                        if (dr != DialogResult.Retry)
+                        {
+                            pendingGivenUp = true;
+                            break;
+                        }
                     }
-                    LoadGames();
-                    return;
                 }
             }
 
-            MessageBox.Show(this.FindForm(),
-                deleteFolder ? "ゲームと関連フォルダを削除しました。" : "ゲームを削除しました。",
-                "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            if (pendingGivenUp)
+            {
+                MessageBox.Show(this.FindForm(),
+                    "ゲームを削除しましたが、退避済みのフォルダの物理削除を諦めました。\n" +
+                    "後で手動削除してください:\n  " + pendingDeleteFolder,
+                    "ゲームフォルダ削除の警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+            else
+            {
+                MessageBox.Show(this.FindForm(),
+                    deleteFolder ? "ゲームと関連フォルダを削除しました。" : "ゲームを削除しました。",
+                    "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
             LoadGames();
         }
 

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -321,6 +321,14 @@ namespace GCTonePrism.Manager.Controls
                         gamesRenamed = true;
                         break;
                     }
+                    catch (DirectoryNotFoundException)
+                    {
+                        // 初期 Directory.Exists チェック後に他プロセスがフォルダを削除した
+                        // race condition。既にフォルダは無く削除目的は達成しているので
+                        // 「rename してない」扱いで次のフェーズ (DB 削除) に進む (Codex P2 #122)
+                        gamesRenamed = false;
+                        break;
+                    }
                     catch (IOException ex) { renameError = ex; }
                     catch (UnauthorizedAccessException ex) { renameError = ex; }
 

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -342,7 +342,10 @@ namespace GCTonePrism.Manager.Controls
             // フェーズ 2: DB 削除 (CASCADE で developers / game_versions / game_genres /
             //   play_records / surveys / store_section_games も削除される)
             //   失敗時は (1) で退避したフォルダを games/{gameId}/ に戻して全体ロールバック
+            //   ロールバック失敗 (権限変更・他プロセスが games/{gameId}/ を再作成した等) は
+            //   rollbackError に記録し、後段で正確に通知する (Codex P2 #122)
             Exception caught = null;
+            Exception rollbackError = null;
             DialogResult dbDr;
             using (var dialog = new ProcessingDialog((progress, token) =>
             {
@@ -358,7 +361,15 @@ namespace GCTonePrism.Manager.Controls
                     // ロールバック: 退避フォルダを games/{gameId}/ に戻す
                     if (gamesRenamed && Directory.Exists(pendingDeleteFolder) && !Directory.Exists(gameFolder))
                     {
-                        try { Directory.Move(pendingDeleteFolder, gameFolder); } catch { /* best effort */ }
+                        try { Directory.Move(pendingDeleteFolder, gameFolder); }
+                        catch (Exception rbEx) { rollbackError = rbEx; }
+                    }
+                    else if (gamesRenamed && Directory.Exists(gameFolder))
+                    {
+                        // 何らかの理由で games/{gameId}/ が既に存在する (例: 別プロセスが再作成) →
+                        // 安全にロールバックできない
+                        rollbackError = new IOException(
+                            $"ロールバック先 '{gameFolder}' が既に存在するためロールバックできません。");
                     }
                     throw;
                 }
@@ -374,13 +385,39 @@ namespace GCTonePrism.Manager.Controls
 
             if (dbDr != DialogResult.OK)
             {
+                string baseMsg;
                 if (caught is System.Data.SQLite.SQLiteException sqEx)
                 {
-                    MessageBox.Show(this.FindForm(),
-                        $"データベースからの削除に失敗しました。フォルダは元に戻されています。\n\n{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}",
-                        "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    baseMsg = $"データベースからの削除に失敗しました。\n\n{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}";
                 }
-                // それ以外は ProcessingDialog 内で MessageBox 表示済み
+                else
+                {
+                    baseMsg = "データベースからの削除に失敗しました。" +
+                        (caught != null ? $"\n\n{caught.Message}" : "");
+                }
+
+                string rollbackMsg;
+                if (!gamesRenamed)
+                {
+                    rollbackMsg = ""; // 元々 rename していないので戻す対象なし
+                }
+                else if (rollbackError != null)
+                {
+                    // ロールバック失敗 → 嘘をつかず正確に通知
+                    rollbackMsg = "\n\n【さらに重要】退避フォルダの復元にも失敗しました。\n" +
+                        $"  退避先: {pendingDeleteFolder}\n" +
+                        $"  本来の場所: {gameFolder}\n" +
+                        $"手動で退避先を本来の場所に戻してください。\n\n復元失敗の詳細: {rollbackError.Message}";
+                }
+                else
+                {
+                    rollbackMsg = "\n\nフォルダは元に戻されています。";
+                }
+
+                MessageBox.Show(this.FindForm(),
+                    baseMsg + rollbackMsg,
+                    "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+
                 LoadGames();
                 return;
             }

--- a/GCTonePrism_Manager/Controls/GameSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/GameSectionPanel.cs
@@ -297,17 +297,60 @@ namespace GCTonePrism.Manager.Controls
                 deleteFolder = confirm.DeleteFolder;
             }
 
-            // CASCADE で developers / game_versions / game_genres / play_records /
-            // surveys / store_section_games が削除される。共有フォルダ越しでは
-            // 数秒かかるケースもあるので Marquee 進捗を表示する。
-            // 削除実行は DB レコード + games/{game_id}/ フォルダのセット (#111)。
-            // フォルダ削除は ProcessingDialog の外で行い、失敗時は再試行 UI を出す (#122)。
+            // 削除順序: フォルダ削除 → DB 削除 (#122 順序見直し)
+            // 旧: DB 削除 → フォルダ削除 だと、フォルダ削除を「諦める」した時に
+            //     「DB から消えたのにファイルだけ残る」中途半端状態になっていた。
+            // 新: フォルダを先に消して、失敗時は DB を温存 (リセットの rename rollback と同じ思想)。
+            //     フォルダ削除成功 (or 元から不在) なら DB を削除する。
+
+            // フェーズ 1: フォルダ削除 (失敗時は再試行ループ、諦めたら全体中止)
+            if (deleteFolder && Directory.Exists(gameFolder))
+            {
+                while (true)
+                {
+                    FolderDeletionService.Result result = null;
+                    using (var dialog = new ProcessingDialog((progress, token) =>
+                    {
+                        progress?.Report(new ProgressInfo(-1, "ゲームフォルダを削除中...", gameFolder));
+                        result = FolderDeletionService.TryDelete(gameFolder);
+                    })
+                    {
+                        Text = "ゲーム削除中",
+                        MarqueeMode = true,
+                        AllowCancel = false
+                    })
+                    {
+                        dialog.ShowDialog(this.FindForm());
+                    }
+
+                    if (result != null && result.Success) break;
+
+                    using (var failDialog = new FolderDeletionFailureDialog(gameFolder, result?.LastError))
+                    {
+                        var dr = failDialog.ShowDialog(this.FindForm());
+                        if (dr != DialogResult.Retry)
+                        {
+                            // 諦めた → DB は触らずに中止 (フォルダもそのまま残る)
+                            MessageBox.Show(this.FindForm(),
+                                "フォルダを削除できなかったため、ゲーム削除を中止しました。\n" +
+                                "Launcher を閉じてから再度「削除」をお試しください。",
+                                "中止", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                            return;
+                        }
+                        // Retry の場合はループ継続
+                    }
+                }
+            }
+
+            // フェーズ 2: DB 削除 (CASCADE で developers / game_versions / game_genres /
+            //   play_records / surveys / store_section_games も削除される)
+            //   ここまで来た = フォルダ削除成功 (または元から不在)、DB を消すフェーズ
             Exception caught = null;
             using (var dialog = new ProcessingDialog((progress, token) =>
             {
                 try
                 {
-                    progress?.Report(new ProgressInfo(-1, "ゲームを削除中...",
+                    progress?.Report(new ProgressInfo(-1, "データベースから削除中...",
                         $"「{selectedGame.Title}」と関連レコードをデータベースから削除しています"));
                     _dbManager.DeleteGame(selectedGame.GameId);
                 }
@@ -326,53 +369,24 @@ namespace GCTonePrism.Manager.Controls
                 var dr = dialog.ShowDialog(this.FindForm());
                 if (dr != DialogResult.OK)
                 {
+                    // フォルダは既に消えてしまっているがロールバック不能。
+                    // ユーザーに「DB 削除失敗、再度削除ボタンで DB だけ消えます」と通知
                     if (caught is System.Data.SQLite.SQLiteException sqEx)
                     {
                         MessageBox.Show(this.FindForm(),
-                            $"ゲームの削除に失敗しました。\n\n{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}",
+                            $"ゲームフォルダは削除されましたが、データベース削除に失敗しました。\n" +
+                            $"再度「削除」を実行するとデータベースから消えます。\n\n" +
+                            $"{DatabaseManager.GetUserFriendlyErrorMessage(sqEx)}",
                             "データベースエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     }
-                    // それ以外は ProcessingDialog 内で MessageBox 表示済み
+                    LoadGames();
                     return;
                 }
             }
 
-            // ここまで来た = DB 削除は成功。フォルダ削除を再試行ループで実行 (#122)
-            // 失敗時は FolderDeletionFailureDialog を出してユーザーに「再試行」or「諦める」を選ばせる
-            bool folderGivenUp = false;
-            if (deleteFolder && Directory.Exists(gameFolder))
-            {
-                while (true)
-                {
-                    var result = FolderDeletionService.TryDelete(gameFolder);
-                    if (result.Success) break;
-
-                    using (var failDialog = new FolderDeletionFailureDialog(gameFolder, result.LastError))
-                    {
-                        var dr = failDialog.ShowDialog(this.FindForm());
-                        if (dr != DialogResult.Retry)
-                        {
-                            folderGivenUp = true;
-                            break;
-                        }
-                        // Retry の場合はループ継続 (再度 TryDelete を試す)
-                    }
-                }
-            }
-
-            if (folderGivenUp)
-            {
-                MessageBox.Show(this.FindForm(),
-                    "ゲームのデータベース削除は完了しましたが、フォルダの削除を諦めました。\n" +
-                    "後で手動削除してください:\n  " + gameFolder,
-                    "ゲームフォルダ削除の警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            }
-            else
-            {
-                MessageBox.Show(this.FindForm(),
-                    deleteFolder ? "ゲームと関連フォルダを削除しました。" : "ゲームを削除しました。",
-                    "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            }
+            MessageBox.Show(this.FindForm(),
+                deleteFolder ? "ゲームと関連フォルダを削除しました。" : "ゲームを削除しました。",
+                "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
             LoadGames();
         }
 

--- a/GCTonePrism_Manager/Controls/SettingsSectionPanel.cs
+++ b/GCTonePrism_Manager/Controls/SettingsSectionPanel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Windows.Forms;
+using GCTonePrism.Manager.Services;
 
 namespace GCTonePrism.Manager.Controls
 {
@@ -60,16 +61,17 @@ namespace GCTonePrism.Manager.Controls
 
             // ResetDatabase は DBファイル削除 + games フォルダ再構築 + テーブル再作成 +
             // マイグレーション再実行を行う。共有フォルダ越しでは時間がかかるので進捗バー表示。
-            // 戻り値は退避フォルダ物理削除に失敗した場合の警告メッセージ (null なら完全成功)。
+            // 戻り値は退避フォルダ物理削除の Result。Success=false なら DB / games は再構築済みだが
+            // 退避フォルダだけ残る状態なので、再試行 UI で対処する (#122 Group C)。
             // 真に失敗した場合は例外が ProcessingDialog 内でハンドリングされ DialogResult.Abort になる。
             Exception caught = null;
-            string warning = null;
+            FolderDeletionService.Result resetResult = null;
             using (var dialog = new ProcessingDialog((progress, token) =>
             {
                 try
                 {
                     progress?.Report(new ProgressInfo(-1, "データベースをリセット中...", "ファイル削除と再作成を実行しています"));
-                    warning = _dbManager.ResetDatabase();
+                    resetResult = _dbManager.ResetDatabase();
                 }
                 catch (Exception ex)
                 {
@@ -90,24 +92,38 @@ namespace GCTonePrism.Manager.Controls
                 }
             }
 
-            // ここまで来た = DB / games は再構築済み。UI リフレッシュは warning の有無に関わらず実行する
+            // ここまで来た = DB / games は再構築済み。UI リフレッシュは結果に関わらず実行する
             // (Codex P2 #121: 警告を例外で表現すると ProcessingDialog で Abort 扱いされて
             //  リフレッシュフックがスキップされ、UI が古いまま「失敗」と誤報告されていたため)
             UpdateVersionInfo();
             DatabaseReset?.Invoke();
 
-            if (warning != null)
+            // 退避フォルダ削除に失敗した場合は再試行 UI を出す (#122)
+            // ユーザーが Launcher を閉じてから「再試行」を押せばロックが解放されて削除成功する想定
+            while (resetResult != null && !resetResult.Success)
             {
-                MessageBox.Show(this,
-                    "データベースのリセットは完了しましたが、警告があります:\n\n" + warning,
-                    "警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                using (var failDialog = new FolderDeletionFailureDialog(resetResult.Path, resetResult.LastError))
+                {
+                    var dr = failDialog.ShowDialog(this);
+                    if (dr == DialogResult.Retry)
+                    {
+                        resetResult = FolderDeletionService.TryDelete(resetResult.Path);
+                    }
+                    else
+                    {
+                        // 諦めた場合は警告 MessageBox を出して終了 (退避フォルダはゴミとして残る)
+                        MessageBox.Show(this,
+                            "データベースのリセットは完了しましたが、退避済みの旧 games フォルダの削除を諦めました。\n" +
+                            "後で手動削除してください:\n  " + resetResult.Path,
+                            "警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        return;
+                    }
+                }
             }
-            else
-            {
-                MessageBox.Show(this,
-                    "データベースのリセットが完了しました。",
-                    "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            }
+
+            MessageBox.Show(this,
+                "データベースのリセットが完了しました。",
+                "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
     }
 }

--- a/GCTonePrism_Manager/DatabaseManager.cs
+++ b/GCTonePrism_Manager/DatabaseManager.cs
@@ -50,7 +50,7 @@ namespace GCTonePrism.Manager
         public int GetTargetDatabaseVersion() => _schema.GetTargetDatabaseVersion();
         public int GetActualDatabaseVersion() => _schema.GetActualDatabaseVersion();
         public void InitializeDatabase() => _schema.InitializeDatabase();
-        public string ResetDatabase() => _schema.ResetDatabase();
+        public Services.FolderDeletionService.Result ResetDatabase() => _schema.ResetDatabase();
 
         // --- ゲーム ---
         public List<GameInfo> GetAllGames() => _gameRepo.GetAll();

--- a/GCTonePrism_Manager/FolderDeletionFailureDialog.Designer.cs
+++ b/GCTonePrism_Manager/FolderDeletionFailureDialog.Designer.cs
@@ -1,0 +1,149 @@
+namespace GCTonePrism.Manager
+{
+    partial class FolderDeletionFailureDialog
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows フォーム デザイナーで生成されたコード
+
+        private void InitializeComponent()
+        {
+            this.lblTitle = new System.Windows.Forms.Label();
+            this.lblExplain = new System.Windows.Forms.Label();
+            this.txtFolderPath = new System.Windows.Forms.TextBox();
+            this.lblHint = new System.Windows.Forms.Label();
+            this.lblErrorHeader = new System.Windows.Forms.Label();
+            this.txtErrorDetail = new System.Windows.Forms.TextBox();
+            this.btnRetry = new System.Windows.Forms.Button();
+            this.btnGiveUp = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            //
+            // lblTitle
+            //
+            this.lblTitle.AutoSize = true;
+            this.lblTitle.Font = new System.Drawing.Font("MS UI Gothic", 11F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.lblTitle.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblTitle.Location = new System.Drawing.Point(20, 20);
+            this.lblTitle.Name = "lblTitle";
+            this.lblTitle.TabIndex = 0;
+            this.lblTitle.Text = "⚠ フォルダの削除に失敗しました";
+            //
+            // lblExplain
+            //
+            this.lblExplain.AutoSize = true;
+            this.lblExplain.Location = new System.Drawing.Point(20, 55);
+            this.lblExplain.Name = "lblExplain";
+            this.lblExplain.TabIndex = 1;
+            this.lblExplain.Text = "以下のフォルダを削除しようとしましたが、Launcher などがフォルダ内のファイルを\r\n掴んでいる可能性があります。";
+            //
+            // txtFolderPath
+            //
+            this.txtFolderPath.Font = new System.Drawing.Font("Consolas", 9F);
+            this.txtFolderPath.Location = new System.Drawing.Point(20, 100);
+            this.txtFolderPath.Name = "txtFolderPath";
+            this.txtFolderPath.ReadOnly = true;
+            this.txtFolderPath.Size = new System.Drawing.Size(560, 22);
+            this.txtFolderPath.TabIndex = 2;
+            this.txtFolderPath.BackColor = System.Drawing.SystemColors.Control;
+            //
+            // lblHint
+            //
+            this.lblHint.AutoSize = true;
+            this.lblHint.ForeColor = System.Drawing.Color.DimGray;
+            this.lblHint.Location = new System.Drawing.Point(20, 135);
+            this.lblHint.Name = "lblHint";
+            this.lblHint.TabIndex = 3;
+            this.lblHint.Text = "⇒ Launcher を閉じてから「再試行」を押すと、再度削除を試みます。";
+            //
+            // lblErrorHeader
+            //
+            this.lblErrorHeader.AutoSize = true;
+            this.lblErrorHeader.Location = new System.Drawing.Point(20, 170);
+            this.lblErrorHeader.Name = "lblErrorHeader";
+            this.lblErrorHeader.TabIndex = 4;
+            this.lblErrorHeader.Text = "失敗の詳細:";
+            //
+            // txtErrorDetail
+            //
+            this.txtErrorDetail.Font = new System.Drawing.Font("Consolas", 9F);
+            this.txtErrorDetail.Location = new System.Drawing.Point(20, 190);
+            this.txtErrorDetail.Multiline = true;
+            this.txtErrorDetail.Name = "txtErrorDetail";
+            this.txtErrorDetail.ReadOnly = true;
+            this.txtErrorDetail.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtErrorDetail.Size = new System.Drawing.Size(560, 90);
+            this.txtErrorDetail.TabIndex = 5;
+            this.txtErrorDetail.BackColor = System.Drawing.SystemColors.Control;
+            //
+            // btnRetry
+            //
+            this.btnRetry.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRetry.BackColor = System.Drawing.Color.SteelBlue;
+            this.btnRetry.Font = new System.Drawing.Font("MS UI Gothic", 9.5F, System.Drawing.FontStyle.Bold);
+            this.btnRetry.ForeColor = System.Drawing.Color.White;
+            this.btnRetry.Location = new System.Drawing.Point(320, 305);
+            this.btnRetry.Name = "btnRetry";
+            this.btnRetry.Size = new System.Drawing.Size(110, 35);
+            this.btnRetry.TabIndex = 6;
+            this.btnRetry.Text = "再試行";
+            this.btnRetry.UseVisualStyleBackColor = false;
+            this.btnRetry.Click += new System.EventHandler(this.btnRetry_Click);
+            //
+            // btnGiveUp
+            //
+            this.btnGiveUp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnGiveUp.Location = new System.Drawing.Point(440, 305);
+            this.btnGiveUp.Name = "btnGiveUp";
+            this.btnGiveUp.Size = new System.Drawing.Size(140, 35);
+            this.btnGiveUp.TabIndex = 7;
+            this.btnGiveUp.Text = "諦める (手動削除)";
+            this.btnGiveUp.UseVisualStyleBackColor = true;
+            this.btnGiveUp.Click += new System.EventHandler(this.btnGiveUp_Click);
+            //
+            // FolderDeletionFailureDialog
+            //
+            this.AcceptButton = this.btnRetry;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnGiveUp;
+            this.ClientSize = new System.Drawing.Size(610, 360);
+            this.Controls.Add(this.btnGiveUp);
+            this.Controls.Add(this.btnRetry);
+            this.Controls.Add(this.txtErrorDetail);
+            this.Controls.Add(this.lblErrorHeader);
+            this.Controls.Add(this.lblHint);
+            this.Controls.Add(this.txtFolderPath);
+            this.Controls.Add(this.lblExplain);
+            this.Controls.Add(this.lblTitle);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "FolderDeletionFailureDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "フォルダ削除に失敗しました";
+            this.Load += new System.EventHandler(this.FolderDeletionFailureDialog_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblTitle;
+        private System.Windows.Forms.Label lblExplain;
+        private System.Windows.Forms.TextBox txtFolderPath;
+        private System.Windows.Forms.Label lblHint;
+        private System.Windows.Forms.Label lblErrorHeader;
+        private System.Windows.Forms.TextBox txtErrorDetail;
+        private System.Windows.Forms.Button btnRetry;
+        private System.Windows.Forms.Button btnGiveUp;
+    }
+}

--- a/GCTonePrism_Manager/FolderDeletionFailureDialog.Designer.cs
+++ b/GCTonePrism_Manager/FolderDeletionFailureDialog.Designer.cs
@@ -101,11 +101,11 @@ namespace GCTonePrism.Manager
             // btnGiveUp
             //
             this.btnGiveUp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnGiveUp.Location = new System.Drawing.Point(440, 305);
+            this.btnGiveUp.Location = new System.Drawing.Point(480, 305);
             this.btnGiveUp.Name = "btnGiveUp";
-            this.btnGiveUp.Size = new System.Drawing.Size(140, 35);
+            this.btnGiveUp.Size = new System.Drawing.Size(100, 35);
             this.btnGiveUp.TabIndex = 7;
-            this.btnGiveUp.Text = "諦める (手動削除)";
+            this.btnGiveUp.Text = "諦める";
             this.btnGiveUp.UseVisualStyleBackColor = true;
             this.btnGiveUp.Click += new System.EventHandler(this.btnGiveUp_Click);
             //

--- a/GCTonePrism_Manager/FolderDeletionFailureDialog.cs
+++ b/GCTonePrism_Manager/FolderDeletionFailureDialog.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Windows.Forms;
+
+namespace GCTonePrism.Manager
+{
+    /// <summary>
+    /// フォルダ削除に失敗した時の対応ダイアログ。
+    /// 失敗フォルダのパスと例外メッセージを表示し、ユーザーに「再試行」「諦める」を選ばせる。
+    /// 主因は Launcher など他プロセスがフォルダ内のファイルを掴んでいるケース。
+    /// その場合はユーザーが Launcher を閉じてから「再試行」を押すだけで解消する。
+    /// (#122 Group C 実装)
+    /// </summary>
+    public partial class FolderDeletionFailureDialog : Form
+    {
+        private readonly string _folderPath;
+        private readonly Exception _lastError;
+
+        public FolderDeletionFailureDialog(string folderPath, Exception lastError)
+        {
+            InitializeComponent();
+            _folderPath = folderPath ?? string.Empty;
+            _lastError = lastError;
+        }
+
+        private void FolderDeletionFailureDialog_Load(object sender, EventArgs e)
+        {
+            txtFolderPath.Text = _folderPath;
+            txtErrorDetail.Text = _lastError != null ? _lastError.Message : "(詳細不明)";
+        }
+
+        private void btnRetry_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Retry;
+            Close();
+        }
+
+        private void btnGiveUp_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Ignore;
+            Close();
+        }
+    }
+}

--- a/GCTonePrism_Manager/FolderDeletionFailureDialog.resx
+++ b/GCTonePrism_Manager/FolderDeletionFailureDialog.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GCTonePrism_Manager/GCTonePrism_Manager.csproj
+++ b/GCTonePrism_Manager/GCTonePrism_Manager.csproj
@@ -90,6 +90,12 @@
     <Compile Include="DeleteGameConfirmForm.Designer.cs">
       <DependentUpon>DeleteGameConfirmForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="FolderDeletionFailureDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="FolderDeletionFailureDialog.Designer.cs">
+      <DependentUpon>FolderDeletionFailureDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="EditGameForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -184,6 +190,7 @@
     <Compile Include="Services\BackupService.cs" />
     <Compile Include="Services\DeveloperListManager.cs" />
     <Compile Include="Services\FileOperationService.cs" />
+    <Compile Include="Services\FolderDeletionService.cs" />
     <Compile Include="Services\GameFormHelper.cs" />
     <Compile Include="Services\ImagePreviewHelper.cs" />
     <Compile Include="Services\PathConversionHelper.cs" />
@@ -198,6 +205,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="DeleteGameConfirmForm.resx">
       <DependentUpon>DeleteGameConfirmForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FolderDeletionFailureDialog.resx">
+      <DependentUpon>FolderDeletionFailureDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="EditGameForm.resx">
       <DependentUpon>EditGameForm.cs</DependentUpon>

--- a/GCTonePrism_Manager/Properties/AssemblyInfo.cs
+++ b/GCTonePrism_Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.8.4.0")]
-[assembly: AssemblyFileVersion("0.8.4.0")]
+[assembly: AssemblyVersion("0.8.5.0")]
+[assembly: AssemblyFileVersion("0.8.5.0")]

--- a/GCTonePrism_Manager/SchemaManager.cs
+++ b/GCTonePrism_Manager/SchemaManager.cs
@@ -116,13 +116,13 @@ namespace GCTonePrism.Manager
         /// rename 自体が失敗するが、その場合も DB は無傷のまま中止できる。
         /// </summary>
         /// <returns>
-        /// 完全成功時は null、退避フォルダ物理削除に失敗した場合は警告メッセージを返す。
-        /// 警告ありでも DB / games/ は再構築済みなので呼び出し側は UI 更新を実行すべき
-        /// (Codex P2 指摘 #121: 「成功 + 警告」を例外で表現すると ProcessingDialog 経由で
-        /// 失敗扱いされて UI リフレッシュフックがスキップされるため、戻り値で表現する)。
-        /// 真に失敗 (rename 失敗 / DB 削除失敗) した場合は IOException 等を throw する。
+        /// 退避フォルダ物理削除の結果。Success=true なら完全成功 (退避フォルダも消えた)。
+        /// Success=false なら DB / games/ は再構築済みだが退避フォルダだけ残っている状態
+        /// (LastError と Path に詳細あり)。呼び出し側は Result を見て再試行 UI を出すか
+        /// 警告だけ表示するかを判断する (#122 Group C)。
+        /// 真に失敗 (rename 失敗 / DB 削除失敗 / 再初期化失敗) した場合は IOException 等を throw する。
         /// </returns>
-        public string ResetDatabase()
+        public Services.FolderDeletionService.Result ResetDatabase()
         {
             string dbPath = _conn.DbPath;
             string gamesFolder = PathManager.GamesFolder;
@@ -238,25 +238,11 @@ namespace GCTonePrism.Manager
             }
 
             // (4) 退避フォルダを物理削除を試みる（失敗しても DB / games は再構築済みなので
-            //     呼び出し側に警告を返すだけにする。Codex P2 #121: 例外でなく戻り値で表現）
+            //     呼び出し側に Result を返すだけにする。Codex P2 #121: 例外でなく戻り値で表現）
             //     rename はファイルロックを解除しないため、Launcher が起動中のゲームの
             //     実行ファイルを掴んでいるとここで IOException が出る可能性がある。
-            string pendingDeleteWarning = null;
-            if (Directory.Exists(pendingDeleteFolder))
-            {
-                try
-                {
-                    Directory.Delete(pendingDeleteFolder, true);
-                }
-                catch (Exception ex)
-                {
-                    pendingDeleteWarning =
-                        $"DB と games/ は再構築されましたが、退避済みの旧 games フォルダの物理削除に失敗しました。\n" +
-                        $"Launcher などがファイルを掴んでいる可能性があります。後で手動削除してください:\n  {pendingDeleteFolder}\n\n{ex.Message}";
-                }
-            }
-
-            return pendingDeleteWarning;
+            //     FolderDeletionService が内部で 5 × 200ms リトライしてから結果を返す (#122)
+            return Services.FolderDeletionService.TryDelete(pendingDeleteFolder);
         }
 
         private void CreateTables(SQLiteConnection connection, SQLiteTransaction transaction)

--- a/GCTonePrism_Manager/Services/FolderDeletionService.cs
+++ b/GCTonePrism_Manager/Services/FolderDeletionService.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace GCTonePrism.Manager.Services
+{
+    /// <summary>
+    /// フォルダ削除のリトライ機構を提供する static service。
+    /// SMB 共有上では Launcher 等が一瞬ファイルを掴むケースがあるため、
+    /// 短時間のリトライで大半の競合を解消できる。それでも失敗した場合は
+    /// 呼び出し側がユーザーに「再試行 / 諦める」を選ばせる UI を出す前提。
+    /// (#122 Group C 実装。RestoreService.DeleteWithRetry と同じ 5 回 × 200ms パターン)
+    /// </summary>
+    public static class FolderDeletionService
+    {
+        public class Result
+        {
+            public bool Success { get; set; }
+            public Exception LastError { get; set; }
+            public string Path { get; set; }
+        }
+
+        /// <summary>
+        /// フォルダを最大 5 回 × 200ms 間隔でリトライ削除する。
+        /// IOException / UnauthorizedAccessException のみ捕捉、それ以外は throw。
+        /// path が null/空、またはフォルダが存在しない場合は Success=true を返す。
+        /// </summary>
+        public static Result TryDelete(string path)
+        {
+            var result = new Result { Path = path };
+            if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+            {
+                result.Success = true;
+                return result;
+            }
+
+            const int maxRetries = 5;
+            const int delayMs = 200;
+
+            for (int i = 0; i < maxRetries; i++)
+            {
+                try
+                {
+                    Directory.Delete(path, true);
+                    result.Success = true;
+                    return result;
+                }
+                catch (IOException ex)
+                {
+                    result.LastError = ex;
+                    if (i == maxRetries - 1) return result;
+                    Thread.Sleep(delayMs);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    result.LastError = ex;
+                    if (i == maxRetries - 1) return result;
+                    Thread.Sleep(delayMs);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -411,7 +411,8 @@
   - 削除前の確認ダイアログ（`DeleteGameConfirmForm`）に削除対象のフォルダパスを表示し、ディスクから物理的に消える旨を警告色で明示
   - `Enter` キー誤操作を防ぐため `AcceptButton` はキャンセルに割り当て
   - フォルダが存在しない場合（手動削除済み等）は表示を「フォルダが見つかりません。DB のみ削除します」に切り替えて DB 削除のみ実行（無害）
-  - 削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、DB 削除は成功した上で再試行 UI (`FolderDeletionFailureDialog`、Manager v0.8.5 / #122) を表示。ユーザーは Launcher を閉じてから「再試行」を押せば削除成功、「諦める」を選べば警告 MessageBox で手動削除を案内
+  - 削除順序は **「(1) フォルダ削除 → (2) DB 削除」** (Manager v0.8.5 / #122)。フォルダ削除に失敗して「諦める」を選んだ場合はゲーム削除全体を中止 (DB / フォルダ両方とも触らない、Launcher を閉じてから再度削除を促す)。リセットの rename rollback と同じ「失敗時は何も変えない」思想に揃えた
+  - フォルダ削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、再試行 UI (`FolderDeletionFailureDialog`) を表示。ユーザーは Launcher を閉じてから「再試行」を押せば削除成功、「諦める」を選べば DB は触らずに削除全体を中止
   - フォルダ削除のリトライ機構は `Services.FolderDeletionService.TryDelete` (5 回 × 200ms) を共通化して使用 (Manager v0.8.5 / #122)
 
 ##### 機能3: ゲーム情報編集機能
@@ -2519,6 +2520,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-10 | 1.9.8 | ゲーム削除の順序を「フォルダ → DB」に入れ替え (#122 Group C のレビュー反映)：旧実装は「DB 削除 → フォルダ削除 (失敗時警告)」で、フォルダ削除を諦めると「DB から消えたのにファイルだけ残る」中途半端状態だった。新実装ではフォルダ削除を先にやって失敗時は DB を温存 (リセットの rename rollback と同じ思想)。「諦める」を選ぶとゲーム削除全体を中止し、ユーザーに「Launcher を閉じてから再度削除」を案内。SPEC §2.2 機能2 を新挙動で書き直し。Manager v0.8.5 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.7 | フォルダ削除失敗時の再試行 UI を追加 (#122 Group C)：ゲーム削除や DB リセットでフォルダ削除に失敗した場合、新規 `FolderDeletionFailureDialog` で「再試行」「諦める」を選べる UX に。主因の Launcher ロックは「Launcher を閉じてから再試行」で解消する想定。リトライ機構は新規 `Services/FolderDeletionService.TryDelete` (5 回 × 200ms) を `RestoreService.DeleteWithRetry` パターンを参考に共通化。`SchemaManager.ResetDatabase` の戻り値を `string` から `FolderDeletionService.Result` に構造化し、呼び出し側で再試行ループを実装可能に。SPEC §2.2 機能2 (削除) と機能11 (リセット) に再試行 UI を追記。「フォルダをエクスプローラで開く」ボタンはロック中はエクスプローラからも消せないため本質的解決にならず削除。ロックプロセス特定 (Restart Manager API) と Manager ファイルログ (#116) は別 Issue として保留。Manager v0.8.5 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.6 | PR #121 への Codex P1 追加指摘への対応：`SchemaManager.ResetDatabase()` を **rename rollback 方式** に変更し、DB 削除失敗時に games フォルダを復元する設計に。中間失敗時でも Manager は再起動可能な状態を保証 (broken partial-reset 状態を排除)。`ResetDatabaseConfirmForm` に「すべての展示PCの Launcher を終了してから実行」警告を追加、`DeleteGameConfirmForm` に「該当ゲームを起動中の Launcher があれば閉じて」ヒントを追加（フォルダ削除失敗の主原因予防）。Edit/Add/VersionUp は影響軽微 + Launcher 側 `ErrorDialog` で十分対応可能と判断しスコープ外。SPEC §2.2 機能11 のリセット項目を rename rollback 設計に書き直し。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.5 | データベースリセット機能の確認画面と実装の整合化 (#119) と AddGameForm の gameId 重複検出 (#120)：§2.2 機能11「その他設定管理機能」配下に「データベースリセット機能」項目を新設し、削除実行 = `prism.db` + `games/` フォルダのセット削除（旧実装は DB のみで確認画面と齟齬していた）+ `backups/` 等の隣接フォルダは触らない方針 + 失敗時の挙動詰めは将来 Issue という整理を明記。§2.2 機能1「ゲーム追加機能」に「gameId 重複検出」項目を追加し、`games/{gameId}/` 残骸検出時は手動退避を促す警告 MessageBox を出す挙動を明記。フォルダ削除失敗時の UX 詰めは別 Issue として保留。Manager v0.8.4 で実装。 | Kenshiro Kuroga & Claude |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -411,8 +411,13 @@
   - 削除前の確認ダイアログ（`DeleteGameConfirmForm`）に削除対象のフォルダパスを表示し、ディスクから物理的に消える旨を警告色で明示
   - `Enter` キー誤操作を防ぐため `AcceptButton` はキャンセルに割り当て
   - フォルダが存在しない場合（手動削除済み等）は表示を「フォルダが見つかりません。DB のみ削除します」に切り替えて DB 削除のみ実行（無害）
-  - 削除順序は **「(1) フォルダ削除 → (2) DB 削除」** (Manager v0.8.5 / #122)。フォルダ削除に失敗して「諦める」を選んだ場合はゲーム削除全体を中止 (DB / フォルダ両方とも触らない、Launcher を閉じてから再度削除を促す)。リセットの rename rollback と同じ「失敗時は何も変えない」思想に揃えた
-  - フォルダ削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、再試行 UI (`FolderDeletionFailureDialog`) を表示。ユーザーは Launcher を閉じてから「再試行」を押せば削除成功、「諦める」を選べば DB は触らずに削除全体を中止
+  - 削除フローは **rename rollback パターン** (リセットと同じ 3 フェーズ、Manager v0.8.5 / #122):
+    1. `games/{gameId}/` を `games/{gameId}.pending-delete-{guid}/` に rename で退避
+    2. DB 削除 (CASCADE で関連レコードも削除)
+    3. 退避フォルダを物理削除
+  - 失敗パターン別の挙動: (1) rename 失敗 → 再試行 UI、諦めたら全体中止 (何も変わらない) / (2) DB 削除失敗 → 退避を rename で戻してロールバック → throw / (3) 退避物理削除失敗 → 再試行 UI、諦めたらゴミ退避フォルダだけ残る (DB / games は確定状態)
+  - フォルダ物理削除前に DB 削除が走るので、DB 削除失敗時にフォルダだけ消える永続データロストを排除 (Codex P1 #122)
+  - フォルダ削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、再試行 UI (`FolderDeletionFailureDialog`) を表示
   - フォルダ削除のリトライ機構は `Services.FolderDeletionService.TryDelete` (5 回 × 200ms) を共通化して使用 (Manager v0.8.5 / #122)
 
 ##### 機能3: ゲーム情報編集機能
@@ -2520,6 +2525,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-10 | 1.9.9 | ゲーム削除を rename rollback パターンに刷新 (Codex P1 #122)：旧実装は「フォルダ物理削除 → DB 削除」順だったため、DB 削除失敗時 (SQLiteException 等) にフォルダだけ消えて戻せない問題があった。新実装はリセットと同じ 3 フェーズ「(1) rename で退避 → (2) DB 削除 → (3) 退避物理削除」に統一し、(2) 失敗時は (1) を rename で戻してロールバックする。永続的データロストを排除。SPEC §2.2 機能2 を新フローで書き直し。Manager v0.8.5 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.8 | ゲーム削除の順序を「フォルダ → DB」に入れ替え (#122 Group C のレビュー反映)：旧実装は「DB 削除 → フォルダ削除 (失敗時警告)」で、フォルダ削除を諦めると「DB から消えたのにファイルだけ残る」中途半端状態だった。新実装ではフォルダ削除を先にやって失敗時は DB を温存 (リセットの rename rollback と同じ思想)。「諦める」を選ぶとゲーム削除全体を中止し、ユーザーに「Launcher を閉じてから再度削除」を案内。SPEC §2.2 機能2 を新挙動で書き直し。Manager v0.8.5 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.7 | フォルダ削除失敗時の再試行 UI を追加 (#122 Group C)：ゲーム削除や DB リセットでフォルダ削除に失敗した場合、新規 `FolderDeletionFailureDialog` で「再試行」「諦める」を選べる UX に。主因の Launcher ロックは「Launcher を閉じてから再試行」で解消する想定。リトライ機構は新規 `Services/FolderDeletionService.TryDelete` (5 回 × 200ms) を `RestoreService.DeleteWithRetry` パターンを参考に共通化。`SchemaManager.ResetDatabase` の戻り値を `string` から `FolderDeletionService.Result` に構造化し、呼び出し側で再試行ループを実装可能に。SPEC §2.2 機能2 (削除) と機能11 (リセット) に再試行 UI を追記。「フォルダをエクスプローラで開く」ボタンはロック中はエクスプローラからも消せないため本質的解決にならず削除。ロックプロセス特定 (Restart Manager API) と Manager ファイルログ (#116) は別 Issue として保留。Manager v0.8.5 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.6 | PR #121 への Codex P1 追加指摘への対応：`SchemaManager.ResetDatabase()` を **rename rollback 方式** に変更し、DB 削除失敗時に games フォルダを復元する設計に。中間失敗時でも Manager は再起動可能な状態を保証 (broken partial-reset 状態を排除)。`ResetDatabaseConfirmForm` に「すべての展示PCの Launcher を終了してから実行」警告を追加、`DeleteGameConfirmForm` に「該当ゲームを起動中の Launcher があれば閉じて」ヒントを追加（フォルダ削除失敗の主原因予防）。Edit/Add/VersionUp は影響軽微 + Launcher 側 `ErrorDialog` で十分対応可能と判断しスコープ外。SPEC §2.2 機能11 のリセット項目を rename rollback 設計に書き直し。 | Kenshiro Kuroga & Claude |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -411,7 +411,8 @@
   - 削除前の確認ダイアログ（`DeleteGameConfirmForm`）に削除対象のフォルダパスを表示し、ディスクから物理的に消える旨を警告色で明示
   - `Enter` キー誤操作を防ぐため `AcceptButton` はキャンセルに割り当て
   - フォルダが存在しない場合（手動削除済み等）は表示を「フォルダが見つかりません。DB のみ削除します」に切り替えて DB 削除のみ実行（無害）
-  - 削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、DB 削除は成功した上で「フォルダ削除に失敗、手動削除してください」の警告に切り替える非破壊運用
+  - 削除中に `IOException`（Launcher など他プロセスがフォルダ内のファイルをロック中）や `UnauthorizedAccessException` が発生した場合は、DB 削除は成功した上で再試行 UI (`FolderDeletionFailureDialog`、Manager v0.8.5 / #122) を表示。ユーザーは Launcher を閉じてから「再試行」を押せば削除成功、「諦める」を選べば警告 MessageBox で手動削除を案内
+  - フォルダ削除のリトライ機構は `Services.FolderDeletionService.TryDelete` (5 回 × 200ms) を共通化して使用 (Manager v0.8.5 / #122)
 
 ##### 機能3: ゲーム情報編集機能
 
@@ -518,7 +519,8 @@
       3. `games/` を再作成 + DB 再初期化
       4. 退避フォルダを物理削除
     - 失敗パターン別の挙動: (1) games rename 失敗 → 何も変わらず throw / (2) DB 削除失敗 → games を rename で復元 (ロールバック) してから throw / (3) games/ 再作成 or DB 再初期化失敗 → 部分作成された games/ と prism.db を削除 + 退避を games/ に戻して throw（DB だけ消えた状態でバックアップ #96 から復元可能） / (4) 退避フォルダ物理削除失敗 → 戻り値で警告メッセージを返す（DB / games 再構築済み + ゴミ退避フォルダだけ残る、Launcher が起動中ゲームの実行ファイルを掴んでいると起き得る）。**いずれの中間失敗でも Manager は再起動可能**
-    - **`ResetDatabase()` の戻り値**: 完全成功は `null`、退避フォルダ削除に失敗した場合は警告メッセージ文字列。呼び出し側 (`SettingsSectionPanel.btnResetDatabase_Click`) は warning の有無に関わらず `UpdateVersionInfo()` / `DatabaseReset?.Invoke()` を実行し、warning があれば情報 MessageBox で通知する。例外で表現すると ProcessingDialog 経由で「失敗」扱いされて UI リフレッシュフックがスキップされてしまうため、戻り値で「成功 + 警告」を表現する設計
+    - **`ResetDatabase()` の戻り値**: `Services.FolderDeletionService.Result` 型 (Manager v0.8.5 で `string` から構造化)。Success=true は完全成功、Success=false は退避フォルダ削除失敗（DB / games は再構築済み）で Path / LastError に詳細あり。呼び出し側 (`SettingsSectionPanel.btnResetDatabase_Click`) は結果に関わらず `UpdateVersionInfo()` / `DatabaseReset?.Invoke()` を実行し、Success=false なら `FolderDeletionFailureDialog` で再試行ループを提供する
+    - **再試行 UI** (`FolderDeletionFailureDialog`、Manager v0.8.5 / #122 Group C): 退避フォルダ削除失敗時、ユーザーが Launcher を閉じてから「再試行」ボタンを押せばロック解放されて削除成功する想定。失敗詳細 (Exception.Message) も表示。「諦める」を選んだ場合は警告 MessageBox で手動削除を案内
     - `backups/` 等の隣接フォルダは触らない（復元用に残す）
     - 確認画面 (`ResetDatabaseConfirmForm`) に「すべての展示PCの Launcher を終了してから実行」警告を表示
     - 実行前にバックアップ機能 (#96 / Manager v0.8.0) で `prism.db` のスナップショット取得を強く推奨
@@ -2517,6 +2519,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-10 | 1.9.7 | フォルダ削除失敗時の再試行 UI を追加 (#122 Group C)：ゲーム削除や DB リセットでフォルダ削除に失敗した場合、新規 `FolderDeletionFailureDialog` で「再試行」「諦める」を選べる UX に。主因の Launcher ロックは「Launcher を閉じてから再試行」で解消する想定。リトライ機構は新規 `Services/FolderDeletionService.TryDelete` (5 回 × 200ms) を `RestoreService.DeleteWithRetry` パターンを参考に共通化。`SchemaManager.ResetDatabase` の戻り値を `string` から `FolderDeletionService.Result` に構造化し、呼び出し側で再試行ループを実装可能に。SPEC §2.2 機能2 (削除) と機能11 (リセット) に再試行 UI を追記。「フォルダをエクスプローラで開く」ボタンはロック中はエクスプローラからも消せないため本質的解決にならず削除。ロックプロセス特定 (Restart Manager API) と Manager ファイルログ (#116) は別 Issue として保留。Manager v0.8.5 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.6 | PR #121 への Codex P1 追加指摘への対応：`SchemaManager.ResetDatabase()` を **rename rollback 方式** に変更し、DB 削除失敗時に games フォルダを復元する設計に。中間失敗時でも Manager は再起動可能な状態を保証 (broken partial-reset 状態を排除)。`ResetDatabaseConfirmForm` に「すべての展示PCの Launcher を終了してから実行」警告を追加、`DeleteGameConfirmForm` に「該当ゲームを起動中の Launcher があれば閉じて」ヒントを追加（フォルダ削除失敗の主原因予防）。Edit/Add/VersionUp は影響軽微 + Launcher 側 `ErrorDialog` で十分対応可能と判断しスコープ外。SPEC §2.2 機能11 のリセット項目を rename rollback 設計に書き直し。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.5 | データベースリセット機能の確認画面と実装の整合化 (#119) と AddGameForm の gameId 重複検出 (#120)：§2.2 機能11「その他設定管理機能」配下に「データベースリセット機能」項目を新設し、削除実行 = `prism.db` + `games/` フォルダのセット削除（旧実装は DB のみで確認画面と齟齬していた）+ `backups/` 等の隣接フォルダは触らない方針 + 失敗時の挙動詰めは将来 Issue という整理を明記。§2.2 機能1「ゲーム追加機能」に「gameId 重複検出」項目を追加し、`games/{gameId}/` 残骸検出時は手動退避を促す警告 MessageBox を出す挙動を明記。フォルダ削除失敗時の UX 詰めは別 Issue として保留。Manager v0.8.4 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.4 | ゲーム削除機能（機能2）の挙動を「DB レコード + `games/{game_id}/` フォルダのセット削除」に統一 (#111)：従来は SPEC §2.2 に「DB のみ / DB + フォルダ削除」の 2 オプションが記載されていたが、運用要望としては削除実行 = 両方削除が常に望ましく、Manager は DB 削除しか実装していなかったため `games/{game_id}/` フォルダがディスクに残る運用上の問題があった。オプション分岐は廃止し、新規 `DeleteGameConfirmForm` で削除対象のフォルダパスを表示して何が消えるかを明示した上で、削除実行時に常に `Directory.Delete(folder, true)` を呼び出す設計に変更。フォルダ不在時は表示を切り替えて DB 削除のみ実行（無害）、ファイルロック / 権限エラー時は「DB 削除は成功・フォルダは手動削除を」の警告に切り替える非破壊運用。SPEC §2.2 機能2 の記述を実装に合わせて書き直し。Manager v0.8.3 で実装。 | Kenshiro Kuroga & Claude |


### PR DESCRIPTION
Closes #122

## Summary

ゲーム削除や DB リセットでフォルダ削除に失敗した場合の UX を改善。従来の「警告 MessageBox 表示 → ユーザーが手動でなんとかする」を、専用ダイアログで「再試行」「諦める」を選べる形に変更。

主因の **Launcher が起動中ゲームの実行ファイルを掴んでいる** ケースは、ユーザーが Launcher を閉じてから「再試行」ボタンを押すだけで解消する。

## バージョン bump

- Manager: v0.8.4 → **v0.8.5**

## 新規ファイル

### `Services/FolderDeletionService.cs`
フォルダ削除のリトライ機構を共通化:
```csharp
public static class FolderDeletionService
{
    public class Result { bool Success; Exception LastError; string Path; }
    public static Result TryDelete(string path);  // 5 回 × 200ms リトライ
}
```
`RestoreService.DeleteWithRetry` と同じパターン (5 回 × 200ms)、`IOException` / `UnauthorizedAccessException` のみリトライ対象。

### `FolderDeletionFailureDialog` (.cs / .Designer.cs / .resx)
失敗時のカスタム Form。フォルダパス・エラー詳細・対処手順 (Launcher を閉じてから再試行) を表示し、`[再試行]` `[諦める (手動削除)]` の 2 ボタン。

```
┌── フォルダ削除に失敗しました ────────────────────┐
│ ⚠ フォルダの削除に失敗しました                  │
│ 以下のフォルダを削除しようとしましたが、        │
│ Launcher などがフォルダ内のファイルを           │
│ 掴んでいる可能性があります。                    │
│                                                  │
│ [ \school-server\share\games\xxx ]             │
│                                                  │
│ ⇒ Launcher を閉じてから「再試行」を押すと、    │
│   再度削除を試みます。                          │
│                                                  │
│ 失敗の詳細:                                     │
│ ┌──────────────────────────────────────────┐   │
│ │ The process cannot access the file ...   │   │
│ └──────────────────────────────────────────┘   │
│                                                  │
│              [再試行]  [諦める (手動削除)]      │
└──────────────────────────────────────────────────┘
```

- `AcceptButton = btnRetry`: Enter で再試行 (何度押しても安全)
- `CancelButton = btnGiveUp`: ESC で諦める
- `DialogResult.Retry` / `DialogResult.Ignore` で結果を返す

## 既存修正

### `SchemaManager.ResetDatabase`
- 戻り値を `string` → `FolderDeletionService.Result` に構造化
- Path / Exception を呼び出し側に渡せるようになり、再試行時に同じ path を使える
- Step 4 (退避フォルダ削除) を `FolderDeletionService.TryDelete()` に置換 (内部で 5 回リトライ)

### `DatabaseManager.ResetDatabase` wrapper
- 同様に戻り値型を `Result` に更新

### `SettingsSectionPanel.btnResetDatabase_Click`
- 退避フォルダ削除失敗時 (`Result.Success=false`) は `FolderDeletionFailureDialog` で再試行ループ
- 「諦める」を選んだ場合のみ警告 MessageBox を出す

### `GameSectionPanel.btnDeleteGame_Click`
- フォルダ削除を `ProcessingDialog` の外に出して再試行ループ化
- `folderWarning` 文字列方式を廃止し、失敗時は `FolderDeletionFailureDialog` で対応

## ドキュメント

- `CHANGELOG.md`: Manager v0.8.5 エントリ
- `SPECIFICATION.md` §2.2 機能2 (削除) と機能11 (リセット) に再試行 UI を追記
- `SPECIFICATION.md` 変更履歴 v1.9.7 として追記

## スコープ外 (将来 Issue 候補)

| 項目 | 理由 |
|---|---|
| ロックプロセス特定 UI (Restart Manager API) | P/Invoke で大規模、CI 困難。別 Issue として検討 |
| ファイルログ機構 | Issue [#116](https://github.com/ken1208git/GCTonePrism/issues/116) で対応 |
| 「フォルダをエクスプローラで開く」ボタン | ロック中はエクスプローラからも消せないため本質的解決にならず削除 (ユーザー判断) |

## Test plan

- [ ] 通常削除/リセット (失敗なし) → ダイアログ出ない、これまでと同じフロー
- [ ] Launcher で対象ゲームを起動した状態でゲーム削除 → DB 削除成功後に `FolderDeletionFailureDialog` 表示
- [ ] 「再試行」(Launcher 閉じてから) → フォルダ削除成功
- [ ] 「諦める」 → 警告 MessageBox + フォルダ残ったまま終了
- [ ] Launcher 起動中に DB リセット → 退避 rename → DB 再構築 → 退避物理削除で `FolderDeletionFailureDialog` 表示 → 再試行 or 諦める
- [ ] Enter キーで「再試行」が動くこと (AcceptButton)
- [ ] ESC キーで「諦める」が動くこと (CancelButton)

## ビルド検証

- Manager の C# コンパイル成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)