### PR TITLE
feat(logging): Manager + Launcher にファイルログ基盤を追加 (#116)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,27 @@
 ## Launcher Implementation
 - ユーザーが調整しやすいよう、UIやレイアウトはなるべく `.tscn`（シーンファイル）で実装すること。
 - 変数はなるべく `@export` で定義し、エディタから調整可能にすること。
+
+## Cross-component Standards
+新規クライアントコンポーネント（Launcher / Manager / Monitor / 将来 Tools 等）を追加・改修する際は、
+以下のベースラインを必ず満たすこと。これは「ファイルログが無いと運用上の事故調査が不可能」(#116) という
+過去の教訓を踏まえた **横断的な共通要件** である。
+
+- **ファイルログ**: 共有プロジェクトルート（prism.db のあるディレクトリ）の `logs/{component}/` 配下に出力
+  - 例: `<project_root>/logs/manager/manager_<PCname>_<YYYY-MM-DD_HHmmss>.log`
+  - 例: `<project_root>/logs/launcher/launcher_<PCname>_<YYYY-MM-DD_HHmmss>.log`
+- **1 起動セッション = 1 ファイル**（日跨ぎでもローテートしない）
+  - 複数 PC が同じファイルに書き込まないので、書き込み競合・行間 interleaving が発生しない
+  - PC 名と起動時刻でファイル名がユニークになる（同秒衝突は連番サフィックスで回避）
+- **レベル**: 最低 INFO / WARN / ERROR の 3 段階（将来 #85 で DEBUG 追加予定）
+- **フォーマット**: `[YYYY-MM-DD HH:mm:ss] [LEVEL] [Module] message` で統一
+- **保持期間**: 30 日。古いファイルは起動時に自動削除（mtime 基準、現セッションのアクティブファイルは保護）
+- **既存出力との統合**: 既存の `Console.WriteLine` (.NET) / `print()` (GDScript) 等は、
+  Console.SetOut / OS.add_logger の自動キャプチャで **コード変更ゼロ** でファイルにも流すこと。
+  新規コードでは `Logger.Info/Warn/Error` 等で明示的にレベル指定
+- **起動・終了イベント**: 必ず INFO で記録（事故調査で「いつ落ちたか」が分かるように）
+- **Logger 自体の障害は握り潰す**: ログ機構の例外でアプリ起動を止めない・無限ループを起こさない
+  （Logger 内部の例外は **ログにも書かない** こと。書くと再帰してハング）
+
+参照実装: `GCTonePrism_Manager/Services/Logger.cs`, `GCTonePrism_Launcher/scripts/logger.gd`
+（クライアント追加時は SPECIFICATION.md §3.6 の仕様も合わせて参照）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,7 @@
 #### Changed
 
 - **`config/version` を `0.5.15` → `0.5.16` に更新、`version.gd` の `PATCH` も `14` → `16` に同期**
-
-### [Launcher v0.5.15] - 2026-05-10
+- **`scripts/database_manager.gd` の `CURRENT_DB_VERSION` を 8 → 12 に追従**: Manager 側 DB が v9 → v12 まで進んでいたが Launcher が 8 のまま放置されており、起動毎に「DBバージョン(12)が Launcher の対応バージョン(8)より新しい」警告が出ていた問題を本 PR の動作確認で発見。v9 / v10 / v12 は backup_log 関連で Launcher は触らない、v11 の surveys / play_records 新スキーマには Launcher のクエリが既に対応済 (`pr.start_time` 等を参照) のため、定数追従のみで安全に解消
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@
 
 ## Launcher（ランチャー本体）
 
+### [Launcher v0.5.16] - 2026-05-11
+
+#### Added
+
+- **ファイルログ基盤 (#116, #85 の土台先行)**: 新規 autoload `scripts/logger.gd` を追加し、`<project_root>/logs/launcher/launcher_<PCname>_<YYYY-MM-DD_HHmmss>.log` に **1 起動セッション = 1 ファイル** でログ出力。INFO / WARN / ERROR の 3 段階、`[YYYY-MM-DD HH:mm:ss] [LEVEL] [Module] msg` 形式（Manager と統一）
+  - **既存 print 系を Godot 標準ログのテールで自動キャプチャ**: 既存 41 件 / 6 ファイルの `print()` および `printerr()` / `push_warning` / `push_error` がすべて自動的にファイルにも流れる仕組み（コード変更ゼロ）。実装は Godot 標準ファイルログ (`user://logs/godot.log`) を 0.5 秒間隔でテール → 新規追加分を本セッションファイルに `[Godot]` プレフィックス付きで転送
+    - 行頭の `WARNING:` / `USER WARNING:` → WARN、`ERROR:` / `SCRIPT ERROR:` / `USER ERROR:` → ERROR、それ以外 (print 等) → INFO で自動振り分け
+    - **設計の経緯**: 当初は `OS.add_logger` (Godot 4.5+) で `Logger` クラスを継承したカスタムロガーを登録する方針だったが、Godot 4.6 の GDScript パーサーが script 継承の `Logger` 型変換を蹴る (inner class / class_name / preload + as Logger キャストすべて NG) ため、Godot 標準ログのテール方式に切替。0.5 秒の polling 遅延が出るが、Godot 内部エラーまで含めて全部キャプチャできるメリットあり
+  - **明示 API**: 新規コードからは `Logger.info(msg)` / `Logger.warn(msg)` / `Logger.error(msg)` でレベル指定可能
+  - **保存先**: prism.db と同じ共有先 `<project_root>/logs/launcher/` に集約。Manager 側 `<project_root>/logs/manager/` と並列配置で、将来 Manager のログビューア UI から複数 PC の Launcher ログも 1 箇所で閲覧可能に
+  - **1 セッション 1 ファイル設計**: PC 名 + 起動時刻でファイル名がユニークになるため、複数展示 PC の Launcher が同時に同じ共有先へ書き込んでも書き込み競合・行間 interleaving が一切起きない。同秒衝突は連番サフィックスで回避
+  - **30 日 retention**: 起動時に `logs/launcher/launcher_*.log` をスキャンし、`get_modified_time` が 30 日より古いものを削除。現セッションのアクティブファイルは保護
+  - **prism.db 自動検出 + フォールバック**: PathManager と同じく exe ベースで上に prism.db を 10 階層まで探す軽量ロジックを Logger 内部に持つ（PathManager の起動 print も Logger でキャプチャしたいため、依存を持たせず重複実装）。見つからなければ exe 隣（エディタ実行時は `res://`）にフォールバック
+  - **起動・終了イベント記録**: `_init()` で「Launcher 起動 (PC=...)」、`NOTIFICATION_WM_CLOSE_REQUEST` / `NOTIFICATION_PREDELETE` で「Launcher 終了」を必ず INFO 出力
+  - **`Logger` autoload を最先頭に登録**: `project.godot` の `[autoload]` 先頭に追加して、他の autoload (`ErrorManager` / `AppManager` 等) の `_init/_ready` の出力も確実にキャプチャ
+  - **既存 `user://logs/` (Godot 標準) との関係**: %APPDATA% 配下の Godot デフォルトログは引き続き残るが、本基盤の `<project_root>/logs/launcher/` が事故調査時の正規場所。本番展示 PC のリカバリで揮発しない
+  - **横断要件として SPEC §3.6 / AGENTS.md "Cross-component Standards" に格上げ**: 同じベースラインを Monitor 等の将来コンポーネントでも適用する仕組みを文書化
+
+#### Changed
+
+- **`config/version` を `0.5.15` → `0.5.16` に更新、`version.gd` の `PATCH` も `14` → `16` に同期**
+
 ### [Launcher v0.5.15] - 2026-05-10
 
 #### Changed
@@ -418,6 +440,21 @@
 ---
 
 ## Manager（管理ソフト）
+
+### [Manager v0.8.8] - 2026-05-11
+
+#### Added
+
+- **ファイルログ基盤 (#116)**: 新規 `Services/Logger.cs` を追加し、`<project_root>/logs/manager/manager_<PCname>_<YYYY-MM-DD_HHmmss>.log` に **1 起動セッション = 1 ファイル** でログを出力。INFO / WARN / ERROR の 3 段階、`[YYYY-MM-DD HH:mm:ss] [LEVEL] [Module] msg` 形式。これまで Manager はエラーが出ても後追いで原因調査ができなかった (#115 の WAL 起因エラー診断時に判明) 問題を根本解決
+  - **既存 `Console.WriteLine` を `Console.SetOut` で自動キャプチャ**: 既存 109 件 / 11 ファイルの `Console.WriteLine($"[Module] msg")` 呼び出しが **コード変更ゼロ** で自動的にログファイルにも書かれるよう、カスタム `TextWriter` (内部 `ConsoleHookWriter`) を `Program.cs` の `Logger.Initialize()` で `Console.SetOut(...)` 経由で差し替え。INFO 扱いで記録
+  - **明示 API**: 新規コードからは `Logger.Info / Warn / Error / Error(msg, ex)` でレベル指定可能。`Error(msg, ex)` は `Exception.ToString()` を改行付きで追記
+  - **保存先の判断**: 当初 Issue #116 提案の `%APPDATA%\GCTonePrism_Manager\logs\` ではなく **`<project_root>/logs/manager/`**（prism.db と同じ共有先）に変更。理由は (1) Manager の将来的なログビューア UI で複数 PC のログを 1 箇所で閲覧可能、(2) 本番展示 PC のリカバリ・OS 再構築で揮発しない、(3) クラブメンバーがエクスプローラから直感的に発見できる、(4) Launcher と対称な設計（Launcher も同じ `<project_root>/logs/launcher/` に出力）
+  - **1 セッション 1 ファイル設計**: PC 名 + 起動時刻でファイル名がユニークになるため、複数 PC が同時に同じ共有先へ書き込んでも書き込み競合・行間 interleaving が一切起きない。同秒衝突は連番サフィックスで回避
+  - **30 日 retention**: 起動時に `logs/manager/manager_*.log` をスキャンし、`LastWriteTime` が 30 日より古いものを削除。現セッションのアクティブファイルは `_currentLogPath` 一致チェックで明示的に保護
+  - **障害耐性**: `Logger.Initialize()` 失敗時は MessageBox 警告のみで Manager 起動は継続。`Write` の例外は握り潰し、Logger 自身の例外は **絶対にログに書かない**（無限ループ防止）
+  - **プロジェクトルート検出は Logger 内部で重複実装**: PathManager の起動 `Console.WriteLine` も Logger でキャプチャしたいため、Logger は PathManager に依存せず自前で exe → 上に prism.db を 10 階層まで探す軽量ロジックを持つ。見つからなければ exe 隣にフォールバック
+  - **起動・終了イベント記録**: `Program.cs` を `try-finally` で囲み、`finally` で `Logger.Shutdown()` を呼んで終了ログを必ず出す。事故調査で「いつ落ちたか」を追跡可能に
+  - **横断要件として SPEC §3.6 / AGENTS.md "Cross-component Standards" に格上げ**: 同じベースラインを Monitor 等の将来コンポーネントにも適用する仕組みを明文化
 
 ### [Manager v0.8.7] - 2026-05-10
 

--- a/GCTonePrism_Launcher/project.godot
+++ b/GCTonePrism_Launcher/project.godot
@@ -19,6 +19,7 @@ config/version="0.5.16"
 run/main_scene="res://scenes/screensaver.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
+run/flush_stdout_on_print=true
 
 [autoload]
 

--- a/GCTonePrism_Launcher/project.godot
+++ b/GCTonePrism_Launcher/project.godot
@@ -15,13 +15,14 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="GCTonePrism_Launcher"
-config/version="0.5.15"
+config/version="0.5.16"
 run/main_scene="res://scenes/screensaver.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 
 [autoload]
 
+Logger="*res://scripts/logger.gd"
 ErrorManager="*res://scripts/error_manager.gd"
 DialogManager="*res://scripts/dialog_manager.gd"
 AppManager="*res://scripts/app_manager.gd"

--- a/GCTonePrism_Launcher/scripts/database_manager.gd
+++ b/GCTonePrism_Launcher/scripts/database_manager.gd
@@ -8,9 +8,11 @@ class_name DatabaseManager
 var db: SQLite = null
 var db_path: String = ""
 
-# 現在のデータベースバージョン
-# 構造変更があるたびにインクリメントする
-const CURRENT_DB_VERSION: int = 8
+# Launcher が想定する DB スキーマバージョン
+# Manager 側 SchemaManager.cs の CurrentDbVersion と歩調を合わせること
+# (v9, v10, v12 は backup_log 関連で Launcher は触らない / v11 の surveys・play_records
+#  新スキーマには Launcher のクエリが既に対応済 → 単に定数追従のみ)
+const CURRENT_DB_VERSION: int = 12
 
 ## データベースを開く
 func open() -> bool:

--- a/GCTonePrism_Launcher/scripts/logger.gd
+++ b/GCTonePrism_Launcher/scripts/logger.gd
@@ -269,10 +269,17 @@ func _cleanup_old_logs() -> void:
 
 
 func _notification(what: int) -> void:
-	# 通常終了 (× ボタン) と autoload 破棄時の両方で終了ログ
-	if what == NOTIFICATION_WM_CLOSE_REQUEST or what == NOTIFICATION_PREDELETE:
+	# Codex P1 #128: ファイル close は本物のプロセス終了 (PREDELETE) でのみ実施。
+	# WM_CLOSE_REQUEST は AppManager.set_auto_accept_quit(false) でインターセプトされて
+	# キャンセルされうるため、ここで _file を閉じてしまうと「キャンセルされた Alt+F4」
+	# 1 回でセッション残り全部のログが消失する。WM_CLOSE_REQUEST 時点では何もしない。
+	#
+	# また project.godot の application/run/flush_stdout_on_print=true により
+	# Godot は print() 毎に stdout を即 flush する → PREDELETE 時点で godot.log に
+	# 全 print 内容が揃っているので _sync_godot_log() で取りこぼし無し。
+	if what == NOTIFICATION_PREDELETE:
 		if _initialized:
-			# 終了直前に最後の Godot ログ分も同期
+			# 終了直前に最後の Godot ログ分も同期 (バッファ済みの print も拾う)
 			_sync_godot_log()
 			_write_safely("INFO", "[Logger] Launcher 終了")
 			if _file != null:

--- a/GCTonePrism_Launcher/scripts/logger.gd
+++ b/GCTonePrism_Launcher/scripts/logger.gd
@@ -1,0 +1,280 @@
+## Launcher のファイルログ機構 (#116, #85 の土台)
+##
+## - 1 起動セッション = 1 ファイル (`launcher_<PCname>_<YYYY-MM-DD_HHmmss>.log`)
+## - 保存先: `<project_root>/logs/launcher/`（prism.db のあるディレクトリの隣）
+##   → 共有上の prism.db と同じ場所に集約することで、複数 PC の Launcher / Manager ログを 1 箇所で見られる
+##   → セッション単位でファイルが分かれるので書き込み競合・行間 interleaving が発生しない
+## - INFO / WARN / ERROR の 3 段階
+## - 既存の print / printerr / push_warning / push_error / Godot エンジン内部エラーを **すべて** キャプチャ:
+##   Godot 標準ファイルログ (user://logs/godot.log) を 0.5 秒間隔でテールして新規分を本ログに転送
+##   (`OS.add_logger` で Logger 継承する案は GDScript パーサーが built-in Logger 型変換を蹴るため断念)
+## - 起動時に 30 日より古いログファイルを削除 (mtime 基準)
+## - スレッドセーフ (Mutex)
+## - 自身の障害で Launcher 起動を止めない (失敗時はファイルログを諦めて Launcher は継続)
+##
+## autoload なので [autoload] の **先頭** に登録すること
+## (Godot 標準ログのテール開始タイミングを早めて、他 autoload の出力をできるだけ早く捕捉するため)
+##
+## 関連: 将来 #85 (Launcher 統一ログ基盤フル仕様) で DEBUG 追加 / [エラーコード] フィールド /
+## リングバッファ / サービスモード (#74) 連携が拡張される。本スクリプトはその土台。
+
+extends Node
+
+const RETENTION_DAYS: int = 30
+const FILE_PREFIX: String = "launcher_"
+const FILE_SUFFIX: String = ".log"
+const LOG_SUBDIRECTORY: String = "launcher"
+const GODOT_LOG_POLL_INTERVAL: float = 0.5  # Godot 標準ログのテール間隔 (秒)
+
+var _file: FileAccess = null
+var _current_log_path: String = ""
+var _log_directory: String = ""
+var _mutex: Mutex = Mutex.new()
+var _initialized: bool = false
+var _init_failed: bool = false
+
+# Godot 標準ログ (user://logs/godot.log) テール用
+var _godot_log_path: String = ""
+var _godot_log_pos: int = 0
+var _sync_timer: Timer = null
+
+
+func _init() -> void:
+	# autoload の _init は engine 起動の極めて早い段階で呼ばれる
+	# ここでファイルを開いておくことで、他の autoload の _ready ログも遅滞なくキャプチャ準備が整う
+	_initialize_logger()
+
+
+func _ready() -> void:
+	# Godot 標準ログのテール開始 (Timer は add_child が必要なので _ready で)
+	if _initialized:
+		_init_godot_log_tail()
+
+
+func _initialize_logger() -> void:
+	if _initialized or _init_failed:
+		return
+
+	if not _open_log_directory_and_file():
+		_init_failed = true
+		push_warning("[Logger] ログ機構の初期化に失敗。Launcher は動作しますがファイルログは記録されません。")
+		return
+
+	_initialized = true
+	_write_safely("INFO", "[Logger] Launcher 起動 (PC=" + _get_pc_name() + ")")
+	_cleanup_old_logs()
+
+
+func _open_log_directory_and_file() -> bool:
+	var project_root = _find_project_root_for_logs()
+	if project_root.is_empty():
+		return false
+
+	_log_directory = project_root.path_join("logs").path_join(LOG_SUBDIRECTORY)
+
+	if not DirAccess.dir_exists_absolute(_log_directory):
+		var err = DirAccess.make_dir_recursive_absolute(_log_directory)
+		if err != OK:
+			return false
+
+	return _open_session_file()
+
+
+# 1 セッション 1 ファイル: launcher_<PCname>_<YYYY-MM-DD_HHmmss>.log
+# 万一同秒で衝突した場合は連番サフィックスでリトライ
+func _open_session_file() -> bool:
+	var pc_name = _sanitize_filename(_get_pc_name())
+	var dt = Time.get_datetime_dict_from_system()
+	var start_ts = "%04d-%02d-%02d_%02d%02d%02d" % [dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second]
+	var base_name = "%s%s_%s" % [FILE_PREFIX, pc_name, start_ts]
+	var path = _log_directory.path_join(base_name + FILE_SUFFIX)
+
+	var counter = 2
+	while FileAccess.file_exists(path) and counter < 100:
+		path = _log_directory.path_join("%s_%d%s" % [base_name, counter, FILE_SUFFIX])
+		counter += 1
+
+	# 新規ファイルとして作成
+	_file = FileAccess.open(path, FileAccess.WRITE)
+	if _file == null:
+		return false
+
+	_current_log_path = path
+	return true
+
+
+# Godot 標準ログをテールする準備:
+# 既存サイズを記録して過去内容のリプレイを防ぎつつ、Timer で新規分の polling を開始
+func _init_godot_log_tail() -> void:
+	var raw_path = ProjectSettings.get_setting("debug/file_logging/log_path", "user://logs/godot.log")
+	_godot_log_path = ProjectSettings.globalize_path(raw_path)
+
+	# 既存内容のサイズを記録 (このセッション開始前に書かれたものはリプレイしない)
+	if FileAccess.file_exists(_godot_log_path):
+		var f = FileAccess.open(_godot_log_path, FileAccess.READ)
+		if f != null:
+			_godot_log_pos = f.get_length()
+			f.close()
+	else:
+		_godot_log_pos = 0  # まだ無い場合は Godot が作ってから 0 から読む
+
+	_sync_timer = Timer.new()
+	_sync_timer.wait_time = GODOT_LOG_POLL_INTERVAL
+	_sync_timer.autostart = true
+	_sync_timer.one_shot = false
+	_sync_timer.timeout.connect(_sync_godot_log)
+	add_child(_sync_timer)
+
+
+# Godot 標準ログを定期的にテール: 新規追加分を本セッションファイルに転送
+func _sync_godot_log() -> void:
+	if not _initialized or _godot_log_path.is_empty():
+		return
+	if not FileAccess.file_exists(_godot_log_path):
+		return
+
+	var f = FileAccess.open(_godot_log_path, FileAccess.READ)
+	if f == null:
+		return
+	var size = f.get_length()
+
+	# Godot 側がローテートして新ファイルになった場合 (size が縮んだ) は位置をリセット
+	if size < _godot_log_pos:
+		_godot_log_pos = 0
+
+	if size <= _godot_log_pos:
+		f.close()
+		return
+
+	f.seek(_godot_log_pos)
+	var bytes_to_read = size - _godot_log_pos
+	var data = f.get_buffer(bytes_to_read).get_string_from_utf8()
+	_godot_log_pos = size
+	f.close()
+
+	# 各行をレベル判定して本ログに書く
+	for line in data.split("\n"):
+		var trimmed = line.strip_edges()
+		if trimmed.is_empty():
+			continue
+		var level = _classify_godot_line(trimmed)
+		_write_safely(level, "[Godot] " + trimmed)
+
+
+# Godot 標準ログ行のレベル判定:
+# WARNING:, USER WARNING: → WARN
+# ERROR:, SCRIPT ERROR:, USER ERROR: → ERROR
+# その他 (print の出力など) → INFO
+func _classify_godot_line(line: String) -> String:
+	if line.begins_with("WARNING:") or line.begins_with("USER WARNING:"):
+		return "WARN"
+	if line.begins_with("ERROR:") or line.begins_with("SCRIPT ERROR:") or line.begins_with("USER ERROR:"):
+		return "ERROR"
+	return "INFO"
+
+
+# PathManager と同じく exe ベースで上に prism.db を探すが、
+# Logger は他の autoload より先に動くため軽量実装で重複させる
+# (print 出力なし、エラーなし、見つからなければ exe 隣にフォールバックして Logger 自体は動かす)
+func _find_project_root_for_logs() -> String:
+	var base_dir: String
+	if OS.has_feature("editor"):
+		base_dir = ProjectSettings.globalize_path("res://")
+	else:
+		base_dir = OS.get_executable_path().get_base_dir()
+
+	if base_dir.is_empty():
+		return ""
+
+	base_dir = base_dir.replace("\\", "/").rstrip("/")
+
+	var current = base_dir
+	for i in 10:
+		if FileAccess.file_exists(current.path_join("prism.db")):
+			return current
+		var parent = current.get_base_dir()
+		if parent == current or parent.is_empty():
+			break
+		current = parent
+
+	# 見つからなければ exe 隣にフォールバック (Logger 自体は動く)
+	return base_dir
+
+
+func _get_pc_name() -> String:
+	var name = OS.get_environment("COMPUTERNAME")
+	if name.is_empty():
+		name = OS.get_environment("HOSTNAME")
+	if name.is_empty():
+		name = "unknown"
+	return name
+
+
+func _sanitize_filename(name: String) -> String:
+	# Windows で禁止される文字を _ に置換
+	var invalid = ["/", "\\", ":", "*", "?", "\"", "<", ">", "|"]
+	var result = name
+	for c in invalid:
+		result = result.replace(c, "_")
+	return result
+
+
+# 公開 API: 新規コードからレベル明示で呼ぶ
+func info(message: String) -> void:
+	_write_safely("INFO", message)
+
+
+func warn(message: String) -> void:
+	_write_safely("WARN", message)
+
+
+func error(message: String) -> void:
+	_write_safely("ERROR", message)
+
+
+# 内部書き込み: ロック取得 → ファイル書き込み (ローテートなし、1 セッション 1 ファイル)
+# Logger 自身の障害で連鎖しないよう、書き込み失敗は静かに無視
+func _write_safely(level: String, message: String) -> void:
+	if _init_failed:
+		return
+	_mutex.lock()
+	if _file != null:
+		var ts = Time.get_datetime_string_from_system(false, true)
+		_file.store_line("[%s] [%s] %s" % [ts, level, message])
+		_file.flush()
+	_mutex.unlock()
+
+
+# 起動時に 30 日より古いログファイルを削除
+# 失敗時 (権限・ロック等) は静かにスキップ
+func _cleanup_old_logs() -> void:
+	var dir = DirAccess.open(_log_directory)
+	if dir == null:
+		return
+
+	var cutoff_unix: int = int(Time.get_unix_time_from_system()) - (RETENTION_DAYS * 86400)
+
+	dir.list_dir_begin()
+	var name = dir.get_next()
+	while name != "":
+		if not dir.current_is_dir() and name.begins_with(FILE_PREFIX) and name.ends_with(FILE_SUFFIX):
+			var full_path: String = _log_directory.path_join(name)
+			# 念のため: 今セッションのアクティブファイルは絶対に消さない
+			if full_path != _current_log_path:
+				var mtime: int = int(FileAccess.get_modified_time(full_path))
+				if mtime > 0 and mtime < cutoff_unix:
+					DirAccess.remove_absolute(full_path)  # 失敗は無視
+		name = dir.get_next()
+	dir.list_dir_end()
+
+
+func _notification(what: int) -> void:
+	# 通常終了 (× ボタン) と autoload 破棄時の両方で終了ログ
+	if what == NOTIFICATION_WM_CLOSE_REQUEST or what == NOTIFICATION_PREDELETE:
+		if _initialized:
+			# 終了直前に最後の Godot ログ分も同期
+			_sync_godot_log()
+			_write_safely("INFO", "[Logger] Launcher 終了")
+			if _file != null:
+				_file.close()
+				_file = null

--- a/GCTonePrism_Launcher/scripts/logger.gd.uid
+++ b/GCTonePrism_Launcher/scripts/logger.gd.uid
@@ -1,0 +1,1 @@
+uid://bt6unphhv1hp

--- a/GCTonePrism_Launcher/version.gd
+++ b/GCTonePrism_Launcher/version.gd
@@ -6,7 +6,7 @@ class_name Version
 
 const MAJOR: int = 0
 const MINOR: int = 5
-const PATCH: int = 14
+const PATCH: int = 16
 
 static func get_version_string() -> String:
 	return "v%d.%d.%d" % [MAJOR, MINOR, PATCH]

--- a/GCTonePrism_Manager/GCTonePrism_Manager.csproj
+++ b/GCTonePrism_Manager/GCTonePrism_Manager.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Services\FolderDeletionService.cs" />
     <Compile Include="Services\GameFormHelper.cs" />
     <Compile Include="Services\ImagePreviewHelper.cs" />
+    <Compile Include="Services\Logger.cs" />
     <Compile Include="Services\PathConversionHelper.cs" />
     <Compile Include="Services\RestoreService.cs" />
     <Compile Include="Program.cs" />

--- a/GCTonePrism_Manager/Program.cs
+++ b/GCTonePrism_Manager/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GCTonePrism.Manager.Services;
 
 namespace GCTonePrism.Manager
 {
@@ -15,17 +16,22 @@ namespace GCTonePrism.Manager
         [STAThread]
         static void Main()
         {
+            // ログ機構を最初に初期化することで、PathManager 以降のすべての Console.WriteLine が
+            // 自動的にファイル (logs/manager_YYYY-MM-DD.log) にも残る (#116)
+            Logger.Initialize();
+
             try
-        {
-            // パスの確認（デバッグ用）
-            PathManager.VerifyPaths();
-            
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new MainForm());
+            {
+                // パスの確認（デバッグ用）
+                PathManager.VerifyPaths();
+
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                Application.Run(new MainForm());
             }
             catch (DirectoryNotFoundException ex)
             {
+                Logger.Error("起動エラー (DirectoryNotFound)", ex);
                 MessageBox.Show(
                     ex.Message,
                     "起動エラー",
@@ -35,12 +41,17 @@ namespace GCTonePrism.Manager
             }
             catch (Exception ex)
             {
+                Logger.Error("起動エラー", ex);
                 MessageBox.Show(
                     $"アプリケーションの起動に失敗しました。\n\n{ex.Message}",
                     "起動エラー",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
                 Application.Exit();
+            }
+            finally
+            {
+                Logger.Shutdown();
             }
         }
     }

--- a/GCTonePrism_Manager/Properties/AssemblyInfo.cs
+++ b/GCTonePrism_Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.8.7.0")]
-[assembly: AssemblyFileVersion("0.8.7.0")]
+[assembly: AssemblyVersion("0.8.8.0")]
+[assembly: AssemblyFileVersion("0.8.8.0")]

--- a/GCTonePrism_Manager/Services/Logger.cs
+++ b/GCTonePrism_Manager/Services/Logger.cs
@@ -1,0 +1,302 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace GCTonePrism.Manager.Services
+{
+    /// <summary>
+    /// Manager 全体のファイルログ機構 (#116)。
+    ///
+    /// - 1 起動セッション = 1 ファイル (`manager_<PCname>_<YYYY-MM-DD_HHmmss>.log`)
+    /// - 保存先: `<project_root>/logs/manager/`（prism.db のあるディレクトリの隣）
+    ///   → 共有上の prism.db と同じ場所に集約することで、複数 PC の Launcher / Manager ログを 1 箇所で見られる
+    ///   → セッション単位でファイルが分かれるので書き込み競合・行間 interleaving が発生しない
+    /// - INFO / WARN / ERROR の 3 段階
+    /// - Console.SetOut フックで既存 Console.WriteLine も自動的にファイルへ流す (INFO 扱い)
+    /// - 起動時に 30 日より古いログファイルを削除 (mtime 基準)
+    /// - スレッドセーフ (内部 lock。lock は同一スレッドで再入可能)
+    /// - 自身の例外で無限ループ・アプリ起動阻害を起こさない (try-catch で握り潰し)
+    ///
+    /// 関連: 将来 #85 (Launcher 統一ログ基盤フル仕様) で DEBUG 追加 / [エラーコード] フィールド /
+    /// リングバッファ / サービスモード連携が拡張される。本クラスはその土台先行。
+    /// </summary>
+    public static class Logger
+    {
+        private const int RetentionDays = 30;
+        private const string FileNamePrefix = "manager_";
+        private const string FileNameSuffix = ".log";
+        private const string LogSubDirectory = "manager";
+
+        private static readonly object _lock = new object();
+        private static StreamWriter _writer;
+        private static string _currentLogPath;
+        private static string _logDirectory;
+        private static bool _initialized;
+        private static bool _initFailed;
+        private static TextWriter _previousConsoleOut;
+
+        /// <summary>
+        /// 現在書き込み中のログファイル絶対パス (検証・診断用)
+        /// </summary>
+        public static string CurrentLogPath
+        {
+            get { lock (_lock) { return _currentLogPath; } }
+        }
+
+        /// <summary>
+        /// ロガーを初期化する。Application.Run より前で必ず呼ぶこと。
+        /// 失敗してもアプリ起動は止めない (例外を握り潰し、以降の API は no-op)。
+        /// </summary>
+        public static void Initialize()
+        {
+            lock (_lock)
+            {
+                if (_initialized || _initFailed) return;
+
+                try
+                {
+                    string projectRoot = FindProjectRootForLogs();
+                    _logDirectory = Path.Combine(projectRoot, "logs", LogSubDirectory);
+                    Directory.CreateDirectory(_logDirectory);
+
+                    OpenSessionFile();
+
+                    // Console.WriteLine の出力を自動キャプチャ
+                    // (このフックを置いた以降の Console.WriteLine はすべて INFO としてファイルにも残る)
+                    _previousConsoleOut = Console.Out;
+                    Console.SetOut(new ConsoleHookWriter());
+
+                    _initialized = true;
+
+                    // 起動イベントは初期化完了後に書く
+                    WriteInternal("INFO", $"[Logger] Manager 起動 (PC={Environment.MachineName})");
+                    CleanupOldLogs();
+                }
+                catch (Exception ex)
+                {
+                    _initFailed = true;
+                    try
+                    {
+                        // ログ機構自体が壊れているので MessageBox に直接出す
+                        System.Windows.Forms.MessageBox.Show(
+                            $"ログ機構の初期化に失敗しました。アプリは動作しますがログは記録されません。\n\n{ex.Message}",
+                            "ログ機構初期化失敗",
+                            System.Windows.Forms.MessageBoxButtons.OK,
+                            System.Windows.Forms.MessageBoxIcon.Warning);
+                    }
+                    catch { /* MessageBox すら出せないなら諦める */ }
+                }
+            }
+        }
+
+        public static void Info(string message) { Write("INFO", message); }
+        public static void Warn(string message) { Write("WARN", message); }
+        public static void Error(string message) { Write("ERROR", message); }
+
+        public static void Error(string message, Exception ex)
+        {
+            if (ex == null) { Write("ERROR", message); return; }
+            Write("ERROR", $"{message}{Environment.NewLine}{ex}");
+        }
+
+        /// <summary>
+        /// アプリ終了時に必ず呼ぶ (Program.cs の try-finally で)。
+        /// 終了イベントを記録して writer を閉じる。
+        /// </summary>
+        public static void Shutdown()
+        {
+            lock (_lock)
+            {
+                if (!_initialized) return;
+                try
+                {
+                    WriteInternal("INFO", "[Logger] Manager 終了");
+                    if (_writer != null)
+                    {
+                        _writer.Flush();
+                        _writer.Dispose();
+                        _writer = null;
+                    }
+                    if (_previousConsoleOut != null)
+                    {
+                        Console.SetOut(_previousConsoleOut);
+                        _previousConsoleOut = null;
+                    }
+                    _initialized = false;
+                }
+                catch { /* swallow */ }
+            }
+        }
+
+        private static void Write(string level, string message)
+        {
+            if (!_initialized) return;
+            lock (_lock)
+            {
+                if (!_initialized) return;
+                WriteInternal(level, message);
+            }
+        }
+
+        private static void WriteInternal(string level, string message)
+        {
+            try
+            {
+                if (_writer == null) return;
+                string ts = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                _writer.WriteLine($"[{ts}] [{level}] {message ?? string.Empty}");
+                _writer.Flush();
+            }
+            catch
+            {
+                // Logger 自身の例外は絶対にログに書かない (無限ループ防止)
+            }
+        }
+
+        /// <summary>
+        /// セッション専用ファイルを 1 つ作って開く。1 起動セッション = 1 ファイルのため、ローテートは不要。
+        /// 万一同秒で衝突した場合 (現実的にはダブルクリック等の極限ケース) は連番サフィックスでリトライ。
+        /// </summary>
+        private static void OpenSessionFile()
+        {
+            string pcName = SanitizeFileName(Environment.MachineName);
+            string startTs = DateTime.Now.ToString("yyyy-MM-dd_HHmmss");
+            string baseName = $"{FileNamePrefix}{pcName}_{startTs}";
+            string path = Path.Combine(_logDirectory, $"{baseName}{FileNameSuffix}");
+
+            int counter = 2;
+            while (File.Exists(path) && counter < 100)
+            {
+                path = Path.Combine(_logDirectory, $"{baseName}_{counter}{FileNameSuffix}");
+                counter++;
+            }
+
+            // FileShare.Read のみ: 同 PC 内で同時に複数の Manager が同じファイル名にならない前提
+            // (秒単位タイムスタンプ + 連番サフィックスで衝突回避済み)
+            var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+            _writer = new StreamWriter(stream, new UTF8Encoding(false));
+            _currentLogPath = path;
+        }
+
+        /// <summary>
+        /// PathManager と同じく exe ベースで上に prism.db を探すが、
+        /// Logger は PathManager より先に動くため軽量実装で重複させる
+        /// (Console 出力なし、例外なし、見つからなければ exe 隣にフォールバックして Logger 自体は動かす)
+        /// </summary>
+        private static string FindProjectRootForLogs()
+        {
+            string exePath = AppDomain.CurrentDomain.BaseDirectory;
+            try
+            {
+                DirectoryInfo dir = new DirectoryInfo(exePath);
+                for (int i = 0; i < 10 && dir != null; i++)
+                {
+                    if (File.Exists(Path.Combine(dir.FullName, "prism.db")))
+                        return dir.FullName;
+                    dir = dir.Parent;
+                }
+            }
+            catch { /* fall through */ }
+            return exePath;
+        }
+
+        private static string SanitizeFileName(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return "unknown";
+            char[] invalid = Path.GetInvalidFileNameChars();
+            StringBuilder sb = new StringBuilder(name.Length);
+            foreach (char c in name)
+            {
+                sb.Append(invalid.Contains(c) ? '_' : c);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// 30 日より古い manager_*.log を削除する。起動時 1 回のみ実行。
+        /// </summary>
+        private static void CleanupOldLogs()
+        {
+            try
+            {
+                DateTime cutoff = DateTime.Now.AddDays(-RetentionDays);
+                foreach (string path in Directory.EnumerateFiles(_logDirectory, $"{FileNamePrefix}*{FileNameSuffix}"))
+                {
+                    try
+                    {
+                        // 念のため: 今セッションのアクティブファイルは絶対に消さない
+                        if (string.Equals(path, _currentLogPath, StringComparison.OrdinalIgnoreCase)) continue;
+                        if (File.GetLastWriteTime(path) < cutoff)
+                        {
+                            File.Delete(path);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // ロック・権限エラー等は警告だけ残して続行
+                        WriteInternal("WARN", $"[Logger] 古いログファイル削除失敗 ({path}): {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                WriteInternal("WARN", $"[Logger] 古いログ掃除中にエラー: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Console.SetOut で差し替える TextWriter。
+        /// Console.WriteLine の出力を Logger.Info にリダイレクトする。
+        /// 部分書き込み (Write(char) や Write(string)) は内部バッファで行末まで蓄積してから 1 行として出力。
+        /// </summary>
+        private sealed class ConsoleHookWriter : TextWriter
+        {
+            private readonly StringBuilder _buffer = new StringBuilder();
+
+            public override Encoding Encoding { get { return Encoding.UTF8; } }
+
+            public override void Write(char value)
+            {
+                if (value == '\n')
+                {
+                    string line = _buffer.ToString();
+                    _buffer.Clear();
+                    // CR を末尾から除去
+                    if (line.Length > 0 && line[line.Length - 1] == '\r')
+                        line = line.Substring(0, line.Length - 1);
+                    Logger.Write("INFO", line);
+                }
+                else
+                {
+                    _buffer.Append(value);
+                }
+            }
+
+            public override void Write(string value)
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                foreach (char c in value)
+                {
+                    Write(c);
+                }
+            }
+
+            public override void WriteLine()
+            {
+                // 末尾までバッファされてた分があれば flush
+                string line = _buffer.ToString();
+                _buffer.Clear();
+                Logger.Write("INFO", line);
+            }
+
+            public override void WriteLine(string value)
+            {
+                // 既存バッファ + value を 1 行として出力
+                string line = _buffer.ToString() + (value ?? string.Empty);
+                _buffer.Clear();
+                Logger.Write("INFO", line);
+            }
+        }
+    }
+}

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -740,6 +740,36 @@ GCTonePrism_Tools/
   - 学校PCの仕様に合わせる必要があるため、顧問の先生と要相談
   - 現在想定している環境: Core i3 11世代、メモリ8GB程度
 
+### 3.6 ログ基盤（全コンポーネント横断要件）
+
+すべてのクライアントコンポーネント（Launcher / Manager / Monitor / 将来追加される Tools 等）は
+本節の最低要件を満たすファイルログ機構を実装すること。本節は #116 で導入された土台仕様であり、
+将来の §2.1「ログ基盤仕様」(#85) でフル仕様（DEBUG・リングバッファ・エラーコード・サービスモード連携）に拡張される。
+
+- **保存先**: プロジェクトルート（`prism.db` のあるディレクトリ）の `logs/{component}/` 配下
+  - 例: `<project_root>/logs/manager/manager_<PCname>_<YYYY-MM-DD_HHmmss>.log`
+  - 例: `<project_root>/logs/launcher/launcher_<PCname>_<YYYY-MM-DD_HHmmss>.log`
+  - 配置の理由: 共有上の prism.db と同じ場所に集約することで Manager の将来的なログビューア UI から複数 PC の Launcher / Manager ログを 1 箇所で閲覧可能になる
+  - 検出方法: exe 隣から最大 10 階層遡って `prism.db` を探す。見つからなければ exe 隣にフォールバック（PathManager と同じ思想だが Logger 専用に重複実装することで PathManager 起動ログのキャプチャ漏れを防ぐ）
+- **1 起動セッション = 1 ファイル**: 日跨ぎでもローテートしない。PC 名 + 起動時刻でファイル名がユニーク
+  - 利点: 複数 PC が同じファイルに書き込まないので、書き込み競合・行間 interleaving が発生しない
+  - 同秒衝突対策: 連番サフィックス (`_2`, `_3` ...) でリトライ
+- **レベル**: INFO / WARN / ERROR の 3 段階（#85 で DEBUG が追加される予定）
+- **フォーマット**: `[YYYY-MM-DD HH:mm:ss] [LEVEL] [Module] message` 形式（PC 名はファイル名で表現するので行に含めない）
+- **保持期間**: 30 日。起動時に古いファイル (mtime 基準) を自動削除。現セッションのアクティブファイルは明示的に保護
+- **既存出力の自動取込**:
+  - .NET (Manager 等): `Console.SetOut(...)` で `Console.WriteLine($"[Module] msg")` をフックし、INFO としてファイルにも書く
+  - Godot (Launcher 等): Godot 標準ファイルログ (`user://logs/godot.log`) を 0.5 秒間隔でテールし、新規追加分を `[Godot]` プレフィックス付きでセッションファイルに転送。行頭の `WARNING:` / `ERROR:` 等を解析してレベル振り分け（`OS.add_logger` で Logger 継承する案は GDScript パーサが script 継承の Logger 型変換を蹴るため断念）
+- **明示 API**: 新規コードは `Logger.Info / Warn / Error` 等で **レベルを明示指定** することを推奨
+- **起動・終了イベント**: 必ず INFO で記録
+- **障害耐性**: ログ機構自身の例外は握り潰し、アプリ起動を止めない・無限ループを起こさない
+  - Logger 内部の例外は **絶対にログに書かない**（書くと再帰してハング）
+  - 初期化失敗時は警告ダイアログを出してアプリは継続
+
+参照実装:
+- `GCTonePrism_Manager/Services/Logger.cs`（Manager v0.8.8 で導入）
+- `GCTonePrism_Launcher/scripts/logger.gd`（Launcher v0.5.16 で導入）
+
 ---
 
 ## 4. UI/UX設計
@@ -2531,6 +2561,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-11 | 1.10.0 | ファイルログ基盤を全コンポーネント横断要件として §3.6 に新設 (#116 / #85 の土台)：Manager (v0.8.8) は新規 `Services/Logger.cs` で `Console.SetOut` フックにより既存 109 件の `Console.WriteLine($"[X] msg")` を **コード変更ゼロ** でファイルにも自動転送、INFO/WARN/ERROR の 3 段階を提供。Launcher (v0.5.16) は新規 autoload `scripts/logger.gd` が `OS.add_logger` (Godot 4.5+) で `print` / `printerr` / `push_warning` / `push_error` をすべて捕捉し、レベル振り分けして出力。**保存先は `<project_root>/logs/{manager,launcher}/<component>_<PCname>_<YYYY-MM-DD_HHmmss>.log`** に集約配置：(a) prism.db と同じ共有先に置くことで Manager の将来的なログビューア UI で複数 PC のログを 1 箇所閲覧可能、(b) **1 起動セッション = 1 ファイル** のため複数 PC が同時に書いても競合・interleaving が起きない、(c) PC 名 + 起動時刻でファイル名がユニーク（同秒衝突は連番サフィックスで回避）。30 日 retention（起動時に mtime 基準で古いファイル自動削除、現セッションは保護）。AGENTS.md に「Cross-component Standards」セクション追加して将来の Monitor / Tools 等の追加時にも同じベースラインが適用されるよう保証。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.11 | バックアップ履歴の改善 (#126)：`backup_log` テーブルに `relative_path` 列を追加 (DB v11 → v12)。バックアップ作成時に `prism.db` のあるディレクトリからの相対パスも記録し、表示・復元時は新規 `BackupPathResolver` で動的にパスを再構築することでプロジェクト場所の移動に追従できるように（ユーザーが「Documents 配下 → C 直下」のように頻繁にプロジェクトを移動するため）。`failed` 状態のレコードは Manager 起動時に物理ファイル + DB レコード両方を自動掃除（表示価値が無く、古いプロジェクトパスのゴミの主因）。履歴一覧に「選択した履歴を削除...」ボタンを追加し、ユーザーが個別にバックアップを片付けられるように。表示時は `File.Exists` チェックで不在ファイルを非表示（DB レコードは保護のため残す）。Manager v0.8.7 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.10 | Manager UI 改善 (#123)：`EditGameForm` / `AddGameForm` / `VersionUpForm` を縦長 (480 × 888〜1000px) から 2 列レイアウト (950 × 570〜645px) に再設計し、ノート PC でも縦スクロールなしで全項目が見渡せるように (左列=基本情報、右列=アセット&設定)。フォーム自体には `AutoScroll = true` を併設し、それでも入りきらない環境では縦スクロールバーが出る fallback を確保。全 `DataGridView` に `AllowUserToResizeRows = false` を設定し、行と行の境界ドラッグで行高が変わる UX バグを排除。`StoreSectionListForm` の `dgvSections` と Add/Edit の `dgvDevelopers` には `RowHeadersVisible = false` も追加して行ヘッダー自体を消し、誤操作余地を物理的に排除。Manager v0.8.6 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.9 | ゲーム削除を rename rollback パターンに刷新 (Codex P1 #122)：旧実装は「フォルダ物理削除 → DB 削除」順だったため、DB 削除失敗時 (SQLiteException 等) にフォルダだけ消えて戻せない問題があった。新実装はリセットと同じ 3 フェーズ「(1) rename で退避 → (2) DB 削除 → (3) 退避物理削除」に統一し、(2) 失敗時は (1) を rename で戻してロールバックする。永続的データロストを排除。SPEC §2.2 機能2 を新フローで書き直し。Manager v0.8.5 で実装。 | Kenshiro Kuroga & Claude |


### PR DESCRIPTION
## Summary

両コンポーネントから全プロセス出力を**プロジェクト共有先 `logs/{manager,launcher}/`** 配下に「**1 起動セッション = 1 ファイル**」(`<component>_<PCname>_<timestamp>.log`) で永続化する基盤を追加。

これまで Manager は `Console.WriteLine` ベースの揮発的な出力しかなく、本番 PC でエラーが出ても**後追いで原因調査ができない**問題があった (#115 の WAL 起因エラー診断時に判明 → #116 起票)。Launcher 側は Godot 標準ログが %APPDATA% 配下に残っていたが、本番展示 PC のリカバリで揮発する可能性があった。

## 主な変更

### Manager (v0.8.7 → v0.8.8)
- 新規 `Services/Logger.cs`
- `Console.SetOut` フックで既存 109 件の `Console.WriteLine($"[X] msg")` を **コード変更ゼロ** で INFO 自動キャプチャ
- 30 日 retention、UTF-8 BOM なし、障害時は MessageBox 警告のみでアプリ起動は継続
- PathManager より先に動かすため独自に exe → 上に prism.db を 10 階層探す軽量検出を内蔵

### Launcher (v0.5.15 → v0.5.16)
- 新規 autoload `scripts/logger.gd`
- 当初 `OS.add_logger` で `Logger` 継承する案だったが、Godot 4.6 の GDScript パーサが built-in Logger 型変換を inner class / class_name / preload + `as Logger` キャストすべてのパターンで蹴るため断念
- **代替: Godot 標準ログ (`user://logs/godot.log`) を 0.5 秒間隔でテール** → 新規分を `[Godot]` プレフィックス付きでセッションファイルに転送
- 行頭の `WARNING:` / `ERROR:` を解析して INFO / WARN / ERROR に自動振り分け（`push_warning` のスタックトレースまで保存される）

### 横断ドキュメント
- `AGENTS.md` に **"Cross-component Standards"** セクション新設（Monitor / Tools 等の将来コンポーネントにも同じベースラインが自動適用される仕組み）
- `SPECIFICATION.md` §3.6「ログ基盤（全コンポーネント横断）」新設 + 変更履歴 v1.10.0
- `CHANGELOG.md` に Manager v0.8.8 / Launcher v0.5.16 を追加

## 設計判断

- **保存先を `<project_root>/logs/`** に集約: prism.db と同じ共有先に置くことで、将来 Manager のログビューア UI で複数 PC のログを 1 箇所閲覧可能
- **1 セッション 1 ファイル**: PC 名 + 起動時刻でファイル名がユニーク → 複数 PC 同時書き込みでも競合・interleaving が一切起きない
- **3 段階レベル (#85 で DEBUG 追加予定)**: API シグネチャは将来拡張しやすい形で
- **障害耐性**: Logger 自身の例外は **絶対にログに書かない** (無限ループ防止) + 初期化失敗時はアプリ起動継続

## Test plan

- [x] Manager 起動 → `logs/manager/manager_<PCname>_<timestamp>.log` 生成、PathManager の Console.WriteLine が INFO で記録されている
- [x] Launcher 起動 → `logs/launcher/launcher_<PCname>_<timestamp>.log` 生成、`[Godot]` プレフィックス付きで `[AppManager]` `[DatabaseManager]` 等の出力が記録されている
- [x] `push_warning` がスタックトレース込みで WARN として記録されている
- [x] Manager / Launcher の終了ラインも記録されている

## 関連

- Closes #116
- 土台先行 → #85 (Launcher 統一ログ基盤フル仕様: DEBUG / リングバッファ / `[エラーコード]` / サービスモード連携)
- 別件 → #114 (エラーダイアログ UX 改善、完成段階で実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)