### PR TITLE
docs(agents): AGENTS.md をスリム化し詳細仕様を SPEC §7.6 に退避 (#131)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,77 +1,50 @@
-﻿# AGENTS Rules
-
-## Release and Versioning
-- コミットする直前に、Launcher と Manager と Monitor のバージョン番号を上げる必要があるかを必ず提案すること。
-- バージョン番号を上げる場合は、必ずそのバージョンの変更内容を `CHANGELOG.md` に記載すること。
-- リリース（タグ/Release）を作成した場合は、`CHANGELOG.md` 末尾のリンク定義に該当バージョンのURLを必ず追記・更新すること。
-
-## Specification Management
-- SPECIFICATION.md の議論・追記・修正が一段落したら、以下を必ずユーザーに提案すること：
-  1. 変更履歴セクションへの追記（日付・バージョン・変更内容・変更者）
-  2. 変更者の記載をどうするか（ユーザー名 or 共同作業の場合の記載方法）
-- バージョン番号は既存の変更履歴の最新バージョンをインクリメントすること。
+# AGENTS Rules
 
 ## Session Start
-- セッション開始時に `README.md`、`SPECIFICATION.md`、`CHANGELOG.md` をくまなく読むこと。
-
-## File Structure
-- 新機能を追加する前に、既存ファイルに足すのではなく新しいファイルを作るべきか必ず検討すること。
-- 既存ファイルに関数を追加する際、そのファイルの既存の責務と一致しない場合は別ファイルにすること。
-
-## Database Schema Management
-- **スキーマ変更には必ずマイグレーションを書く**: `GCTonePrism_Manager/SchemaManager.cs` の `CreateTables()` 内のスキーマ定義を変更したら、対応する `MigrateVxToVy` 関数を追加し、`CurrentDbVersion` をインクリメントすること。
-- **`CREATE TABLE IF NOT EXISTS` は新規 DB 用**: 既存テーブルが存在する場合は何もしないため、スキーマ変更には ALTER TABLE / DROP+CREATE+データ移行 を伴う明示的なマイグレーションが必要。
-- **マイグレーション実装後は `tools/sqlite3/sqlite3.exe` で検証**: 変更前後で `PRAGMA table_info(<tableName>);` を実行し、想定通りのスキーマになっているか確認すること。Manager 起動時の `VerifySchema()` でも自動チェックされるが、手動検証も併用する。
-- **`ExpectedSchema` 辞書 ↔ SPEC §7.3 の同期**: `SchemaManager.cs` 末尾の `ExpectedSchema` 辞書を更新したら、`SPECIFICATION.md` §7.3 のテーブル定義表（およびできれば §7.2 階層図 / §7.4 ER 図）も同時に更新すること。VerifySchema は ExpectedSchema との比較のみで SPEC は読まないため、SPEC 側の drift は人間が見つける必要がある。
-- **過去事例**: SPEC v1.5.1 (2026-03-28) で `surveys` / `play_records` のスキーマを変更したが、マイグレーション未実装のため drift が温存されていた（Manager v0.8.1 の `MigrateV10ToV11` で修正）。
+- `README.md`、`SPECIFICATION.md`、`CHANGELOG.md` をくまなく読む。
+- オープン中のイシューとマイルストーンの進捗を確認し、現状をユーザーに共有する。
 
 ## Branch Strategy
-- 原則 main ブランチのまま実装せず、大まかな機能単位でブランチを分けること。
-- ブランチ名は `feature/〇〇`（新機能）、`fix/〇〇`（修正）の形式を使うこと。
+- main で直接実装せず、機能単位でブランチを切る。
+- ブランチ名は `feature/〇〇`（新機能）/ `fix/〇〇`（修正）。
+
+## File Structure
+- 新機能の追加は、既存ファイルへの追記ではなく新ファイル作成を必ず検討する。
+- 既存ファイルへの関数追加時、ファイルの責務と合わなければ別ファイルにする。
+
+## Release and Versioning
+- コミット直前に Launcher / Manager / Monitor のバージョン番号を上げるべきかを必ず提案する。
+- バージョンを上げる場合は `CHANGELOG.md` に変更内容を記載する。
+- タグ/Release を作成した場合は `CHANGELOG.md` 末尾のリンク定義を追記・更新する。
+
+## Specification Management
+- `SPECIFICATION.md` の議論・追記・修正が一段落したら、変更履歴セクションへの追記（日付・バージョン・変更内容・変更者）を必ず提案する。バージョン番号は既存最新からインクリメント。
+
+## Database Schema Management
+- スキーマ変更時のワークフロー（マイグレーション関数・`CurrentDbVersion` 増分・`sqlite3.exe` 検証・`ExpectedSchema` ↔ SPEC §7.3 同期）は **SPECIFICATION.md §7.6** を参照のこと。
+- 重要： `CreateTables()` を編集したら必ず `MigrateVxToVy` を書く。スキーマ drift の温床。
+
+## Cross-component Standards (ファイルログ)
+- 新規クライアントコンポーネント（Launcher / Manager / Monitor / Tools 等）を追加・改修する際は、ファイルログ基盤を必ず実装する。仕様詳細は **SPECIFICATION.md §3.6** を参照。
+- 参照実装: [`GCTonePrism_Manager/Services/Logger.cs`](GCTonePrism_Manager/Services/Logger.cs), [`GCTonePrism_Launcher/scripts/logger.gd`](GCTonePrism_Launcher/scripts/logger.gd)
+- Logger 自体の障害は握り潰す（再帰ハング回避のため、Logger 内部例外はログにも書かない）。
+
+## Launcher Implementation
+- UI やレイアウトはなるべく `.tscn`（シーンファイル）で実装する。
+- 変数はなるべく `@export` で定義し、エディタから調整可能にする。
 
 ## GitHub Integration
 
-### セッション開始時
-- オープン中のイシューとマイルストーンの進捗を確認し、現状をユーザーに共有すること。
-
 ### 作業中
-- 作業がイシューに関連する場合、コミットメッセージやPRに `#イシュー番号` を含めること。
-- 作業中に発見したバグ・課題・TODOは GitHub イシューとして登録を提案すること。
-- ユーザーが「覚えておいて」と言った内容は、メモリ保存に加えてイシュー登録も提案すること。
+- 作業がイシューに関連する場合、コミットメッセージ・PR に `#イシュー番号` を含める。
+- 作業中に発見したバグ・課題・TODO は GitHub イシュー登録を提案する。
+- ユーザーが「覚えておいて」と言った内容は、メモリ保存に加えてイシュー登録も提案する。
 
 ### 作業完了時
-- 完了したイシューのクローズを提案すること。
-- マイルストーンの進捗を確認し、全イシュー完了時はマイルストーンのクローズも提案すること。
-- 次に取りかかるべきイシューを提示すること。
+- 完了したイシューのクローズを提案する。
+- 全イシュー完了時はマイルストーンのクローズも提案する。
+- 次に取りかかるべきイシューを提示する。
 
 ### 仕様書との同期
-- SPECIFICATION.md に記載があるがイシューが存在しない機能・課題を発見した場合、イシュー作成を提案すること。
-- イシューに記載があるが SPECIFICATION.md に反映されていない仕様変更を発見した場合、仕様書への追記を提案すること。
-
-## Launcher Implementation
-- ユーザーが調整しやすいよう、UIやレイアウトはなるべく `.tscn`（シーンファイル）で実装すること。
-- 変数はなるべく `@export` で定義し、エディタから調整可能にすること。
-
-## Cross-component Standards
-新規クライアントコンポーネント（Launcher / Manager / Monitor / 将来 Tools 等）を追加・改修する際は、
-以下のベースラインを必ず満たすこと。これは「ファイルログが無いと運用上の事故調査が不可能」(#116) という
-過去の教訓を踏まえた **横断的な共通要件** である。
-
-- **ファイルログ**: 共有プロジェクトルート（prism.db のあるディレクトリ）の `logs/{component}/` 配下に出力
-  - 例: `<project_root>/logs/manager/manager_<PCname>_<YYYY-MM-DD_HHmmss>.log`
-  - 例: `<project_root>/logs/launcher/launcher_<PCname>_<YYYY-MM-DD_HHmmss>.log`
-- **1 起動セッション = 1 ファイル**（日跨ぎでもローテートしない）
-  - 複数 PC が同じファイルに書き込まないので、書き込み競合・行間 interleaving が発生しない
-  - PC 名と起動時刻でファイル名がユニークになる（同秒衝突は連番サフィックスで回避）
-- **レベル**: 最低 INFO / WARN / ERROR の 3 段階（将来 #85 で DEBUG 追加予定）
-- **フォーマット**: `[YYYY-MM-DD HH:mm:ss] [LEVEL] [Module] message` で統一
-- **保持期間**: 30 日。古いファイルは起動時に自動削除（mtime 基準、現セッションのアクティブファイルは保護）
-- **既存出力との統合**: 既存の `Console.WriteLine` (.NET) / `print()` (GDScript) 等は、
-  Console.SetOut / OS.add_logger の自動キャプチャで **コード変更ゼロ** でファイルにも流すこと。
-  新規コードでは `Logger.Info/Warn/Error` 等で明示的にレベル指定
-- **起動・終了イベント**: 必ず INFO で記録（事故調査で「いつ落ちたか」が分かるように）
-- **Logger 自体の障害は握り潰す**: ログ機構の例外でアプリ起動を止めない・無限ループを起こさない
-  （Logger 内部の例外は **ログにも書かない** こと。書くと再帰してハング）
-
-参照実装: `GCTonePrism_Manager/Services/Logger.cs`, `GCTonePrism_Launcher/scripts/logger.gd`
-（クライアント追加時は SPECIFICATION.md §3.6 の仕様も合わせて参照）
+- `SPECIFICATION.md` に記載があるがイシューが存在しない機能・課題を発見した場合、イシュー作成を提案する。
+- イシューに記載があるが `SPECIFICATION.md` に未反映の仕様変更を発見した場合、仕様書への追記を提案する。

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -2106,6 +2106,44 @@ GCTonePrism/
 
 ---
 
+### 7.6 スキーマ管理ワークフロー
+
+`prism.db` のスキーマを変更する際は、以下のワークフローを必ず守ること。
+本節は v1.5.1 (2026-03-28) で `surveys` / `play_records` のスキーマ定義を更新したものの
+マイグレーション未実装で実 DB と SPEC が drift していた事故（Manager v0.8.1 の
+`MigrateV10ToV11` で事後修正）の再発防止として設けられた運用規約。
+
+#### 7.6.1 マイグレーション実装の必須化
+
+- `GCTonePrism_Manager/SchemaManager.cs` の `CreateTables()` 内のスキーマ定義を変更したら：
+  1. 対応する `MigrateVxToVy()` 関数を追加する
+  2. `CurrentDbVersion` をインクリメントする
+- **`CREATE TABLE IF NOT EXISTS` は新規 DB 用**。既存 DB ではテーブルが存在する場合に何もしないため、
+  既存運用 DB に変更を反映するには ALTER TABLE / DROP+CREATE+データ移行 を伴う
+  明示的なマイグレーション関数が必要。
+
+#### 7.6.2 検証
+
+- マイグレーション実装後は `tools/sqlite3/sqlite3.exe` で
+  変更前後の `PRAGMA table_info(<tableName>);` を実行し、想定スキーマと一致するか手動検証する。
+- Manager 起動時の `VerifySchema()` でも `ExpectedSchema` 辞書との自動比較が走るが、
+  手動検証も併用する（自動チェックは `ExpectedSchema` との比較のみで、本書 §7.3 とは比較しない）。
+
+#### 7.6.3 ExpectedSchema ↔ SPEC §7.3 同期義務
+
+- `SchemaManager.cs` 末尾の `ExpectedSchema` 辞書を更新したら、本書 §7.3 のテーブル定義表
+  （およびできれば §7.2 階層図 / §7.4 ER 図）も同時に更新すること。
+- `VerifySchema()` は `ExpectedSchema` との比較しか行わず、SPEC は読まないため、
+  SPEC 側の drift は人間が見つける必要がある。
+
+#### 7.6.4 過去事例
+
+- **SPEC v1.5.1 (2026-03-28)**: `surveys` / `play_records` のスキーマを変更したが
+  マイグレーション未実装のため drift が温存。Manager v0.8.1 の `MigrateV10ToV11` で修正。
+- 詳細は §変更履歴 v1.9.1 / v1.9.2 を参照。
+
+---
+
 ## 8. 開発計画
 
 ### 8.1 フェーズ
@@ -2521,7 +2559,7 @@ GCTonePrism/
     - アプリ起動時に古いDBバージョンを検知した場合、自動的に構造変更（ALTER TABLEなど）を行い、データを保持したまま最新バージョンへ更新する
   - **整合性維持**:
     - LauncherとManagerの両方で同じバージョン定数を持ち、バージョン不一致によるデータ破損を防ぐ
-
+- **実装ワークフロー**: §7.6「スキーマ管理ワークフロー」を参照。
 
 詳細なバージョン管理戦略については、`.cursorrules`の「バージョン管理戦略」セクションを参照してください。
 
@@ -2561,6 +2599,7 @@ GCTonePrism/
 
 | 日付 | バージョン | 変更内容 | 変更者 |
 | --- | --- | --- | --- |
+| 2026-05-11 | 1.10.2 | §7.6「スキーマ管理ワークフロー」を新設 (#131)：マイグレーション実装の必須化（`CreateTables()` 変更 → `MigrateVxToVy()` 追加 → `CurrentDbVersion` 増分）、`tools/sqlite3/sqlite3.exe` での手動検証、`ExpectedSchema` ↔ §7.3 同期義務、v1.5.1 drift 事故の再発防止規約を SPEC 側に正式収録。これまで `AGENTS.md` にしか存在しなかった運用規約を SPEC 側に格上げし、`AGENTS.md` は「ルールのみ」に絞ってコンテキストロード時のサイズを削減（78 行 → 約 40 行）。§3.6 のログ基盤要件と合わせて、`AGENTS.md` からはリンクで参照する構造に統一。§8.2 #5 Database Schema Version から §7.6 への参照リンクも追加。 | Kenshiro Kuroga & Claude |
 | 2026-05-11 | 1.10.1 | Manager にログビューア UI を追加 (#129)：v1.10.0 で導入したファイルログ基盤の実用化。新規「ログ」タブで `<project_root>/logs/{manager,launcher}/` 両方のセッションログを横割りレイアウト（上=ファイル一覧 / 下=本文）で閲覧可能に。ツールバーは INFO/WARN/ERROR レベルフィルタ + Manager/Launcher コンポーネントフィルタ + 全文検索窓。**ハイライトモード**を採用：フィルタや検索で他の行が消えるのではなく、マッチ行は通常表示+レベル別背景色、非マッチ行は薄い灰色文字でディム表示するため文脈を失わず追跡可能。検索ヒット substring には追加で黄色ハイライト。本文は WordWrap 有効で横スクロール無し。Logger が書き込み中のファイルも `FileShare.ReadWrite` でロックなし閲覧可能。Manager v0.8.9 で実装。 | Kenshiro Kuroga & Claude |
 | 2026-05-11 | 1.10.0 | ファイルログ基盤を全コンポーネント横断要件として §3.6 に新設 (#116 / #85 の土台)：Manager (v0.8.8) は新規 `Services/Logger.cs` で `Console.SetOut` フックにより既存 109 件の `Console.WriteLine($"[X] msg")` を **コード変更ゼロ** でファイルにも自動転送、INFO/WARN/ERROR の 3 段階を提供。Launcher (v0.5.16) は新規 autoload `scripts/logger.gd` が `OS.add_logger` (Godot 4.5+) で `print` / `printerr` / `push_warning` / `push_error` をすべて捕捉し、レベル振り分けして出力。**保存先は `<project_root>/logs/{manager,launcher}/<component>_<PCname>_<YYYY-MM-DD_HHmmss>.log`** に集約配置：(a) prism.db と同じ共有先に置くことで Manager の将来的なログビューア UI で複数 PC のログを 1 箇所閲覧可能、(b) **1 起動セッション = 1 ファイル** のため複数 PC が同時に書いても競合・interleaving が起きない、(c) PC 名 + 起動時刻でファイル名がユニーク（同秒衝突は連番サフィックスで回避）。30 日 retention（起動時に mtime 基準で古いファイル自動削除、現セッションは保護）。AGENTS.md に「Cross-component Standards」セクション追加して将来の Monitor / Tools 等の追加時にも同じベースラインが適用されるよう保証。 | Kenshiro Kuroga & Claude |
 | 2026-05-10 | 1.9.11 | バックアップ履歴の改善 (#126)：`backup_log` テーブルに `relative_path` 列を追加 (DB v11 → v12)。バックアップ作成時に `prism.db` のあるディレクトリからの相対パスも記録し、表示・復元時は新規 `BackupPathResolver` で動的にパスを再構築することでプロジェクト場所の移動に追従できるように（ユーザーが「Documents 配下 → C 直下」のように頻繁にプロジェクトを移動するため）。`failed` 状態のレコードは Manager 起動時に物理ファイル + DB レコード両方を自動掃除（表示価値が無く、古いプロジェクトパスのゴミの主因）。履歴一覧に「選択した履歴を削除...」ボタンを追加し、ユーザーが個別にバックアップを片付けられるように。表示時は `File.Exists` チェックで不在ファイルを非表示（DB レコードは保護のため残す）。Manager v0.8.7 で実装。 | Kenshiro Kuroga & Claude |


### PR DESCRIPTION
## Summary

- `CLAUDE.md` から `@AGENTS.md` で毎セッション全文ロードされる `AGENTS.md` が 9 セクション 78 行に肥大化していたため、ルール（do/don't）だけを残して詳細仕様を `SPECIFICATION.md` 側に格上げ移管。
- `SPECIFICATION.md` に **§7.6「スキーマ管理ワークフロー」** を新設（マイグレーション必須化・`sqlite3.exe` 検証・`ExpectedSchema` ↔ §7.3 同期義務・v1.5.1 drift 事故の再発防止規約）。
- `AGENTS.md` は 78 → 50 行に圧縮。`Cross-component Standards` のログ仕様詳細は SPEC §3.6 リンクに、`Database Schema Management` の運用詳細は SPEC §7.6 リンクに置換。

## 設計のポイント

- **「Logger 自体の障害は握り潰す」**（再帰ハング回避）と **「`CreateTables()` 編集時の `MigrateVxToVy` 義務」** は最重要ルールとして AGENTS.md に残置。SPEC を読まないと忘れる類のものは AGENTS.md に冗長に書く価値あり。
- **Session Start を最上段に移動**：このルールが効くべきはまさにセッション開始時なので AGENTS.md 上端へ。GitHub Integration の「セッション開始時」項目は重複削減のため統合。
- **CLAUDE.md / CHANGELOG.md は変更なし**：`@AGENTS.md` 参照は維持。Launcher / Manager / Monitor のコード変更が無いためアプリ版数も据え置き、SPEC のみ v1.10.1 → v1.10.2 に更新。

Closes #131

## Test plan

- [ ] `AGENTS.md` を新セッションで読み込ませて、セッション開始時の挙動が従来通りであることを確認
- [ ] SPEC §7.6 の見出しが §3.6 同様に参照しやすい形式になっていることを目視確認
- [ ] AGENTS.md から SPEC §3.6 / §7.6 への参照リンクが、SPEC の見出しと一致していることを目視確認
- [ ] 重要ルール（Logger 障害握り潰し、Migrate 義務）が AGENTS.md に残存しているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)