### PR TITLE
fix(release): bat の BOM 認識失敗 + gh release view の terminating error を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,19 @@
 
 #### Fixed
 
-- **`Release.bat` を UTF-8 (no BOM) + ASCII プレフィックスに変更**: 実機で BOM (`EF BB BF`) が CP932 として解釈され `@echo off` が機能しない問題を解消。`chcp 65001` 以降の領域は引き続き日本語可。v1.0.5 で導入した日本語併記 `[WARN]` echo は chcp 切替前 + no-BOM の整合性確保のため削除 (撤回が意図的であることを明示)
-- **PS 5.1 + `$ErrorActionPreference='Stop'` 下での `2>&1` native command stderr trap を全 3 箇所で潰し、Release.ps1 冒頭に集約コメントを設置**:
-  - `gh release view` (タグ衝突チェック): `2>$null | Out-Null` + exit code 判定で、release 存在時の JSON 大量出力も同時に抑止
-  - `gh auth status` (Test-Preflight): 旧実装は `2>&1` が NativeCommandError 化、新実装は変数代入 + `Out-String` で診断情報を文字列として捕捉。失敗時に `gh auth login` 以外の原因 (network / proxy / token expiry) も Fail メッセージに出して切り分け可能に
-  - `git status --porcelain` (Assert-WorkingTreeClean): redirect 削除 + 明示的 `$LASTEXITCODE` チェック + Fail 追加。redirect 単純削除では git 失敗時に `else` 分岐へ落ちて "clean" 誤報告する **silent pass regression を踏むため、exit code check を必須で組み合わせる** (このリポジトリの bad release を防ぐ preflight 安全網の中枢部分なので明示的に Fail で止める)
-- **Release.bat の codepage 復元コメントを 4 行 → 2 行に簡素化** (詳細は冒頭 docstring に集約済みのため二重記述解消)
+#### Fixed
+
+- **`Release.bat` ダブルクリック / ターミナル実行で実質動作しない問題**: cmd.exe が UTF-8 BOM (`EF BB BF`) を CP932 として解釈、1 行目の `@echo off` が機能せず、全 REM 行を echo on で splay + cp932-mojibake で表示する状態だった。UTF-8 (no BOM) + ASCII プレフィックス (`chcp 65001` 以前は ASCII 限定) に変更して解消
+- **`gh release view` が release 不在時に script を terminating error で止める問題**: preflight タグ衝突チェックの `2>&1` が PS 5.1 + `$ErrorActionPreference='Stop'` 下で NativeCommandError 化、本来「衝突なし続行」のはずの正常系で fail していた問題。`2>$null | Out-Null` パターンに変更
+- **同 anti-pattern が `gh auth status` と `git status --porcelain` にも残っていた問題**: シニアレビューで指摘され全 3 箇所を統一
+  - `gh auth status`: `& cmd 2>&1 | Out-String` パターンで診断情報を文字列として保持。失敗時に `gh auth login` 以外の原因 (network / proxy / token expiry / install 破損) も Fail メッセージに出して切り分け可能に
+  - `git status --porcelain`: redirect 削除 + 明示的 `$LASTEXITCODE` チェック + Fail 追加。redirect 単純削除では git 失敗時に "clean" 誤報告の **silent pass regression** を踏むため exit code check 必須
+
+#### Changed
+
+- **v1.0.5 で導入した `[WARN]` メッセージの日本語併記行を削除**: chcp 取得失敗パスは codepage 未切替 + ファイル no-BOM のため日本語 echo の文字化けが確定的、ASCII-only ルールに整合させる形で意図的に撤回
+- **`2>&1` trap 関連の per-site コメント 3 箇所を集約 + 参照形式に整理**: Release.ps1 冒頭の `Set-StrictMode` 直後に集約コメントを設置 (GOOD-1 / GOOD-2 / GOOD-3 / BAD-a / BAD-b の早見表)、各 call site は集約参照 + 1-2 行に絞り込んで重複削減
+- **Release.bat の docstring に「BOM 復活禁止」の明示注記** + chcp 65001 境界の banner-style 区切り強化、editor が BOM を自動付与しようとする誘惑への防御
 
 ### [Release Tooling v1.0.5] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@
 - **`Get-BundleReleaseNotes` の正規表現に `\Z` 追加**: 旧 lookahead `(?=^### |^---|^## )` は必ず後続セクションマーカーを要求し、Bundle entry が CHANGELOG 末尾 (後続なし) だと空文字列を返す regression。現状の CHANGELOG 構造 (Bundle 配下に Launcher / Manager / Release Tooling が続く) では発火しないが、将来セクション順を入れ替えた場合や最小 CHANGELOG での誤動作を防ぐ保険
 - **`gh auth status` の success 時 warning を抽出して `Write-Warn`**: `gh` は exit 0 でも stderr に token scope 不足 / token expiry 近接の warning を出すことがある。失敗ではないが早期の気付きをリリース担当に届けるため、出力中の特定パターンを検出して警告表示 (release 自体は継続)
   - **シニアレビュー round 8 (M1) 反映**: 初版の `warning|expir` regex は `expiration` / `experimental` / 通常 success 時の `Token expires:` 等にも hit する false positive 多数。特異性高めの `(token has expired\|token expir(es\|ed\|ing) in \d+\s*(day\|hour)\|missing.*scope\|insufficient.*scope\|^warning:)` に厳密化
+- **シニアレビュー round 9 反映**:
+  - **H1**: `Test-ExpectedFiles` → `Assert-ExpectedFiles` リネーム。round 6 で `Test-Preflight` → `Assert-Preflight` した時と完全に同じ条件 (`Fail` (exit 1) する関数で PowerShell の `Test-*` = `[bool]` 規約に違反) に該当していた漏れを解消、命名規約の対象範囲を完結させる
+  - **M2**: `gh auth status` warning 検出 regex を `^warning:` (gh 公式の warning prefix) のみに簡素化。round 8 の特殊形式 (`token expir(es|ed|ing) in \d+...` 等) は false negative リスク (「Token will expire soon」「tomorrow」等の日数表記なし形式の取りこぼし) があり、かつ gh 出力フォーマット変更に脆弱。本格的な structured 検出は別 issue (#141 系) で JSON parse に寄せる方針なので、ここでは過信を生む特殊形式を持たない方向に倒した
+  - **L2**: `Get-BundleReleaseNotes` の `\Z` コメントを 6 行 → 1 行に圧縮。発火確率の低さに対しコメント長が不釣り合いだった
+  - **L4**: `Assert-Preflight` 関数内のリネーム言い訳コメント (2 行) を削除。リネーム判断の justification は CHANGELOG / PR 説明に書く内容で、関数定義に残すと半年後の reader が「なぜここに?」となる
+  - **L5**: `Release.bat` の `enabledelayedexpansion` 副作用例から架空引数 `-Tag` を削除、現存 pass-through 引数の列挙 + 「新規 pass-through 引数追加時の注意」framing に変更
+- **別 issue 化**:
+  - **M1 (#142)**: catalog vs per-site コメントの方針統一 — ラベル参照 + 詳細説明の二重化がメンテナンスコストを生む構造に逆戻りしていた問題。本 PR スコープ外で trackable 化
+  - **M3 (#143)**: `Release.bat` の docstring 経緯を `SPECIFICATION.md` に分離 — 100/150 行が REM の状態を整理する separate PR 候補
 - **シニアレビュー round 8 反映**:
   - **H1**: `Release.bat` の `findstr` validation コメントに「`findstr` 自体の起動失敗 (minimal WinPE / PATH 破損) も同じ skip path に落ちる」旨を追記。区別不可なので同一扱いは意図的だが、コメントが反映していなかった
   - **M2**: catalog ⇔ call site 整合性の最終 sweep。`Resolve-MsBuild` の vswhere call site (CAPTURE_STDOUT 該当) に label が欠落していたため追加。これで全 6 件の native `&` call site にパターンマーカー揃った

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,18 +33,12 @@
 
 #### Fixed
 
-- **`Release.bat` を UTF-8 (no BOM) に変更してダブルクリック起動時の BOM 認識失敗を解消**: 実機で `.\Release.bat` 実行すると `'・ｿ@echo' は内部コマンドまたは外部コマンドとして認識されていません` のエラーで `@echo off` が機能せず、すべての REM 行がエコー出力 + Japanese 文字化けする問題が発生。原因は cmd.exe が UTF-8 BOM (`EF BB BF`) を CP932 として解釈して 1 行目を破壊していたこと
-  - BOM を外して UTF-8 (no BOM) + CRLF に書き直し、`chcp 65001` より前の REM / echo を全部 ASCII (英語) に統一
-  - `chcp 65001 >nul` 以降の REM / echo は引き続き日本語可
-  - docstring 冒頭にも「`chcp 65001` 行より上は ASCII-only 必須」のルールを明記、将来編集者の事故防止
-  - PR #138 v1.0.5 docstring に書いていた「BOM 認識不能環境での脱出方法 (Win 10 1809 以前の cmd.exe build 等)」(同 PR でレビュアーが "M2" として指摘していた将来想定) をついに本採用
-  - 副作用として v1.0.5 で導入していた **`[WARN]` メッセージの日本語併記行を削除**。これは chcp 取得失敗時にのみ実行される警告だが、その時点で codepage は切り替わっておらず + ファイルが UTF-8 no-BOM になったため日本語 echo がコンソールで文字化けすることが確定的なため、ASCII-only ルールに整合させる形で撤回
-- **`gh release view` が release 不在時に script を terminating error で止める問題を修正 (タグ衝突チェック)**: preflight でタグ衝突を確認する `& gh release view "v$Version" 2>&1` の `2>&1` が `$ErrorActionPreference='Stop'` 下で native command stderr を `NativeCommandError` の terminating error として扱い、本来「衝突なし、続行」のはずの正常系で script が止まっていた
-  - `2>&1` を `2>$null` に変更して stderr を捨て、`$LASTEXITCODE` だけで判定する形に修正
-  - `| Out-Null` で stdout も握り潰し: release 存在時は gh が release の JSON / 詳細を stdout に dump するため、preflight 中にコンソールが汚れるのを抑止
-- **同種の `2>&1` 罠が他 2 箇所残っていたため一括修正**: 上記 1 箇所修正したシニアレビューで「同じ anti-pattern が他にもある」と指摘 → 全箇所統一
-  - `& gh auth status 2>&1` (`Test-Preflight`): gh auth status は **正常系でも stderr に認証情報を書く** (gh の設計仕様) ため、`2>&1` 経由で NativeCommandError 化する bomb。`2>$null | Out-Null` + exit code 判定の形に修正。失敗時メッセージは「`gh auth login` を実行してください」だけで十分自明なため、認証情報詳細の表示はやめた
-  - `& git -C $RepoRoot status --porcelain 2>&1` (`Assert-WorkingTreeClean`): git status は正常系で stderr を出さないため発火しないが、対称性のため `2>&1` を削除して native exit code だけで判定する形に統一
+- **`Release.bat` を UTF-8 (no BOM) + ASCII プレフィックスに変更**: 実機で BOM (`EF BB BF`) が CP932 として解釈され `@echo off` が機能しない問題を解消。`chcp 65001` 以降の領域は引き続き日本語可。v1.0.5 で導入した日本語併記 `[WARN]` echo は chcp 切替前 + no-BOM の整合性確保のため削除 (撤回が意図的であることを明示)
+- **PS 5.1 + `$ErrorActionPreference='Stop'` 下での `2>&1` native command stderr trap を全 3 箇所で潰し、Release.ps1 冒頭に集約コメントを設置**:
+  - `gh release view` (タグ衝突チェック): `2>$null | Out-Null` + exit code 判定で、release 存在時の JSON 大量出力も同時に抑止
+  - `gh auth status` (Test-Preflight): 旧実装は `2>&1` が NativeCommandError 化、新実装は変数代入 + `Out-String` で診断情報を文字列として捕捉。失敗時に `gh auth login` 以外の原因 (network / proxy / token expiry) も Fail メッセージに出して切り分け可能に
+  - `git status --porcelain` (Assert-WorkingTreeClean): redirect 削除 + 明示的 `$LASTEXITCODE` チェック + Fail 追加。redirect 単純削除では git 失敗時に `else` 分岐へ落ちて "clean" 誤報告する **silent pass regression を踏むため、exit code check を必須で組み合わせる** (このリポジトリの bad release を防ぐ preflight 安全網の中枢部分なので明示的に Fail で止める)
+- **Release.bat の codepage 復元コメントを 4 行 → 2 行に簡素化** (詳細は冒頭 docstring に集約済みのため二重記述解消)
 
 ### [Release Tooling v1.0.5] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,17 @@
 - **Release.bat の docstring 整理**: BOM 失敗症状の記述を「最初の 1 行目で `@echo off` ITSELF が fail する」に厳密化 (旧記述 "subsequent commands fail" は誤り)、chcp 65001 境界 banner を 4 行 → 1 行 marker に簡素化 (詳細は docstring と一元化)
 - **Release.bat に codepage 切替の Flow ダイアグラム追加**: `for /f` + 3 if 文の状態遷移 (`captured + numeric` / `captured + invalid` / `not captured`) を docstring 冒頭の Flow セクションで明示。3 つの独立 if を逐次読まなくても判断できる
 - **`Get-BundleReleaseNotes` の正規表現に `\Z` 追加**: 旧 lookahead `(?=^### |^---|^## )` は必ず後続セクションマーカーを要求し、Bundle entry が CHANGELOG 末尾 (後続なし) だと空文字列を返す regression。現状の CHANGELOG 構造 (Bundle 配下に Launcher / Manager / Release Tooling が続く) では発火しないが、将来セクション順を入れ替えた場合や最小 CHANGELOG での誤動作を防ぐ保険
-- **`gh auth status` の success 時 warning を抽出して `Write-Warn`**: `gh` は exit 0 でも stderr に token scope 不足 / token expiry 近接の warning を出すことがある。失敗ではないが早期の気付きをリリース担当に届けるため、stdout 中の `warning|expir` を検出して警告表示 (release 自体は継続)
+- **`gh auth status` の success 時 warning を抽出して `Write-Warn`**: `gh` は exit 0 でも stderr に token scope 不足 / token expiry 近接の warning を出すことがある。失敗ではないが早期の気付きをリリース担当に届けるため、出力中の特定パターンを検出して警告表示 (release 自体は継続)
+  - **シニアレビュー round 8 (M1) 反映**: 初版の `warning|expir` regex は `expiration` / `experimental` / 通常 success 時の `Token expires:` 等にも hit する false positive 多数。特異性高めの `(token has expired\|token expir(es\|ed\|ing) in \d+\s*(day\|hour)\|missing.*scope\|insufficient.*scope\|^warning:)` に厳密化
+- **シニアレビュー round 8 反映**:
+  - **H1**: `Release.bat` の `findstr` validation コメントに「`findstr` 自体の起動失敗 (minimal WinPE / PATH 破損) も同じ skip path に落ちる」旨を追記。区別不可なので同一扱いは意図的だが、コメントが反映していなかった
+  - **M2**: catalog ⇔ call site 整合性の最終 sweep。`Resolve-MsBuild` の vswhere call site (CAPTURE_STDOUT 該当) に label が欠落していたため追加。これで全 6 件の native `&` call site にパターンマーカー揃った
+  - **M3**: PS 7.3+ の `$PSNativeCommandUseErrorActionPreference` (default `$true`) が `& cmd` の非ゼロ exit code を terminating error 化する仕様を集約コメントに追記。本スクリプトの「2>&1 を外して `$LASTEXITCODE` で判定」イディオムが PS 7 で silent regression する可能性 + 回避策 (`$false` 固定 or try/catch) を記録
+  - **L1**: `Release.bat` の `setlocal enabledelayedexpansion` で引数中の `!` が消費される副作用を docstring に明記
+  - **L2**: anti-pattern の「変数 capture なし版」が現実に書かれる経緯 (副作用 only call で stderr も console に出したい意図の typo) を 1 行追加
+  - **L4**: chcp 65001 skip path で日本語 echo が文字化けする旨を ASCII 1 行で改めて警告 (line 89-90 の `[WARN]` だけでは見落とされる可能性に対する保険)
+  - **L5**: `Get-BundleReleaseNotes` の `\Z` コメントを精度向上。現実の発火条件は「初回 Bundle release + 後続セクション未追加の極初期状態」のみで、汎用的な「セクション順変更時」は誤誘導
+  - **H2 → 別 issue 化 (#141)**: `gh release view` の exit code 単独依存による silent false-negative。zip ビルド完了後に fail する path が残るが、本 PR スコープ外で `--json id` への移行を別 issue として trackable 化
 
 ### [Release Tooling v1.0.5] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@
 
 #### Fixed
 
-#### Fixed
-
 - **`Release.bat` ダブルクリック / ターミナル実行で実質動作しない問題**: cmd.exe が UTF-8 BOM (`EF BB BF`) を CP932 として解釈、1 行目の `@echo off` が機能せず、全 REM 行を echo on で splay + cp932-mojibake で表示する状態だった。UTF-8 (no BOM) + ASCII プレフィックス (`chcp 65001` 以前は ASCII 限定) に変更して解消
 - **`gh release view` が release 不在時に script を terminating error で止める問題**: preflight タグ衝突チェックの `2>&1` が PS 5.1 + `$ErrorActionPreference='Stop'` 下で NativeCommandError 化、本来「衝突なし続行」のはずの正常系で fail していた問題。`2>$null | Out-Null` パターンに変更
 - **同 anti-pattern が `gh auth status` と `git status --porcelain` にも残っていた問題**: シニアレビューで指摘され全 3 箇所を統一
@@ -44,8 +42,12 @@
 #### Changed
 
 - **v1.0.5 で導入した `[WARN]` メッセージの日本語併記行を削除**: chcp 取得失敗パスは codepage 未切替 + ファイル no-BOM のため日本語 echo の文字化けが確定的、ASCII-only ルールに整合させる形で意図的に撤回
-- **`2>&1` trap 関連の per-site コメント 3 箇所を集約 + 参照形式に整理**: Release.ps1 冒頭の `Set-StrictMode` 直後に集約コメントを設置 (GOOD-1 / GOOD-2 / GOOD-3 / BAD-a / BAD-b の早見表)、各 call site は集約参照 + 1-2 行に絞り込んで重複削減
-- **Release.bat の docstring に「BOM 復活禁止」の明示注記** + chcp 65001 境界の banner-style 区切り強化、editor が BOM を自動付与しようとする誘惑への防御
+- **`2>&1` trap 関連の per-site コメント 3 箇所を集約 + 参照形式に整理**: Release.ps1 冒頭の `Set-StrictMode` 直後に集約コメントを設置、各 call site は集約参照 + 1-2 行の理由のみ。集約ラベルは self-documenting な名前 (`SUPPRESS_BOTH` / `CAPTURE_DIAGNOSTIC` / `CAPTURE_STDOUT` / `PASS_THROUGH` / `STOP_TRAP` / `STREAM_TO_VAR`) で索引参照型コメントの欠点 (表まで戻る往復) を解消。集約コメント内に「機構」セクションを追加して PS 7.x 等への移植時の調査起点を明示
+- **`Test-Preflight` → `Assert-Preflight` リネーム**: PowerShell 規約で `Test-*` は `[bool]` 返却用 (`Test-Path` / `Test-Connection` 等)。preflight は違反時 `Fail` (= `exit 1`) する性質なので `Assert-*` 系に揃え、同ファイル内の `Assert-WorkingTreeClean` と命名一貫性を取る
+- **`Release.bat` の防御性向上**:
+  - `ORIGINAL_CODEPAGE` の数値 validation (`findstr /R "^[0-9][0-9]*$"`) を追加。chcp 出力が想定外フォーマット (unicode digit / 想定外 locale 等) の場合に exit 時の `chcp %ORIGINAL_CODEPAGE%` が garbage を渡して cmd 窓が壊れるレアケースを防御
+  - `FORWARDED_ARGS` 連結ロジックを `if defined` 分岐で書き換え、初回 append 時の leading space を解消 (echo 出力の見た目改善)
+- **Release.bat の docstring 整理**: BOM 失敗症状の記述を「最初の 1 行目で `@echo off` ITSELF が fail する」に厳密化 (旧記述 "subsequent commands fail" は誤り)、chcp 65001 境界 banner を 4 行 → 1 行 marker に簡素化 (詳細は docstring と一元化)
 
 ### [Release Tooling v1.0.5] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,14 @@
   - BOM を外して UTF-8 (no BOM) + CRLF に書き直し、`chcp 65001` より前の REM / echo を全部 ASCII (英語) に統一
   - `chcp 65001 >nul` 以降の REM / echo は引き続き日本語可
   - docstring 冒頭にも「`chcp 65001` 行より上は ASCII-only 必須」のルールを明記、将来編集者の事故防止
-  - PR #138 で UTF-8 BOM 採用してた M2 想定の脱出経路をついに本採用 (Win 10 1809 以前と思しき cmd.exe 環境で BOM 認識が動かなかったため)
+  - PR #138 v1.0.5 docstring に書いていた「BOM 認識不能環境での脱出方法 (Win 10 1809 以前の cmd.exe build 等)」(同 PR でレビュアーが "M2" として指摘していた将来想定) をついに本採用
+  - 副作用として v1.0.5 で導入していた **`[WARN]` メッセージの日本語併記行を削除**。これは chcp 取得失敗時にのみ実行される警告だが、その時点で codepage は切り替わっておらず + ファイルが UTF-8 no-BOM になったため日本語 echo がコンソールで文字化けすることが確定的なため、ASCII-only ルールに整合させる形で撤回
 - **`gh release view` が release 不在時に script を terminating error で止める問題を修正 (タグ衝突チェック)**: preflight でタグ衝突を確認する `& gh release view "v$Version" 2>&1` の `2>&1` が `$ErrorActionPreference='Stop'` 下で native command stderr を `NativeCommandError` の terminating error として扱い、本来「衝突なし、続行」のはずの正常系で script が止まっていた
   - `2>&1` を `2>$null` に変更して stderr を捨て、`$LASTEXITCODE` だけで判定する形に修正
-  - 結果も使わないので出力を `Out-Null` に流す
+  - `| Out-Null` で stdout も握り潰し: release 存在時は gh が release の JSON / 詳細を stdout に dump するため、preflight 中にコンソールが汚れるのを抑止
+- **同種の `2>&1` 罠が他 2 箇所残っていたため一括修正**: 上記 1 箇所修正したシニアレビューで「同じ anti-pattern が他にもある」と指摘 → 全箇所統一
+  - `& gh auth status 2>&1` (`Test-Preflight`): gh auth status は **正常系でも stderr に認証情報を書く** (gh の設計仕様) ため、`2>&1` 経由で NativeCommandError 化する bomb。`2>$null | Out-Null` + exit code 判定の形に修正。失敗時メッセージは「`gh auth login` を実行してください」だけで十分自明なため、認証情報詳細の表示はやめた
+  - `& git -C $RepoRoot status --porcelain 2>&1` (`Assert-WorkingTreeClean`): git status は正常系で stderr を出さないため発火しないが、対称性のため `2>&1` を削除して native exit code だけで判定する形に統一
 
 ### [Release Tooling v1.0.5] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@
 - **`Get-BundleReleaseNotes` の正規表現に `\Z` 追加**: 旧 lookahead `(?=^### |^---|^## )` は必ず後続セクションマーカーを要求し、Bundle entry が CHANGELOG 末尾 (後続なし) だと空文字列を返す regression。現状の CHANGELOG 構造 (Bundle 配下に Launcher / Manager / Release Tooling が続く) では発火しないが、将来セクション順を入れ替えた場合や最小 CHANGELOG での誤動作を防ぐ保険
 - **`gh auth status` の success 時 warning を抽出して `Write-Warn`**: `gh` は exit 0 でも stderr に token scope 不足 / token expiry 近接の warning を出すことがある。失敗ではないが早期の気付きをリリース担当に届けるため、出力中の特定パターンを検出して警告表示 (release 自体は継続)
   - **シニアレビュー round 8 (M1) 反映**: 初版の `warning|expir` regex は `expiration` / `experimental` / 通常 success 時の `Token expires:` 等にも hit する false positive 多数。特異性高めの `(token has expired\|token expir(es\|ed\|ing) in \d+\s*(day\|hour)\|missing.*scope\|insufficient.*scope\|^warning:)` に厳密化
+- **シニアレビュー round 10 反映**:
+  - **L4**: catalog `PASS_THROUGH` の「exit code チェック必須」理由を cross-reference から自己完結型に修正。旧コメントは「CAPTURE_STDOUT_PASS_STDERR と同じ理由」と参照していたが、後者の理由は「出力空でも `$LASTEXITCODE` 非ゼロ誤判定防止」で変数 capture が前提。`PASS_THROUGH` は変数 capture なしで構造的に該当しない。`PASS_THROUGH` の真の理由「成否判定の信号が exit code のみのため」に書き換え
+  - **L5**: `Get-BundleReleaseNotes` の `-SilentMissing` switch を `-AllowMissing` にリネーム。旧名は「CHANGELOG.md が見つからない時」のみを silent にする読みだが、実体は「Bundle セクションが見つからなかった時」も含めて empty 返却する semantics。`AllowMissing` の方が実態に近い
+- **別 issue 化**:
+  - **M1 (#144)**: `Read-LauncherVersion` / `Read-ManagerVersion` / `Read-ComponentVersions` の命名規約 sweep — `Read-*` は PowerShell では対話的入力 (`Read-Host` 等) を意味、ファイル読み出しは `Get-*` 系が原則。さらに `Fail` する性質を踏まえると round 6/9 の `Test-*` → `Assert-*` sweep の対象範囲外として漏れていた
+  - **M2 (#145)**: catalog `CAPTURE_DIAGNOSTIC` ラベル説明 (「失敗時に表示するため」) が実態より狭い。実装では success 時の `^warning:` 検出にも再利用しているため、「両 stream 文字列化キャプチャ」相当に拡張すべき
+  - **M3 (#146)**: `Assert-WorkingTreeClean` の `$Context -like '*sync 後*'` 文字列マッチを `[switch]$PostSync` パラメータに構造化 — call site の文字列を変えると特例メッセージが silent に失われる脆さを解消
 - **シニアレビュー round 9 反映**:
   - **H1**: `Test-ExpectedFiles` → `Assert-ExpectedFiles` リネーム。round 6 で `Test-Preflight` → `Assert-Preflight` した時と完全に同じ条件 (`Fail` (exit 1) する関数で PowerShell の `Test-*` = `[bool]` 規約に違反) に該当していた漏れを解消、命名規約の対象範囲を完結させる
   - **M2**: `gh auth status` warning 検出 regex を `^warning:` (gh 公式の warning prefix) のみに簡素化。round 8 の特殊形式 (`token expir(es|ed|ing) in \d+...` 等) は false negative リスク (「Token will expire soon」「tomorrow」等の日数表記なし形式の取りこぼし) があり、かつ gh 出力フォーマット変更に脆弱。本格的な structured 検出は別 issue (#141 系) で JSON parse に寄せる方針なので、ここでは過信を生む特殊形式を持たない方向に倒した

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@
 
 `Release.ps1` / `Release.bat` / `Install.bat` (Phase 2 以降) / `Updater` (Phase 3 以降) 等の配布インフラの変更履歴。エンドユーザー向けではなく、開発者が「リリーススクリプトのこの挙動はいつから？」を辿るために残す。
 
+### [Release Tooling v1.0.6] - 2026-05-11
+
+#### Fixed
+
+- **`Release.bat` を UTF-8 (no BOM) に変更してダブルクリック起動時の BOM 認識失敗を解消**: 実機で `.\Release.bat` 実行すると `'・ｿ@echo' は内部コマンドまたは外部コマンドとして認識されていません` のエラーで `@echo off` が機能せず、すべての REM 行がエコー出力 + Japanese 文字化けする問題が発生。原因は cmd.exe が UTF-8 BOM (`EF BB BF`) を CP932 として解釈して 1 行目を破壊していたこと
+  - BOM を外して UTF-8 (no BOM) + CRLF に書き直し、`chcp 65001` より前の REM / echo を全部 ASCII (英語) に統一
+  - `chcp 65001 >nul` 以降の REM / echo は引き続き日本語可
+  - docstring 冒頭にも「`chcp 65001` 行より上は ASCII-only 必須」のルールを明記、将来編集者の事故防止
+  - PR #138 で UTF-8 BOM 採用してた M2 想定の脱出経路をついに本採用 (Win 10 1809 以前と思しき cmd.exe 環境で BOM 認識が動かなかったため)
+- **`gh release view` が release 不在時に script を terminating error で止める問題を修正 (タグ衝突チェック)**: preflight でタグ衝突を確認する `& gh release view "v$Version" 2>&1` の `2>&1` が `$ErrorActionPreference='Stop'` 下で native command stderr を `NativeCommandError` の terminating error として扱い、本来「衝突なし、続行」のはずの正常系で script が止まっていた
+  - `2>&1` を `2>$null` に変更して stderr を捨て、`$LASTEXITCODE` だけで判定する形に修正
+  - 結果も使わないので出力を `Out-Null` に流す
+
 ### [Release Tooling v1.0.5] - 2026-05-11
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,18 @@
 #### Changed
 
 - **v1.0.5 で導入した `[WARN]` メッセージの日本語併記行を削除**: chcp 取得失敗パスは codepage 未切替 + ファイル no-BOM のため日本語 echo の文字化けが確定的、ASCII-only ルールに整合させる形で意図的に撤回
-- **`2>&1` trap 関連の per-site コメント 3 箇所を集約 + 参照形式に整理**: Release.ps1 冒頭の `Set-StrictMode` 直後に集約コメントを設置、各 call site は集約参照 + 1-2 行の理由のみ。集約ラベルは self-documenting な名前 (`SUPPRESS_BOTH` / `CAPTURE_DIAGNOSTIC` / `CAPTURE_STDOUT` / `PASS_THROUGH` / `STOP_TRAP` / `STREAM_TO_VAR`) で索引参照型コメントの欠点 (表まで戻る往復) を解消。集約コメント内に「機構」セクションを追加して PS 7.x 等への移植時の調査起点を明示
+- **`2>&1` trap 関連の per-site コメント 3 箇所を集約 + 参照形式に整理**: Release.ps1 冒頭の `Set-StrictMode` 直後に集約コメントを設置、各 call site は集約参照 + 1-2 行の理由のみ。集約ラベルは self-documenting な名前 (`SUPPRESS_BOTH` / `CAPTURE_DIAGNOSTIC` / `CAPTURE_STDOUT` / `CAPTURE_STDOUT_PASS_STDERR` / `PASS_THROUGH` / `STOP_TRAP`) で索引参照型コメントの欠点 (表まで戻る往復) を解消。集約コメント内に「機構」セクションを追加して PS 7.x 等への移植時の調査起点を明示
+  - **シニアレビュー round 7 反映**: `Assert-WorkingTreeClean` の git status call site は stdout を変数 capture / stderr を console 直書きする hybrid なので、PASS_THROUGH (console 直書き、変数 capture なし) では実態と乖離していた。`CAPTURE_STDOUT_PASS_STDERR` パターンを新設して移行。call site のパターンマーカーと catalog 定義の整合性を保つことが「self-documenting パターン名」アプローチの前提
+  - **`STREAM_TO_VAR` の独立記載を廃止**: `STOP_TRAP` と本質的に同じ罠 (`2>&1` 自体が原因) で、変数 capture 有無は表面の違い。「PS バージョンで挙動が変わる」表現が誤読を招くため統合し、両形式を `STOP_TRAP` 配下にまとめて回避策を 2 つ並記
+  - **`Invoke-GhRelease` の gh release create / delete に pattern マーカー追加**: 集約 catalog の「例外」節に書いてあるが call site にマーカーがなく「対象外」と読まれる余地があった。`# pattern: PASS_THROUGH (例外節)` を 2 箇所に追加
 - **`Test-Preflight` → `Assert-Preflight` リネーム**: PowerShell 規約で `Test-*` は `[bool]` 返却用 (`Test-Path` / `Test-Connection` 等)。preflight は違反時 `Fail` (= `exit 1`) する性質なので `Assert-*` 系に揃え、同ファイル内の `Assert-WorkingTreeClean` と命名一貫性を取る
 - **`Release.bat` の防御性向上**:
   - `ORIGINAL_CODEPAGE` の数値 validation (`findstr /R "^[0-9][0-9]*$"`) を追加。chcp 出力が想定外フォーマット (unicode digit / 想定外 locale 等) の場合に exit 時の `chcp %ORIGINAL_CODEPAGE%` が garbage を渡して cmd 窓が壊れるレアケースを防御
   - `FORWARDED_ARGS` 連結ロジックを `if defined` 分岐で書き換え、初回 append 時の leading space を解消 (echo 出力の見た目改善)
 - **Release.bat の docstring 整理**: BOM 失敗症状の記述を「最初の 1 行目で `@echo off` ITSELF が fail する」に厳密化 (旧記述 "subsequent commands fail" は誤り)、chcp 65001 境界 banner を 4 行 → 1 行 marker に簡素化 (詳細は docstring と一元化)
+- **Release.bat に codepage 切替の Flow ダイアグラム追加**: `for /f` + 3 if 文の状態遷移 (`captured + numeric` / `captured + invalid` / `not captured`) を docstring 冒頭の Flow セクションで明示。3 つの独立 if を逐次読まなくても判断できる
+- **`Get-BundleReleaseNotes` の正規表現に `\Z` 追加**: 旧 lookahead `(?=^### |^---|^## )` は必ず後続セクションマーカーを要求し、Bundle entry が CHANGELOG 末尾 (後続なし) だと空文字列を返す regression。現状の CHANGELOG 構造 (Bundle 配下に Launcher / Manager / Release Tooling が続く) では発火しないが、将来セクション順を入れ替えた場合や最小 CHANGELOG での誤動作を防ぐ保険
+- **`gh auth status` の success 時 warning を抽出して `Write-Warn`**: `gh` は exit 0 でも stderr に token scope 不足 / token expiry 近接の warning を出すことがある。失敗ではないが早期の気付きをリリース担当に届けるため、stdout 中の `warning|expir` を検出して警告表示 (release 自体は継続)
 
 ### [Release Tooling v1.0.5] - 2026-05-11
 

--- a/Release.bat
+++ b/Release.bat
@@ -7,10 +7,11 @@ REM   - cmd.exe parses LF-only bat files incorrectly (silent fail). CRLF is
 REM     required; .gitattributes enforces this via `*.bat eol=crlf`.
 REM   - UTF-8 BOM is NOT used: on cmd.exe builds that do not recognize the
 REM     BOM (observed on some Windows installations), the BOM bytes
-REM     (EF BB BF) are interpreted as CP932 text on the first line. This
-REM     breaks `@echo off` (the script then visibly runs with echo enabled,
-REM     splaying every REM line + cp932-mojibake to the console), and
-REM     subsequent commands fail with "not recognized as ... command" errors.
+REM     (EF BB BF) are interpreted as CP932 text and concatenated with the
+REM     first command. The very first line becomes something like
+REM     "'_@echo' is not recognized as ... command", which means `@echo off`
+REM     ITSELF fails. From that point on the script runs with echo enabled,
+REM     splaying every REM line + cp932-mojibake to the console.
 REM     Do NOT re-introduce a BOM here even if a modern editor suggests it.
 REM   - Comments / echo above the `chcp 65001` line MUST stay ASCII because
 REM     they are parsed under the console codepage (cp932 on JP locale).
@@ -53,6 +54,13 @@ REM   Other locales also follow "label: number" pattern, so `delims=:` works.
 for /f "tokens=2 delims=:" %%a in ('chcp') do set ORIGINAL_CODEPAGE=%%a
 REM `%VAR: =%` strips ALL spaces in VAR (chcp output is " 932" with leading space).
 if defined ORIGINAL_CODEPAGE set ORIGINAL_CODEPAGE=%ORIGINAL_CODEPAGE: =%
+REM Validate that the captured value is a pure decimal number. If parsing
+REM produced anything else (unknown locale format, unicode digit, etc.),
+REM treat as "capture failed" by clearing the variable. This protects the
+REM exit-time `chcp %ORIGINAL_CODEPAGE%` from receiving garbage.
+if defined ORIGINAL_CODEPAGE (
+    echo %ORIGINAL_CODEPAGE%| findstr /R "^[0-9][0-9]*$" >nul || set ORIGINAL_CODEPAGE=
+)
 
 REM If ORIGINAL_CODEPAGE failed to parse (unknown locale format, redirection
 REM filtering, etc.), skip the chcp 65001 switch entirely to avoid leaking
@@ -64,10 +72,7 @@ if defined ORIGINAL_CODEPAGE (
     echo [WARN] Skipping UTF-8 codepage switch ^(Japanese output may be garbled^).
 )
 
-REM ====================================================================
-REM Above this line: ASCII-only required (cmd.exe parses under cp932).
-REM Below this line: Japanese OK (UTF-8 console after chcp 65001).
-REM ====================================================================
+REM ==== ASCII boundary (chcp 65001 above, UTF-8 console below) ====
 
 set SCRIPT_DIR=%~dp0
 
@@ -82,7 +87,12 @@ if /i "%~1"=="-NoPause" (
     goto :parseargs
 )
 REM 引数にスペースが含まれる場合 (パス等) のためダブルクォートで保護
-set FORWARDED_ARGS=!FORWARDED_ARGS! "%~1"
+REM 初回 append 時は leading space を付けないため if defined で分岐
+if defined FORWARDED_ARGS (
+    set FORWARDED_ARGS=!FORWARDED_ARGS! "%~1"
+) else (
+    set FORWARDED_ARGS="%~1"
+)
 shift
 goto :parseargs
 

--- a/Release.bat
+++ b/Release.bat
@@ -31,6 +31,13 @@ REM ============================================================================
 
 REM enabledelayedexpansion is required for `!FORWARDED_ARGS!` concatenation in
 REM the parseargs loop below. Removing it breaks argument forwarding.
+REM
+REM Side effect: with delayed expansion enabled, `!` in argument values is
+REM consumed as the delayed-expansion token. e.g. `.\Release.bat -Tag "alpha!"`
+REM loses the `!`. PowerShell switches (-DryRun, -Force, -NoPause, -Version)
+REM never contain `!`, and `-Version` only takes M.m.p[-suffix] strings, so
+REM this is a non-issue in practice. Documented here in case someone adds a
+REM new pass-through arg that accepts arbitrary text.
 setlocal enabledelayedexpansion
 
 REM ---- UTF-8 codepage switch + restore-on-exit setup ----
@@ -63,8 +70,12 @@ REM `%VAR: =%` strips ALL spaces in VAR (chcp output is " 932" with leading spac
 if defined ORIGINAL_CODEPAGE set ORIGINAL_CODEPAGE=%ORIGINAL_CODEPAGE: =%
 REM Validate that the captured value is a pure decimal number. If parsing
 REM produced anything else (unknown locale format, unicode digit, etc.),
-REM treat as "capture failed" by clearing the variable. This protects the
-REM exit-time `chcp %ORIGINAL_CODEPAGE%` from receiving garbage.
+REM OR if `findstr` itself fails to launch (minimal WinPE, broken PATH),
+REM the `||` branch fires and we treat as "capture failed" by clearing
+REM the variable. We can't distinguish "non-numeric" from "findstr missing"
+REM here, so both fall into the same skip path below. That's intentional:
+REM if we can't verify the captured value, refuse the codepage switch and
+REM leak garbage to the caller's cmd window on exit.
 if defined ORIGINAL_CODEPAGE (
     echo %ORIGINAL_CODEPAGE%| findstr /R "^[0-9][0-9]*$" >nul || set ORIGINAL_CODEPAGE=
 )
@@ -104,6 +115,13 @@ shift
 goto :parseargs
 
 :runps
+REM Below uses Japanese echo. If the chcp 65001 skip path was taken above
+REM (no `[WARN]` line, codepage still the original cp932/cp437 etc.), the
+REM Japanese here will be garbled. We emit one more ASCII line to make that
+REM context explicit instead of silently relying on the line 89-90 warning.
+if not defined ORIGINAL_CODEPAGE (
+    echo [WARN] Codepage switch was skipped; the following Japanese output may be garbled.
+)
 echo Release.bat: 引数 = %FORWARDED_ARGS%
 echo Release.bat: NoPause = %NO_PAUSE%
 echo.

--- a/Release.bat
+++ b/Release.bat
@@ -35,13 +35,16 @@ REM bat file character parsing. The file is no-BOM UTF-8, so the top of this
 REM script (above this point) is intentionally ASCII-only.
 REM
 REM Note: `chcp` is console-wide state and is NOT scoped by setlocal/endlocal,
-REM       so an explicit `chcp %ORIGINAL_CODEPAGE%` at the end is required.
-REM       (Otherwise the caller's cmd window keeps codepage 65001 after exit.)
+REM       so an explicit `chcp %ORIGINAL_CODEPAGE%` at the end is required
+REM       (only if we successfully captured the original codepage; see below).
+REM       Otherwise the caller's cmd window keeps codepage 65001 after exit.
 REM
-REM Expected chcp output formats:
-REM   English:  "Active code page: 932"
-REM   Japanese: "Current code page: 932" (translated, same colon layout)
-REM   Other locales also follow "label: number" pattern, so delims=: works.
+REM Expected chcp output structure (this REM block must stay ASCII because it
+REM runs before `chcp 65001`, so don't paste the actual localized strings here):
+REM   English locale (cp437/cp1252): "Active code page: 932"
+REM   Japanese locale (cp932):       label is the localized version (non-ASCII),
+REM                                  same "label: number" layout with colon
+REM   Other locales also follow "label: number" pattern, so `delims=:` works.
 for /f "tokens=2 delims=:" %%a in ('chcp') do set ORIGINAL_CODEPAGE=%%a
 REM `%VAR: =%` strips ALL spaces in VAR (chcp output is " 932" with leading space).
 if defined ORIGINAL_CODEPAGE set ORIGINAL_CODEPAGE=%ORIGINAL_CODEPAGE: =%

--- a/Release.bat
+++ b/Release.bat
@@ -44,6 +44,13 @@ REM       so an explicit `chcp %ORIGINAL_CODEPAGE%` at the end is required
 REM       (only if we successfully captured the original codepage; see below).
 REM       Otherwise the caller's cmd window keeps codepage 65001 after exit.
 REM
+REM Flow (this `for /f` + 3 if blocks below implement the following 3-way branch):
+REM   chcp output captured + numeric  -> chcp 65001, restore original on exit
+REM   chcp output captured + invalid  -> SKIP chcp 65001 (corrupted format)
+REM   chcp output not captured        -> SKIP chcp 65001 (redirect filter, etc.)
+REM Skipping the switch is the safe default: leaks codepage 65001 to the
+REM caller's cmd window can only happen if we entered the switch successfully.
+REM
 REM Expected chcp output structure (this REM block must stay ASCII because it
 REM runs before `chcp 65001`; the JP localized label is intentionally NOT
 REM pasted here, see CHANGELOG [Release Tooling v1.0.5] for the literal):

--- a/Release.bat
+++ b/Release.bat
@@ -5,9 +5,13 @@ REM
 REM File format: UTF-8 (no BOM) + CRLF line endings.
 REM   - cmd.exe parses LF-only bat files incorrectly (silent fail). CRLF is
 REM     required; .gitattributes enforces this via `*.bat eol=crlf`.
-REM   - UTF-8 BOM is NOT used: some older cmd.exe builds (Win 10 < 1809) fail
-REM     to recognize the BOM and dump mojibake before `chcp 65001` can fire.
-REM     Keeping the top ASCII-only avoids this trap entirely.
+REM   - UTF-8 BOM is NOT used: on cmd.exe builds that do not recognize the
+REM     BOM (observed on some Windows installations), the BOM bytes
+REM     (EF BB BF) are interpreted as CP932 text on the first line. This
+REM     breaks `@echo off` (the script then visibly runs with echo enabled,
+REM     splaying every REM line + cp932-mojibake to the console), and
+REM     subsequent commands fail with "not recognized as ... command" errors.
+REM     Do NOT re-introduce a BOM here even if a modern editor suggests it.
 REM   - Comments / echo above the `chcp 65001` line MUST stay ASCII because
 REM     they are parsed under the console codepage (cp932 on JP locale).
 REM   - Below `chcp 65001 >nul`, Japanese is safe (UTF-8 console).
@@ -15,7 +19,7 @@ REM
 REM Usage:
 REM   .\Release.bat                  : full release using CHANGELOG.md head Bundle entry
 REM   .\Release.bat -SkipUpload      : build zip only, skip GitHub upload
-REM   .\Release.bat -DryRun -SkipUpload : build verification only
+REM   .\Release.bat -DryRun          : build verification only (auto-implies -SkipUpload)
 REM   .\Release.bat -Force           : allow uncommitted changes
 REM   .\Release.bat -NoPause         : skip pause on exit (for CI / automation)
 REM
@@ -40,7 +44,8 @@ REM       (only if we successfully captured the original codepage; see below).
 REM       Otherwise the caller's cmd window keeps codepage 65001 after exit.
 REM
 REM Expected chcp output structure (this REM block must stay ASCII because it
-REM runs before `chcp 65001`, so don't paste the actual localized strings here):
+REM runs before `chcp 65001`; the JP localized label is intentionally NOT
+REM pasted here, see CHANGELOG [Release Tooling v1.0.5] for the literal):
 REM   English locale (cp437/cp1252): "Active code page: 932"
 REM   Japanese locale (cp932):       label is the localized version (non-ASCII),
 REM                                  same "label: number" layout with colon
@@ -59,7 +64,10 @@ if defined ORIGINAL_CODEPAGE (
     echo [WARN] Skipping UTF-8 codepage switch ^(Japanese output may be garbled^).
 )
 
-REM ---- 以下、chcp 65001 後は日本語 OK ----
+REM ====================================================================
+REM Above this line: ASCII-only required (cmd.exe parses under cp932).
+REM Below this line: Japanese OK (UTF-8 console after chcp 65001).
+REM ====================================================================
 
 set SCRIPT_DIR=%~dp0
 

--- a/Release.bat
+++ b/Release.bat
@@ -97,9 +97,7 @@ if %NO_PAUSE% EQU 0 (
     echo.
     pause
 )
-REM codepage を元に戻す (chcp は console-wide で setlocal の endlocal 対象外、
-REM 明示復元が必須。ここを削ると呼び出し元 cmd 窓の codepage に副作用が残る)
-REM pause より後にしてあるのは、直前の echo メッセージ ([FAIL] / 正常終了 等) を
-REM ユーザーが pause 中も正しく表示し続けるため (chcp 復元すると過去出力の見え方が崩れうる)
+REM 呼出元 cmd の codepage を復元 (詳細経緯は冒頭 docstring 参照)。
+REM pause より後にしているのは、直前 echo を pause 中も正しく表示し続けるため。
 if defined ORIGINAL_CODEPAGE chcp %ORIGINAL_CODEPAGE% >nul
 exit /b %EXIT_CODE%

--- a/Release.bat
+++ b/Release.bat
@@ -33,11 +33,11 @@ REM enabledelayedexpansion is required for `!FORWARDED_ARGS!` concatenation in
 REM the parseargs loop below. Removing it breaks argument forwarding.
 REM
 REM Side effect: with delayed expansion enabled, `!` in argument values is
-REM consumed as the delayed-expansion token. e.g. `.\Release.bat -Tag "alpha!"`
-REM loses the `!`. PowerShell switches (-DryRun, -Force, -NoPause, -Version)
-REM never contain `!`, and `-Version` only takes M.m.p[-suffix] strings, so
-REM this is a non-issue in practice. Documented here in case someone adds a
-REM new pass-through arg that accepts arbitrary text.
+REM consumed as the delayed-expansion token. The current pass-through args
+REM (-DryRun / -Force / -NoPause / -Version / -SkipUpload / -Offline /
+REM -GodotExe / -GodotPatch / -MsBuildExe / -NugetExe) never contain `!`,
+REM so this is a non-issue today. Documented here in case a future
+REM pass-through arg accepts arbitrary text containing `!`.
 setlocal enabledelayedexpansion
 
 REM ---- UTF-8 codepage switch + restore-on-exit setup ----

--- a/Release.bat
+++ b/Release.bat
@@ -1,62 +1,62 @@
-﻿@echo off
+@echo off
 REM ============================================================================
-REM Release.bat - Release.ps1 のラッパー (ダブルクリック / 短縮コマンド用)
+REM Release.bat - Release.ps1 wrapper for double-click / shortcut use.
 REM
-REM ファイル形式: UTF-8 BOM + CRLF 改行 (Windows cmd.exe 要件)
-REM   - cmd.exe は LF only の bat を正しくパースできず、無音で実行が止まる
-REM   - .gitattributes で *.bat eol=crlf を指定して checkout 時に CRLF を強制
-REM   - cmd.exe の echo / pause 出力およびファイルパース時の文字解釈の保険として
-REM     chcp 65001 (UTF-8 codepage) に切替。BOM 認識挙動が cmd.exe build に依存するため
+REM File format: UTF-8 (no BOM) + CRLF line endings.
+REM   - cmd.exe parses LF-only bat files incorrectly (silent fail). CRLF is
+REM     required; .gitattributes enforces this via `*.bat eol=crlf`.
+REM   - UTF-8 BOM is NOT used: some older cmd.exe builds (Win 10 < 1809) fail
+REM     to recognize the BOM and dump mojibake before `chcp 65001` can fire.
+REM     Keeping the top ASCII-only avoids this trap entirely.
+REM   - Comments / echo above the `chcp 65001` line MUST stay ASCII because
+REM     they are parsed under the console codepage (cp932 on JP locale).
+REM   - Below `chcp 65001 >nul`, Japanese is safe (UTF-8 console).
 REM
-REM BOM 認識不能環境での脱出方法 (Win 10 1809 以前の cmd.exe build 等):
-REM   1. BOM を外して UTF-8 (no BOM) + CRLF で保存し直す
-REM   2. chcp 65001 より前の REM / echo 行を全部 ASCII (英語) に置換する
-REM      (chcp 65001 が効くまでの数行は console codepage のままパースされるため)
-REM   3. .gitattributes の *.bat の rule に working-tree-encoding=UTF-8 は付けない
-REM      (git の eol=crlf が CRLF 強制してくれれば十分)
+REM Usage:
+REM   .\Release.bat                  : full release using CHANGELOG.md head Bundle entry
+REM   .\Release.bat -SkipUpload      : build zip only, skip GitHub upload
+REM   .\Release.bat -DryRun -SkipUpload : build verification only
+REM   .\Release.bat -Force           : allow uncommitted changes
+REM   .\Release.bat -NoPause         : skip pause on exit (for CI / automation)
 REM
-REM 使い方:
-REM   .\Release.bat                  : CHANGELOG.md の最新 Bundle エントリで本番リリース
-REM   .\Release.bat -SkipUpload      : zip 生成のみ、アップロードしない
-REM   .\Release.bat -DryRun -SkipUpload : ビルド確認のみ
-REM   .\Release.bat -Force           : uncommitted change 許容
-REM   .\Release.bat -NoPause         : 完了時に pause しない (CI / 自動化用)
-REM
-REM `-NoPause` 以外の引数はすべて Release.ps1 にそのまま渡す。
-REM Bundle version は Release.ps1 が CHANGELOG.md から自動取得 (-Version 省略可)。
-REM 詳細は Release.ps1 のヘルプ (Get-Help .\Release.ps1 -Detailed) を参照。
+REM Arguments other than `-NoPause` are forwarded verbatim to Release.ps1.
+REM The Bundle version is auto-detected from CHANGELOG.md (-Version optional).
+REM See Release.ps1 docstring for details (Get-Help .\Release.ps1 -Detailed).
 REM ============================================================================
 
-REM enabledelayedexpansion は parseargs ループ内の `!FORWARDED_ARGS!` 連結のために必要。
-REM (それ以外の通常 set 行では遅延展開を使ってないため、削除すると引数 forward だけ壊れる)
+REM enabledelayedexpansion is required for `!FORWARDED_ARGS!` concatenation in
+REM the parseargs loop below. Removing it breaks argument forwarding.
 setlocal enabledelayedexpansion
 
-REM ---- UTF-8 codepage 切替 + 終了時の復元準備 ----
-REM cmd.exe の echo / pause / ファイルパース時の文字解釈の保険として 65001 へ切替。
+REM ---- UTF-8 codepage switch + restore-on-exit setup ----
 REM
-REM 注意: chcp は console-wide な状態で setlocal / endlocal の対象外なので、
-REM       明示的に元の codepage に復元しないとユーザーの cmd 窓に副作用が残る。
-REM       (このため終了時に明示 chcp で復元する処理が下部にある)
+REM `chcp 65001` is a defense-in-depth for cmd.exe echo / pause output and
+REM bat file character parsing. The file is no-BOM UTF-8, so the top of this
+REM script (above this point) is intentionally ASCII-only.
 REM
-REM chcp 出力フォーマット例:
-REM   英:  "Active code page: 932"
-REM   日:  "現在のコード ページ: 932"
-REM   他ロケールも "ラベル: 番号" の形式を踏襲しているため delims=: で動作する想定
+REM Note: `chcp` is console-wide state and is NOT scoped by setlocal/endlocal,
+REM       so an explicit `chcp %ORIGINAL_CODEPAGE%` at the end is required.
+REM       (Otherwise the caller's cmd window keeps codepage 65001 after exit.)
+REM
+REM Expected chcp output formats:
+REM   English:  "Active code page: 932"
+REM   Japanese: "Current code page: 932" (translated, same colon layout)
+REM   Other locales also follow "label: number" pattern, so delims=: works.
 for /f "tokens=2 delims=:" %%a in ('chcp') do set ORIGINAL_CODEPAGE=%%a
-REM %VAR: =% は VAR 内の全スペースを空文字に置換する構文 (" 932" → "932")
+REM `%VAR: =%` strips ALL spaces in VAR (chcp output is " 932" with leading space).
 if defined ORIGINAL_CODEPAGE set ORIGINAL_CODEPAGE=%ORIGINAL_CODEPAGE: =%
 
-REM ORIGINAL_CODEPAGE が取れなかった場合は codepage を切り替えない (副作用回避)。
-REM 出力フォーマットが未知のロケール / リダイレクトでフィルタされる等のレアケース対策。
+REM If ORIGINAL_CODEPAGE failed to parse (unknown locale format, redirection
+REM filtering, etc.), skip the chcp 65001 switch entirely to avoid leaking
+REM codepage 65001 to the caller's cmd window.
 if defined ORIGINAL_CODEPAGE (
     chcp 65001 >nul
 ) else (
-    REM chcp 65001 未切替の状態で出力するため、ASCII 限定の英語を先に出す
-    REM (この時点で UTF-8 BOM bat の日本語 echo は文字化けして読めない可能性が高い)
     echo [WARN] Failed to capture codepage from 'chcp' output.
     echo [WARN] Skipping UTF-8 codepage switch ^(Japanese output may be garbled^).
-    echo        chcp 出力から codepage を取得できませんでした ^(UTF-8 切替を skip^)。
 )
+
+REM ---- 以下、chcp 65001 後は日本語 OK ----
 
 set SCRIPT_DIR=%~dp0
 

--- a/Release.ps1
+++ b/Release.ps1
@@ -92,6 +92,39 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# ============================================================================
+# Native command の `2>&1` trap (PS 5.1 + $ErrorActionPreference='Stop' 環境)
+# ============================================================================
+# このスクリプトでは git / gh / msbuild / nuget 等の native command を呼び出すが、
+# `2>&1` で stderr を success stream に merge すると PS 5.1 + Stop モードでは
+# native command の stderr 出力が NativeCommandError の terminating error として
+# 扱われ、本来「正常系」のはずの path で script が止まる。
+#
+# パターン早見表:
+#   # GOOD-1: 出力を捨てたい場合 (preflight の存在確認系)
+#   & native-cmd 2>$null | Out-Null    # stderr 捨て、stdout 捨て、exit code 判定
+#
+#   # GOOD-2: 出力を診断情報として保持したい場合 (失敗時に表示したい)
+#   $output = & native-cmd 2>&1 | Out-String
+#   # ↑ Out-String が pipeline 中で ErrorRecord を文字列化するため Stop は飛ばない
+#   #   (PS 5.1 で実機確認済み)
+#
+#   # GOOD-3: 出力使わない / 単純に native-cmd 実行 (stderr は console 直書きに任せる)
+#   & native-cmd                       # redirect なし、$LASTEXITCODE で異常を catch
+#   # ↑ stderr は親 console に直行、PS 側で ErrorRecord 化されないので Stop しない
+#   # ↑ ただし $LASTEXITCODE を必ずチェックして silent pass regression を防ぐこと
+#
+#   # BAD-a: 単独 pipeline 末尾の 2>&1 (Stop モードで terminating error)
+#   & native-cmd 2>&1
+#
+#   # BAD-b: 変数代入のみ (Out-String なし)
+#   $var = & native-cmd 2>&1           # PS バージョン依存で不安定
+#
+# 例外:
+#   - 実 release 操作 (Invoke-GhRelease 内の gh release create / delete) は
+#     redirect せず、出力をユーザーに見せる (GOOD-3 と同じ形だが exit code 必須)
+# ============================================================================
+
 # -Offline / -DryRun は upload を行わないので、preflight の gh 関連チェックも
 # skip するため -SkipUpload を強制 ON とみなす（Codex P2 #137 ×2）
 # - -Offline: そもそも network 不可なので gh API 呼び出し不可
@@ -165,32 +198,6 @@ $script:GodotPatchUsed      = $null  # 解決された Godot patch (例: "4.6.2"
 $script:LauncherVersion     = $null
 $script:ManagerVersion      = $null
 $script:DeleteExistingRelease = $false
-
-# ============================================================================
-# Native command の `2>&1` trap (PS 5.1 + $ErrorActionPreference='Stop' 環境)
-# ============================================================================
-# このスクリプトでは git / gh / msbuild / nuget 等の native command を呼び出すが、
-# `2>&1` で stderr を success stream に merge すると PS 5.1 + Stop モードでは
-# native command の stderr 出力が NativeCommandError の terminating error として
-# 扱われ、本来「正常系」のはずの path で script が止まる。
-#
-# 採用パターン:
-#   1. 出力を捨てたい場合 (preflight の存在確認系):
-#      & native-cmd 2>$null | Out-Null    # stderr 捨て、stdout 捨て、exit code 判定
-#   2. 出力を診断情報として保持したい場合 (失敗時に表示したい):
-#      $output = & native-cmd 2>&1 | Out-String
-#      ↑ Out-String が pipeline 中で ErrorRecord を文字列化するため Stop は飛ばない (PS 5.1 で実機確認済み)
-#
-# 採用しないパターン:
-#   & native-cmd 2>&1                  # 単独 pipeline 末尾だと NativeCommandError 飛ぶ
-#   $var = & native-cmd 2>&1           # 変数代入のみ (Out-String なし) は PS バージョン依存で不安定
-#
-# 例外:
-#   - 実 release 操作 (Invoke-GhRelease 内の gh release create / delete) は redirect
-#     せず、出力をユーザーに見せる
-#   - `git -C ... status --porcelain` は stderr に出ない前提で redirect 省略、ただし
-#     $LASTEXITCODE は明示的にチェック (regression 防止)
-# ============================================================================
 
 # ============================================================================
 # 出力ユーティリティ
@@ -554,13 +561,10 @@ function Resolve-Nuget {
 
 function Assert-WorkingTreeClean {
     param([string]$Context)
-    # 2>&1 native command stderr trap については Release.ps1 冒頭の集約コメントを参照。
-    # ここでは redirect なしで stderr をコンソールに直書きさせ、exit code で異常系を catch。
+    # native command redirection: GOOD-3 (冒頭集約コメント参照)
+    # silent pass regression 防止のため $LASTEXITCODE を必ずチェックする。
     $gitStatus = & git -C $RepoRoot status --porcelain
     if ($LASTEXITCODE -ne 0) {
-        # git status 自体が失敗 (壊れた repo / 不正なパス / 権限問題 等)。
-        # stderr が直前にコンソールに出ているはずだが、それだけだと preflight が
-        # silent pass する regression を踏むので Fail で明示的に止める。
         Fail "git status の実行に失敗しました (exit code: $LASTEXITCODE, context: $Context)"
     }
     if ($gitStatus) {
@@ -622,10 +626,8 @@ function Test-Preflight {
             Fail "gh (GitHub CLI) が見つかりません。`n        https://cli.github.com/ からインストールするか、-SkipUpload で upload を抑止してください。"
         }
         Write-Ok "gh: $gh"
-        # 2>&1 native command stderr trap については冒頭集約コメントを参照。
-        # gh auth status は正常系でも stderr に認証情報を書く gh 仕様。
-        # 診断情報を活かすため Out-String 経由で文字列化して捕捉 (PS 5.1 では
-        # 変数代入 + Out-String パターンは ErrorRecord を文字列化するため Stop しない)。
+        # native command redirection: GOOD-2 (冒頭集約コメント参照)
+        # gh auth status は正常系でも stderr に書く gh 仕様、診断情報として保持。
         $authResult = & gh auth status 2>&1 | Out-String
         if ($LASTEXITCODE -ne 0) {
             Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$authResult"
@@ -658,10 +660,9 @@ function Test-Preflight {
 
     # 既存リリースとのタグ衝突
     if (-not $SkipUpload) {
-        # 2>&1 native command stderr trap については冒頭集約コメントを参照。
-        # gh release view は release 不在時 stderr へ + 非ゼロ exit。
-        # stdout も Out-Null で捨てるのは、release 存在時 gh が JSON / 詳細を
-        # stdout に dump して preflight コンソールが汚れるのを防ぐため。
+        # native command redirection: GOOD-1 (冒頭集約コメント参照)
+        # stdout も Out-Null で捨てるのは、release 存在時 gh が JSON を dump して
+        # preflight コンソールが汚れるのを防ぐため。
         & gh release view "v$Version" 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) {
             if ($Force) {

--- a/Release.ps1
+++ b/Release.ps1
@@ -528,7 +528,11 @@ function Resolve-Nuget {
 
 function Assert-WorkingTreeClean {
     param([string]$Context)
-    $gitStatus = & git -C $RepoRoot status --porcelain 2>&1
+    # 2>&1 を使わない: $ErrorActionPreference='Stop' 下で native command stderr が
+    # NativeCommandError として terminating error 扱いになる PS 5.1 の挙動を避けるため。
+    # `git status --porcelain` は正常系で stderr に出さないのでこのままで OK。
+    # (stderr に出る場合 = repo 不整合等のエラー、その時はコンソールに直接出して問題ない)
+    $gitStatus = & git -C $RepoRoot status --porcelain
     if ($LASTEXITCODE -eq 0 -and $gitStatus) {
         if ($Force) {
             Write-Warn "uncommitted change がありますが -Force のため続行 ($Context)"
@@ -588,9 +592,14 @@ function Test-Preflight {
             Fail "gh (GitHub CLI) が見つかりません。`n        https://cli.github.com/ からインストールするか、-SkipUpload で upload を抑止してください。"
         }
         Write-Ok "gh: $gh"
-        $authResult = & gh auth status 2>&1
+        # gh auth status は 正常系でも stderr に認証情報を書く (gh の設計仕様) ため
+        # `2>&1` を使うと $ErrorActionPreference='Stop' 下で NativeCommandError として
+        # terminating error 扱いになる。stderr を捨てて exit code だけで判定する。
+        # 失敗時のメッセージは「gh auth login を実行してください」だけで十分自明なので、
+        # 認証情報の詳細をユーザーに見せる必要はない。
+        & gh auth status 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) {
-            Fail "gh への認証ができていません。`gh auth login` を実行してください。`n$authResult"
+            Fail "gh への認証ができていません。`gh auth login` を実行してください。"
         }
         Write-Ok "gh 認証 OK"
     }
@@ -622,8 +631,12 @@ function Test-Preflight {
     if (-not $SkipUpload) {
         # gh release view は release 不在時 stderr に "release not found" を出して
         # 非ゼロで exit する。$ErrorActionPreference='Stop' 下で `2>&1` を使うと
-        # native command stderr が ErrorRecord として terminating error 扱いになり
-        # script が止まるため、stderr は $null に捨てて exit code だけで判定する。
+        # native command stderr が ErrorRecord として terminating error 扱いになる
+        # PS 5.1 の挙動を避けるため、stderr は $null に捨てて exit code だけで判定する。
+        #
+        # 加えて、release 存在時は gh が stdout に release の JSON / 詳細を dump する
+        # ため、preflight 中にコンソールに大量出力されるのを抑止する目的で
+        # `| Out-Null` で stdout も握り潰す。
         & gh release view "v$Version" 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) {
             if ($Force) {

--- a/Release.ps1
+++ b/Release.ps1
@@ -107,6 +107,18 @@ $ErrorActionPreference = 'Stop'
 # 流れ Stop の判定対象から外れる。(PS 5.1 で確認。PS 7.x は stream 処理仕様が
 # 異なるため要再検証)
 #
+# PS 7.3+ 移行時の追加注意 (現状未対応):
+#   PS 7.3 以降は $PSNativeCommandUseErrorActionPreference (default $true) が
+#   追加され、`& native-cmd` の非ゼロ exit code 自体が ErrorActionPreference に
+#   従って terminating error 化する。本スクリプトの「2>&1 を外して $LASTEXITCODE で
+#   判定」というイディオム (例: Assert-WorkingTreeClean の git status, vswhere の
+#   失敗パス等) は、PS 7.3+ では `if ($LASTEXITCODE -ne 0)` に到達せず、エラー
+#   メッセージや context 情報を出す前に script 自体が abort する経路に変わる。
+#   将来 PS 7 移行する場合は以下のいずれか必須:
+#     (a) script 冒頭で $PSNativeCommandUseErrorActionPreference = $false に固定
+#     (b) 各 $LASTEXITCODE チェックを try/catch でラップ
+#   現状は PS 5.1 を前提とした実装。
+#
 # パターン早見表 (call site では「pattern: 名前」で参照する):
 #
 #   # pattern: SUPPRESS_BOTH (stderr / stdout 両方破棄、exit code のみ判定)
@@ -134,6 +146,10 @@ $ErrorActionPreference = 'Stop'
 #   $var = & native-cmd 2>&1         # 変数 capture あり版
 #   # ↑ どちらも同じ罠。本質は `2>&1` 自体: stderr が ErrorRecord として success
 #   #   stream に流れ、$ErrorActionPreference='Stop' の判定対象になる
+#   # ↑ 「変数 capture なし版」は通常書く理由がないが、副作用 only の native
+#   #   call で stderr も console に出したい意図で `2>&1` をつけてしまう typo
+#   #   として頻発するため anti-pattern として明示。redirect なしの PASS_THROUGH
+#   #   が正解 (stderr は自動で console 直行する)
 #   # ↑ 回避策は (a) Out-String を挟む = CAPTURE_DIAGNOSTIC、または
 #   #   (b) 2>&1 をやめる = SUPPRESS_BOTH / CAPTURE_STDOUT / *_PASS_STDERR 系
 #
@@ -488,6 +504,7 @@ function Resolve-MsBuild {
     $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (-not (Test-Path $vswhere)) { $vswhere = "$env:ProgramFiles\Microsoft Visual Studio\Installer\vswhere.exe" }
     if (Test-Path $vswhere) {
+        # pattern: CAPTURE_STDOUT (冒頭集約コメント参照)
         $vsInstall = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath 2>$null
         if ($vsInstall) {
             $vsCands = @(
@@ -617,10 +634,12 @@ function Get-BundleReleaseNotes {
     }
     $content = [System.IO.File]::ReadAllText($ChangelogPath, [System.Text.Encoding]::UTF8)
     # `### [Bundle v0.1.0] - YYYY-MM-DD` から次の `### ` / `---` / `## ` / EOF まで
-    # `\Z` は対象 Bundle entry が CHANGELOG.md 末尾 (後続セクションマーカーなし)
-    # の場合の保険。現状は Bundle 配下に Launcher / Manager 等が必ず続くため発火
-    # しないが、将来セクション順を変えた時や Bundle 単独の最小 CHANGELOG だった
-    # 場合に空文字列を返してしまう regression を防ぐ
+    # `\Z` は「対象 Bundle entry の直後に終端マーカー (### / --- / ##) が一切
+    # 存在しない」極端なケースの保険。AGENTS.md ルールで新 Bundle entry は最上段
+    # 追加なので「最新 = 末尾」になるのは初回 Bundle release で他 Bundle / 後続
+    # Launcher/Manager セクションが未追加の極初期状態のみ。現状の CHANGELOG では
+    # 発火しないが、将来この regex の前提が崩れる方向 (構造変更 / CHANGELOG 縮小)
+    # に動いた時の防御。`\Z` の追加コストはほぼゼロなので入れておく
     $pattern = '(?ms)^### \[Bundle v' + [regex]::Escape($Version) + '\][^\r\n]*\r?\n(.*?)(?=^### |^---|^## |\Z)'
     $m = [regex]::Match($content, $pattern)
     if (-not $m.Success) { return '' }
@@ -662,8 +681,15 @@ function Assert-Preflight {
         # gh は exit 0 でも stderr に early warning を出すことがある:
         #   - token scope 不足の予兆 (release upload に必要な scope が削られた場合)
         #   - token expiry が近い旨の通知
-        # 失敗してないので Fail はしないが、リリース担当に気付かせる
-        if ($authStatusOutput -match '(?im)warning|expir') {
+        # 失敗してないので Fail はしないが、リリース担当に気付かせる。
+        #
+        # regex は特異性高めに絞り込み (旧 `warning|expir` は `expiration` や
+        # `experimental` 等の通常 success 文言にも hit する false positive 多数)。
+        # gh の出力フォーマットは version で変動するので「!= 100% 検出」前提:
+        # 真の early-warning 検出は本格的には別 issue (#141 系) で structured
+        # JSON parse に寄せる方が確実。
+        $warningPattern = '(?im)(token has expired|token expir(es|ed|ing) in \d+\s*(day|hour)|missing.*scope|insufficient.*scope|^warning:)'
+        if ($authStatusOutput -match $warningPattern) {
             Write-Warn "gh auth status からの警告 (release 実行自体は継続):`n$authStatusOutput"
         }
     }

--- a/Release.ps1
+++ b/Release.ps1
@@ -634,12 +634,7 @@ function Get-BundleReleaseNotes {
     }
     $content = [System.IO.File]::ReadAllText($ChangelogPath, [System.Text.Encoding]::UTF8)
     # `### [Bundle v0.1.0] - YYYY-MM-DD` から次の `### ` / `---` / `## ` / EOF まで
-    # `\Z` は「対象 Bundle entry の直後に終端マーカー (### / --- / ##) が一切
-    # 存在しない」極端なケースの保険。AGENTS.md ルールで新 Bundle entry は最上段
-    # 追加なので「最新 = 末尾」になるのは初回 Bundle release で他 Bundle / 後続
-    # Launcher/Manager セクションが未追加の極初期状態のみ。現状の CHANGELOG では
-    # 発火しないが、将来この regex の前提が崩れる方向 (構造変更 / CHANGELOG 縮小)
-    # に動いた時の防御。`\Z` の追加コストはほぼゼロなので入れておく
+    # `\Z`: 後続セクション無しの初回 Bundle release だけが該当する保険
     $pattern = '(?ms)^### \[Bundle v' + [regex]::Escape($Version) + '\][^\r\n]*\r?\n(.*?)(?=^### |^---|^## |\Z)'
     $m = [regex]::Match($content, $pattern)
     if (-not $m.Success) { return '' }
@@ -653,8 +648,6 @@ $script:ReleaseNotesText = ''
 # ============================================================================
 
 function Assert-Preflight {
-    # Test-* verb は [bool] 返却が PowerShell 規約だが、preflight は違反時に Fail
-    # (exit 1) する性質なので Assert-* に揃える (同ファイル内の Assert-WorkingTreeClean と統一)
     Write-Step "Preflight: 環境とパラメータを検証"
 
     # Version 形式 (CHANGELOG から取った時点で確定済みだが念のため)
@@ -678,18 +671,15 @@ function Assert-Preflight {
             Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$authStatusOutput"
         }
         Write-Ok "gh 認証 OK"
-        # gh は exit 0 でも stderr に early warning を出すことがある:
-        #   - token scope 不足の予兆 (release upload に必要な scope が削られた場合)
-        #   - token expiry が近い旨の通知
-        # 失敗してないので Fail はしないが、リリース担当に気付かせる。
+        # gh は exit 0 でも stderr に early warning を出すことがある (token scope
+        # 不足の予兆 / token expiry 近接通知 等)。失敗してないので Fail はしないが、
+        # リリース担当に気付かせる。
         #
-        # regex は特異性高めに絞り込み (旧 `warning|expir` は `expiration` や
-        # `experimental` 等の通常 success 文言にも hit する false positive 多数)。
-        # gh の出力フォーマットは version で変動するので「!= 100% 検出」前提:
-        # 真の early-warning 検出は本格的には別 issue (#141 系) で structured
-        # JSON parse に寄せる方が確実。
-        $warningPattern = '(?im)(token has expired|token expir(es|ed|ing) in \d+\s*(day|hour)|missing.*scope|insufficient.*scope|^warning:)'
-        if ($authStatusOutput -match $warningPattern) {
+        # 検出は `^warning:` (gh の公式 warning prefix) のみに絞る。token expiry の
+        # 特殊形式までカバーする regex は false positive を増やし、かつ gh の出力
+        # フォーマット変更に脆弱。本格的な structured 検出は別 issue (#141 系) で
+        # JSON parse に寄せる方針なので、ここでは過信を生む特殊形式を持たない。
+        if ($authStatusOutput -match '(?im)^warning:') {
             Write-Warn "gh auth status からの警告 (release 実行自体は継続):`n$authStatusOutput"
         }
     }
@@ -1042,7 +1032,7 @@ function Copy-Templates {
 # Phase 7: ExpectedFiles 検証
 # ============================================================================
 
-function Test-ExpectedFiles {
+function Assert-ExpectedFiles {
     Write-Step "ExpectedFiles 検証"
 
     # 期待ファイル一覧
@@ -1196,7 +1186,7 @@ Clear-Staging
 Build-Launcher
 Build-Manager
 Copy-Templates
-Test-ExpectedFiles
+Assert-ExpectedFiles
 Clear-OldGodot
 
 if ($DryRun) {

--- a/Release.ps1
+++ b/Release.ps1
@@ -118,22 +118,29 @@ $ErrorActionPreference = 'Stop'
 #   # pattern: CAPTURE_STDOUT (stdout は変数に、stderr は破棄)
 #   $output = & native-cmd 2>$null
 #
-#   # pattern: PASS_THROUGH (console 直書き、exit code チェック必須)
+#   # pattern: CAPTURE_STDOUT_PASS_STDERR (stdout は変数、stderr は console 直書き)
+#   $output = & native-cmd
+#   # ↑ stderr は親 console に直行 (ErrorRecord 化されないので Stop しない)
+#   # ↑ stdout は通常の string array として変数に capture される
+#   # ↑ exit code チェック必須 (出力が空でも $LASTEXITCODE 非ゼロのまま誤判定防止)
+#
+#   # pattern: PASS_THROUGH (console 直書き、変数 capture なし)
 #   & native-cmd
-#   # ↑ stderr は親 console に直行、PS 側で ErrorRecord 化されないので Stop しない
-#   # ↑ ただし $LASTEXITCODE を必ずチェック (redirect 削除だけだと出力が空でも
-#   #   $LASTEXITCODE 非ゼロのまま「正常」誤判定する経路ができる)
+#   # ↑ stdout/stderr 両方とも親 console に直行
+#   # ↑ exit code チェック必須 (CAPTURE_STDOUT_PASS_STDERR と同じ理由)
 #
-#   # ANTI-PATTERN: STOP_TRAP (Stop モードで確実に terminating error 飛ぶ)
-#   & native-cmd 2>&1
-#
-#   # ANTI-PATTERN: STREAM_TO_VAR (Out-String なし、PS バージョンと
-#   # $ErrorActionPreference の組合せで挙動が変わる。5.1+Stop では確実に fail)
-#   $var = & native-cmd 2>&1
+#   # ANTI-PATTERN: STOP_TRAP (Stop モードで terminating error が飛ぶ)
+#   & native-cmd 2>&1                # 変数 capture なし版
+#   $var = & native-cmd 2>&1         # 変数 capture あり版
+#   # ↑ どちらも同じ罠。本質は `2>&1` 自体: stderr が ErrorRecord として success
+#   #   stream に流れ、$ErrorActionPreference='Stop' の判定対象になる
+#   # ↑ 回避策は (a) Out-String を挟む = CAPTURE_DIAGNOSTIC、または
+#   #   (b) 2>&1 をやめる = SUPPRESS_BOTH / CAPTURE_STDOUT / *_PASS_STDERR 系
 #
 # 例外:
 #   - 実 release 操作 (Invoke-GhRelease 内の gh release create / delete) は
-#     redirect せず、出力をユーザーに見せる (PASS_THROUGH の派生)
+#     PASS_THROUGH を採用する。出力をユーザーに見せて何が起きているか追える
+#     ようにするのが目的 (preflight 中の SUPPRESS_BOTH とは方針が逆)
 # ============================================================================
 
 # -Offline / -DryRun は upload を行わないので preflight の gh 関連チェックも
@@ -570,7 +577,9 @@ function Resolve-Nuget {
 
 function Assert-WorkingTreeClean {
     param([string]$Context)
-    # pattern: PASS_THROUGH (冒頭集約コメント参照)
+    # pattern: CAPTURE_STDOUT_PASS_STDERR (冒頭集約コメント参照)
+    # stdout (--porcelain の差分行) は変数に capture、stderr (git の通常 error
+    # メッセージ) は console 直書きでユーザーに見せる
     # redirect を外しただけだと git 失敗時に $gitStatus が空文字になり「working
     # tree clean」と誤判定されるため、exit code チェックが必須
     $gitStatus = & git -C $RepoRoot status --porcelain
@@ -607,8 +616,12 @@ function Get-BundleReleaseNotes {
         Fail "CHANGELOG.md が見つかりません: $ChangelogPath"
     }
     $content = [System.IO.File]::ReadAllText($ChangelogPath, [System.Text.Encoding]::UTF8)
-    # `### [Bundle v0.1.0] - YYYY-MM-DD` から次の `### ` または `---` または `## ` まで
-    $pattern = '(?ms)^### \[Bundle v' + [regex]::Escape($Version) + '\][^\r\n]*\r?\n(.*?)(?=^### |^---|^## )'
+    # `### [Bundle v0.1.0] - YYYY-MM-DD` から次の `### ` / `---` / `## ` / EOF まで
+    # `\Z` は対象 Bundle entry が CHANGELOG.md 末尾 (後続セクションマーカーなし)
+    # の場合の保険。現状は Bundle 配下に Launcher / Manager 等が必ず続くため発火
+    # しないが、将来セクション順を変えた時や Bundle 単独の最小 CHANGELOG だった
+    # 場合に空文字列を返してしまう regression を防ぐ
+    $pattern = '(?ms)^### \[Bundle v' + [regex]::Escape($Version) + '\][^\r\n]*\r?\n(.*?)(?=^### |^---|^## |\Z)'
     $m = [regex]::Match($content, $pattern)
     if (-not $m.Success) { return '' }
     return $m.Groups[1].Value.Trim()
@@ -646,6 +659,13 @@ function Assert-Preflight {
             Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$authStatusOutput"
         }
         Write-Ok "gh 認証 OK"
+        # gh は exit 0 でも stderr に early warning を出すことがある:
+        #   - token scope 不足の予兆 (release upload に必要な scope が削られた場合)
+        #   - token expiry が近い旨の通知
+        # 失敗してないので Fail はしないが、リリース担当に気付かせる
+        if ($authStatusOutput -match '(?im)warning|expir') {
+            Write-Warn "gh auth status からの警告 (release 実行自体は継続):`n$authStatusOutput"
+        }
     }
 
     # CHANGELOG から Bundle セクションを抽出できるか確認
@@ -1054,6 +1074,8 @@ function Invoke-GhRelease {
 
     if ($script:DeleteExistingRelease) {
         Write-Info "既存タグ v$Version を削除"
+        # pattern: PASS_THROUGH (例外節 - 冒頭集約コメント参照)
+        # 実 release 操作中の gh 出力はユーザーに見せる方針
         & gh release delete "v$Version" --yes --cleanup-tag
         if ($LASTEXITCODE -ne 0) { Fail "既存 release の削除に失敗しました" }
     }
@@ -1063,6 +1085,8 @@ function Invoke-GhRelease {
     $tmpNotes = New-TemporaryFile
     try {
         [System.IO.File]::WriteAllText($tmpNotes.FullName, $script:ReleaseNotesText, [System.Text.UTF8Encoding]::new($false))
+        # pattern: PASS_THROUGH (例外節 - 冒頭集約コメント参照)
+        # upload 進捗等を見せたいので redirect しない
         & gh release create "v$Version" $ZipPath --notes-file $tmpNotes.FullName --title "v$Version"
         if ($LASTEXITCODE -ne 0) { Fail "gh release create に失敗しました" }
     } finally {

--- a/Release.ps1
+++ b/Release.ps1
@@ -167,6 +167,32 @@ $script:ManagerVersion      = $null
 $script:DeleteExistingRelease = $false
 
 # ============================================================================
+# Native command の `2>&1` trap (PS 5.1 + $ErrorActionPreference='Stop' 環境)
+# ============================================================================
+# このスクリプトでは git / gh / msbuild / nuget 等の native command を呼び出すが、
+# `2>&1` で stderr を success stream に merge すると PS 5.1 + Stop モードでは
+# native command の stderr 出力が NativeCommandError の terminating error として
+# 扱われ、本来「正常系」のはずの path で script が止まる。
+#
+# 採用パターン:
+#   1. 出力を捨てたい場合 (preflight の存在確認系):
+#      & native-cmd 2>$null | Out-Null    # stderr 捨て、stdout 捨て、exit code 判定
+#   2. 出力を診断情報として保持したい場合 (失敗時に表示したい):
+#      $output = & native-cmd 2>&1 | Out-String
+#      ↑ Out-String が pipeline 中で ErrorRecord を文字列化するため Stop は飛ばない (PS 5.1 で実機確認済み)
+#
+# 採用しないパターン:
+#   & native-cmd 2>&1                  # 単独 pipeline 末尾だと NativeCommandError 飛ぶ
+#   $var = & native-cmd 2>&1           # 変数代入のみ (Out-String なし) は PS バージョン依存で不安定
+#
+# 例外:
+#   - 実 release 操作 (Invoke-GhRelease 内の gh release create / delete) は redirect
+#     せず、出力をユーザーに見せる
+#   - `git -C ... status --porcelain` は stderr に出ない前提で redirect 省略、ただし
+#     $LASTEXITCODE は明示的にチェック (regression 防止)
+# ============================================================================
+
+# ============================================================================
 # 出力ユーティリティ
 # ============================================================================
 
@@ -528,12 +554,16 @@ function Resolve-Nuget {
 
 function Assert-WorkingTreeClean {
     param([string]$Context)
-    # 2>&1 を使わない: $ErrorActionPreference='Stop' 下で native command stderr が
-    # NativeCommandError として terminating error 扱いになる PS 5.1 の挙動を避けるため。
-    # `git status --porcelain` は正常系で stderr に出さないのでこのままで OK。
-    # (stderr に出る場合 = repo 不整合等のエラー、その時はコンソールに直接出して問題ない)
+    # 2>&1 native command stderr trap については Release.ps1 冒頭の集約コメントを参照。
+    # ここでは redirect なしで stderr をコンソールに直書きさせ、exit code で異常系を catch。
     $gitStatus = & git -C $RepoRoot status --porcelain
-    if ($LASTEXITCODE -eq 0 -and $gitStatus) {
+    if ($LASTEXITCODE -ne 0) {
+        # git status 自体が失敗 (壊れた repo / 不正なパス / 権限問題 等)。
+        # stderr が直前にコンソールに出ているはずだが、それだけだと preflight が
+        # silent pass する regression を踏むので Fail で明示的に止める。
+        Fail "git status の実行に失敗しました (exit code: $LASTEXITCODE, context: $Context)"
+    }
+    if ($gitStatus) {
         if ($Force) {
             Write-Warn "uncommitted change がありますが -Force のため続行 ($Context)"
             ($gitStatus -split "`n") | ForEach-Object { Write-Info "    $_" }
@@ -592,14 +622,13 @@ function Test-Preflight {
             Fail "gh (GitHub CLI) が見つかりません。`n        https://cli.github.com/ からインストールするか、-SkipUpload で upload を抑止してください。"
         }
         Write-Ok "gh: $gh"
-        # gh auth status は 正常系でも stderr に認証情報を書く (gh の設計仕様) ため
-        # `2>&1` を使うと $ErrorActionPreference='Stop' 下で NativeCommandError として
-        # terminating error 扱いになる。stderr を捨てて exit code だけで判定する。
-        # 失敗時のメッセージは「gh auth login を実行してください」だけで十分自明なので、
-        # 認証情報の詳細をユーザーに見せる必要はない。
-        & gh auth status 2>$null | Out-Null
+        # 2>&1 native command stderr trap については冒頭集約コメントを参照。
+        # gh auth status は正常系でも stderr に認証情報を書く gh 仕様。
+        # 診断情報を活かすため Out-String 経由で文字列化して捕捉 (PS 5.1 では
+        # 変数代入 + Out-String パターンは ErrorRecord を文字列化するため Stop しない)。
+        $authResult = & gh auth status 2>&1 | Out-String
         if ($LASTEXITCODE -ne 0) {
-            Fail "gh への認証ができていません。`gh auth login` を実行してください。"
+            Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$authResult"
         }
         Write-Ok "gh 認証 OK"
     }
@@ -629,14 +658,10 @@ function Test-Preflight {
 
     # 既存リリースとのタグ衝突
     if (-not $SkipUpload) {
-        # gh release view は release 不在時 stderr に "release not found" を出して
-        # 非ゼロで exit する。$ErrorActionPreference='Stop' 下で `2>&1` を使うと
-        # native command stderr が ErrorRecord として terminating error 扱いになる
-        # PS 5.1 の挙動を避けるため、stderr は $null に捨てて exit code だけで判定する。
-        #
-        # 加えて、release 存在時は gh が stdout に release の JSON / 詳細を dump する
-        # ため、preflight 中にコンソールに大量出力されるのを抑止する目的で
-        # `| Out-Null` で stdout も握り潰す。
+        # 2>&1 native command stderr trap については冒頭集約コメントを参照。
+        # gh release view は release 不在時 stderr へ + 非ゼロ exit。
+        # stdout も Out-Null で捨てるのは、release 存在時 gh が JSON / 詳細を
+        # stdout に dump して preflight コンソールが汚れるのを防ぐため。
         & gh release view "v$Version" 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) {
             if ($Force) {

--- a/Release.ps1
+++ b/Release.ps1
@@ -620,7 +620,11 @@ function Test-Preflight {
 
     # 既存リリースとのタグ衝突
     if (-not $SkipUpload) {
-        $existingRelease = & gh release view "v$Version" 2>&1
+        # gh release view は release 不在時 stderr に "release not found" を出して
+        # 非ゼロで exit する。$ErrorActionPreference='Stop' 下で `2>&1` を使うと
+        # native command stderr が ErrorRecord として terminating error 扱いになり
+        # script が止まるため、stderr は $null に捨てて exit code だけで判定する。
+        & gh release view "v$Version" 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) {
             if ($Force) {
                 Write-Warn "タグ v$Version は既存だが -Force のため後で削除して作り直す"

--- a/Release.ps1
+++ b/Release.ps1
@@ -100,35 +100,44 @@ $ErrorActionPreference = 'Stop'
 # native command の stderr 出力が NativeCommandError の terminating error として
 # 扱われ、本来「正常系」のはずの path で script が止まる。
 #
-# パターン早見表:
-#   # GOOD-1: 出力を捨てたい場合 (preflight の存在確認系)
-#   & native-cmd 2>$null | Out-Null    # stderr 捨て、stdout 捨て、exit code 判定
+# 機構: $ErrorActionPreference='Stop' は success stream に流れる ErrorRecord を
+# terminating error として扱う。`2>&1` は stderr の string output を ErrorRecord
+# として success stream に流すため Stop の判定対象になる。一方 Out-String を経由
+# すると ErrorRecord が string 化されるため、success stream には string のみが
+# 流れ Stop の判定対象から外れる。(PS 5.1 で確認。PS 7.x は stream 処理仕様が
+# 異なるため要再検証)
 #
-#   # GOOD-2: 出力を診断情報として保持したい場合 (失敗時に表示したい)
+# パターン早見表 (call site では「pattern: 名前」で参照する):
+#
+#   # pattern: SUPPRESS_BOTH (stderr / stdout 両方破棄、exit code のみ判定)
+#   & native-cmd 2>$null | Out-Null
+#
+#   # pattern: CAPTURE_DIAGNOSTIC (失敗時に表示するため文字列化保持)
 #   $output = & native-cmd 2>&1 | Out-String
-#   # ↑ Out-String が pipeline 中で ErrorRecord を文字列化するため Stop は飛ばない
-#   #   (PS 5.1 で実機確認済み)
 #
-#   # GOOD-3: 出力使わない / 単純に native-cmd 実行 (stderr は console 直書きに任せる)
-#   & native-cmd                       # redirect なし、$LASTEXITCODE で異常を catch
+#   # pattern: CAPTURE_STDOUT (stdout は変数に、stderr は破棄)
+#   $output = & native-cmd 2>$null
+#
+#   # pattern: PASS_THROUGH (console 直書き、exit code チェック必須)
+#   & native-cmd
 #   # ↑ stderr は親 console に直行、PS 側で ErrorRecord 化されないので Stop しない
-#   # ↑ ただし $LASTEXITCODE を必ずチェックして silent pass regression を防ぐこと
+#   # ↑ ただし $LASTEXITCODE を必ずチェック (redirect 削除だけだと出力が空でも
+#   #   $LASTEXITCODE 非ゼロのまま「正常」誤判定する経路ができる)
 #
-#   # BAD-a: 単独 pipeline 末尾の 2>&1 (Stop モードで terminating error)
+#   # ANTI-PATTERN: STOP_TRAP (Stop モードで確実に terminating error 飛ぶ)
 #   & native-cmd 2>&1
 #
-#   # BAD-b: 変数代入のみ (Out-String なし)
-#   $var = & native-cmd 2>&1           # PS バージョン依存で不安定
+#   # ANTI-PATTERN: STREAM_TO_VAR (Out-String なし、PS バージョンと
+#   # $ErrorActionPreference の組合せで挙動が変わる。5.1+Stop では確実に fail)
+#   $var = & native-cmd 2>&1
 #
 # 例外:
 #   - 実 release 操作 (Invoke-GhRelease 内の gh release create / delete) は
-#     redirect せず、出力をユーザーに見せる (GOOD-3 と同じ形だが exit code 必須)
+#     redirect せず、出力をユーザーに見せる (PASS_THROUGH の派生)
 # ============================================================================
 
-# -Offline / -DryRun は upload を行わないので、preflight の gh 関連チェックも
-# skip するため -SkipUpload を強制 ON とみなす（Codex P2 #137 ×2）
-# - -Offline: そもそも network 不可なので gh API 呼び出し不可
-# - -DryRun: zip 化と upload を skip するモード、preflight だけ network 必須にする意味なし
+# -Offline / -DryRun は upload を行わないので preflight の gh 関連チェックも
+# skip するため -SkipUpload を auto-promote する (Codex P2 #137 ×2)
 if (($Offline -or $DryRun) -and -not $SkipUpload) {
     $SkipUpload = $true
 }
@@ -561,8 +570,9 @@ function Resolve-Nuget {
 
 function Assert-WorkingTreeClean {
     param([string]$Context)
-    # native command redirection: GOOD-3 (冒頭集約コメント参照)
-    # silent pass regression 防止のため $LASTEXITCODE を必ずチェックする。
+    # pattern: PASS_THROUGH (冒頭集約コメント参照)
+    # redirect を外しただけだと git 失敗時に $gitStatus が空文字になり「working
+    # tree clean」と誤判定されるため、exit code チェックが必須
     $gitStatus = & git -C $RepoRoot status --porcelain
     if ($LASTEXITCODE -ne 0) {
         Fail "git status の実行に失敗しました (exit code: $LASTEXITCODE, context: $Context)"
@@ -610,7 +620,9 @@ $script:ReleaseNotesText = ''
 # Phase 0: Preflight
 # ============================================================================
 
-function Test-Preflight {
+function Assert-Preflight {
+    # Test-* verb は [bool] 返却が PowerShell 規約だが、preflight は違反時に Fail
+    # (exit 1) する性質なので Assert-* に揃える (同ファイル内の Assert-WorkingTreeClean と統一)
     Write-Step "Preflight: 環境とパラメータを検証"
 
     # Version 形式 (CHANGELOG から取った時点で確定済みだが念のため)
@@ -626,11 +638,12 @@ function Test-Preflight {
             Fail "gh (GitHub CLI) が見つかりません。`n        https://cli.github.com/ からインストールするか、-SkipUpload で upload を抑止してください。"
         }
         Write-Ok "gh: $gh"
-        # native command redirection: GOOD-2 (冒頭集約コメント参照)
-        # gh auth status は正常系でも stderr に書く gh 仕様、診断情報として保持。
-        $authResult = & gh auth status 2>&1 | Out-String
+        # pattern: CAPTURE_DIAGNOSTIC (冒頭集約コメント参照)
+        # gh auth status は失敗原因が多様 (未認証 / token expiry / network / proxy /
+        # gh 自体の install 破損)、Fail メッセージに stderr ダンプを含めて切り分け可能にする
+        $authStatusOutput = & gh auth status 2>&1 | Out-String
         if ($LASTEXITCODE -ne 0) {
-            Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$authResult"
+            Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$authStatusOutput"
         }
         Write-Ok "gh 認証 OK"
     }
@@ -660,9 +673,14 @@ function Test-Preflight {
 
     # 既存リリースとのタグ衝突
     if (-not $SkipUpload) {
-        # native command redirection: GOOD-1 (冒頭集約コメント参照)
+        # pattern: SUPPRESS_BOTH (冒頭集約コメント参照)
         # stdout も Out-Null で捨てるのは、release 存在時 gh が JSON を dump して
         # preflight コンソールが汚れるのを防ぐため。
+        #
+        # 注: gh の exit code 契約に依存している。過去に gh は release 不在以外
+        #     (auth / network 等) でも非ゼロ exit する仕様変更があり、将来また
+        #     変わる可能性がある。より堅くしたい場合は --json id 等で structured
+        #     output を取って parse 結果で判定する。
         & gh release view "v$Version" 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) {
             if ($Force) {
@@ -1117,7 +1135,7 @@ if ($SkipUpload) { Write-Host "Mode: SKIP-UPLOAD" -ForegroundColor Yellow }
 if ($Force)      { Write-Host "Mode: FORCE" -ForegroundColor Yellow }
 if ($Offline)    { Write-Host "Mode: OFFLINE" -ForegroundColor Yellow }
 
-Test-Preflight
+Assert-Preflight
 Read-ComponentVersions
 Resolve-Godot
 Resolve-MsBuild

--- a/Release.ps1
+++ b/Release.ps1
@@ -139,7 +139,7 @@ $ErrorActionPreference = 'Stop'
 #   # pattern: PASS_THROUGH (console 直書き、変数 capture なし)
 #   & native-cmd
 #   # ↑ stdout/stderr 両方とも親 console に直行
-#   # ↑ exit code チェック必須 (CAPTURE_STDOUT_PASS_STDERR と同じ理由)
+#   # ↑ exit code チェック必須 (成否を判定する唯一の信号が exit code のみのため)
 #
 #   # ANTI-PATTERN: STOP_TRAP (Stop モードで terminating error が飛ぶ)
 #   & native-cmd 2>&1                # 変数 capture なし版
@@ -627,9 +627,9 @@ function Assert-WorkingTreeClean {
 # ============================================================================
 
 function Get-BundleReleaseNotes {
-    param([switch]$SilentMissing)
+    param([switch]$AllowMissing)
     if (-not (Test-Path $ChangelogPath)) {
-        if ($SilentMissing) { return '' }
+        if ($AllowMissing) { return '' }
         Fail "CHANGELOG.md が見つかりません: $ChangelogPath"
     }
     $content = [System.IO.File]::ReadAllText($ChangelogPath, [System.Text.Encoding]::UTF8)
@@ -694,7 +694,7 @@ function Assert-Preflight {
         $script:ReleaseNotesText = $notes
         Write-Ok "CHANGELOG から Bundle v$Version セクションを抽出 ($($notes.Length) 文字)"
     } else {
-        $notes = Get-BundleReleaseNotes -SilentMissing
+        $notes = Get-BundleReleaseNotes -AllowMissing
         if ($notes) {
             $script:ReleaseNotesText = $notes
             Write-Info "CHANGELOG Bundle セクション検出: $($notes.Length) 文字 (-SkipUpload のため未使用)"


### PR DESCRIPTION
## Summary

PR #138 マージ後の実機テストで判明した 2 件の問題を修正。

## 問題 1: `Release.bat` の UTF-8 BOM が cmd.exe で認識されず @echo off 失敗

実機で `.\Release.bat` を実行すると以下のエラーで `@echo off` が機能せず、すべての REM 行がエコー + 日本語文字化け:

\`\`\`
C:\...> ・ｿ@echo off
'・ｿ@echo' は、内部コマンドまたは外部コマンドとして認識されていません。
\`\`\`

**原因**: cmd.exe が UTF-8 BOM (`EF BB BF`) を CP932 として解釈して 1 行目を破壊。これは PR #138 で M2 として docstring に書いていた「Win 10 1809 以前の cmd.exe build で BOM 認識が壊れている環境」のケースに該当。

**修正**: M2 docstring で書いていた脱出経路を本採用:

- BOM を外して **UTF-8 (no BOM) + CRLF** に書き直し
- `chcp 65001 >nul` より**前**の REM / echo を **ASCII (英語)** に統一
- `chcp 65001 >nul` 以降の REM / echo は引き続き日本語可
- docstring 冒頭に「`chcp 65001` 行より上は ASCII-only 必須」のルールを明記

## 問題 2: `gh release view` が release 不在時に script を terminating error で止める

preflight でタグ衝突確認する `& gh release view "v$Version" 2>&1` が、release 不在時 (本来は「衝突なし、続行」の正常系) に以下のエラーで script を強制終了:

\`\`\`
gh.exe : release not found
... FullyQualifiedErrorId : NativeCommandError
\`\`\`

**原因**: `$ErrorActionPreference='Stop'` 下で `2>&1` 経由の native command stderr が `NativeCommandError` という terminating error として扱われる PowerShell 5.1 の挙動。

**修正**: `2>&1` を `2>$null` に変更、stderr を捨てて `$LASTEXITCODE` だけで判定。結果も使わないので `Out-Null` に流す。

## 動作確認

修正後:
\`\`\`powershell
.\Release.bat -NoPause -DryRun -Force -GodotExe \"...\"
\`\`\`

→ `@echo off` 機能、Japanese 出力正常、DRY-RUN 完了。

実機ダブルクリックでの本番 release 実行も近日中に検証予定。

## 1 PR 1 bump 原則 (#139 で追加予定のルール) に従って

本 PR では Release Tooling v1.0.6 のみで bump、レビュー対応コミットで version を変えない方針。

🤖 Generated with [Claude Code](https://claude.com/claude-code)