### PR TITLE
fix(release): gh release view が NativeCommandError trap を踏む問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
   - 影響範囲は preflight の 1 call site のみ。zip / upload ロジックには変更なし
 - **#141 (元シニアレビュー round 8 H2) を本 fix で close**: 当時「別 issue で `--json id` への移行」と切り出した内容を、本番踏み抜きを機にインラインで本格対応
 
+#### Known follow-up (本 PR スコープ外、別ブランチで対処予定)
+
+- **`gh auth status` の call site は本 PR の catalog 制約に未追従**: `Release.ps1` の `Assert-Preflight` 内 `$authStatusOutput = & gh auth status 2>&1 | Out-String` (CAPTURE_DIAGNOSTIC) は、本 PR で新設した制約 (「失敗 path で stderr を出すコマンドには TRY_CATCH_NATIVE 必須」) に該当する。`gh auth status` は未認証時 exit 1 + stderr 出力なので、`gh auth login` 未実行の dev clone / token 期限切れ / `GH_TOKEN` 消失 等のシナリオで NativeCommandError 例外で abort し、本来表示するはずの `Fail "gh 認証に失敗しました ..."` メッセージが届かない。本 PR のスコープは `gh release view` の 1 call site に絞ったため未対応、改善ブランチでまとめて TRY_CATCH_NATIVE に移行予定。シニアレビュー round 11 で同 PR 内対応 or CHANGELOG note のどちらかが許容ラインとされたため、後者を選択
+
 ### [Release Tooling v1.0.6] - 2026-05-11
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@
 
 `Release.ps1` / `Release.bat` / `Install.bat` (Phase 2 以降) / `Updater` (Phase 3 以降) 等の配布インフラの変更履歴。エンドユーザー向けではなく、開発者が「リリーススクリプトのこの挙動はいつから？」を辿るために残す。
 
+### [Release Tooling v1.0.7] - 2026-05-12
+
+#### Fixed
+
+- **本番 release で `gh release view` が NativeCommandError trap を踏んで preflight が失敗する問題 (#141 のインライン解決)**: v1.0.6 までの `& gh release view "v$Version" 2>$null | Out-Null` は DRY-RUN で `-SkipUpload` 自動 promote により実行されず、本番 release で v0.1.0 を publish しようとして初めて発火した
+  - **根本原因**: PS 5.1 + `$ErrorActionPreference='Stop'` 環境では、native command が **exit 非ゼロ + stderr 出力** という組合せを返した場合に `2>$null` redirect が trap を防げない。これは PS が native command 用に別途生成する NativeCommandError ErrorRecord が `2>$null` の redirect 処理よりも先 (exit code 確定時点) に作られるため。v1.0.6 までの集約コメントは「`Out-String` を経由すれば Stop の判定対象から外れる」と書いていたが、これは exit 0 限定の挙動で、`gh release view "v0.1.0"` 不在時の `exit 1 + stderr "release not found"` には適用できなかった
+  - **修正**: `try/catch` で受ける `TRY_CATCH_NATIVE` パターンを新設 + 該当 call site に適用。`--json id` で stdout を最小化 (#141 で提案していた structured parse)、`"release not found"` 文字列マッチで "確実に存在しない" を確証、別種の失敗 (auth / network / API rate limit / gh install 破損 等) は preflight で早期 Fail させる形に。これで H2 silent false-negative (gh の auth/network 障害を「タグ衝突なし」と誤判定して zip ビルド完了後に fail する path) も同時解消
+  - **catalog 全体の精度向上**: 集約コメントの機構説明に「重要な制約」セクションを追加、`SUPPRESS_BOTH` / `CAPTURE_STDOUT` / `CAPTURE_DIAGNOSTIC` の各パターンが「success/failure path のどちらで stderr を出すか」によって安全性が変わる旨を明記。失敗 path で stderr を出すコマンドには `TRY_CATCH_NATIVE` 一択
+  - 影響範囲は preflight の 1 call site のみ。zip / upload ロジックには変更なし
+- **#141 (元シニアレビュー round 8 H2) を本 fix で close**: 当時「別 issue で `--json id` への移行」と切り出した内容を、本番踏み抜きを機にインラインで本格対応
+
 ### [Release Tooling v1.0.6] - 2026-05-11
 
 #### Fixed

--- a/Release.ps1
+++ b/Release.ps1
@@ -103,9 +103,17 @@ $ErrorActionPreference = 'Stop'
 # 機構: $ErrorActionPreference='Stop' は success stream に流れる ErrorRecord を
 # terminating error として扱う。`2>&1` は stderr の string output を ErrorRecord
 # として success stream に流すため Stop の判定対象になる。一方 Out-String を経由
-# すると ErrorRecord が string 化されるため、success stream には string のみが
-# 流れ Stop の判定対象から外れる。(PS 5.1 で確認。PS 7.x は stream 処理仕様が
-# 異なるため要再検証)
+# すると ErrorRecord が string 化される。(PS 5.1 で確認。PS 7.x は stream 処理
+# 仕様が異なるため要再検証)
+#
+# !! 重要な制約 (v1.0.7 で訂正): !!
+#   Out-String 経由でも、native command が **exit 非ゼロ + stderr 出力** という
+#   組み合わせを返した場合は Stop の trap が飛ぶ。これは PS が native command 用
+#   に別途生成する NativeCommandError ErrorRecord が Out-String の pipeline 化
+#   よりも先 (exit code 確定時点) に作られるため。
+#   - success path で stderr を出すコマンド (例: gh auth status exit 0): OK
+#   - 失敗 path で stderr を出すコマンド (例: gh release view exit 1): NG
+#   後者には TRY_CATCH_NATIVE を使う必要がある。
 #
 # PS 7.3+ 移行時の追加注意 (現状未対応):
 #   PS 7.3 以降は $PSNativeCommandUseErrorActionPreference (default $true) が
@@ -123,12 +131,31 @@ $ErrorActionPreference = 'Stop'
 #
 #   # pattern: SUPPRESS_BOTH (stderr / stdout 両方破棄、exit code のみ判定)
 #   & native-cmd 2>$null | Out-Null
+#   # ↑ 「success path で stderr を出さない」コマンド限定 (例: vswhere)
+#   # ↑ 失敗 path で stderr を出すコマンドは NativeCommandError trap が飛ぶ
+#   #   (v1.0.6 の gh release view で本番踏み → v1.0.7 で TRY_CATCH_NATIVE 化)
 #
-#   # pattern: CAPTURE_DIAGNOSTIC (失敗時に表示するため文字列化保持)
+#   # pattern: CAPTURE_DIAGNOSTIC (success exit + stderr 出力を文字列化保持)
 #   $output = & native-cmd 2>&1 | Out-String
+#   # ↑ success path で stderr を出すコマンド限定 (例: gh auth status exit 0)
+#   # ↑ 失敗 path で stderr を出すと Stop trap 発火、TRY_CATCH_NATIVE 必須
+#
+#   # pattern: TRY_CATCH_NATIVE (失敗 exit + stderr 出力を安全に捕捉)
+#   $output = ''; $exit = 0
+#   try {
+#       $output = & native-cmd 2>&1 | Out-String
+#       $exit   = $LASTEXITCODE
+#   } catch {
+#       $output = $_.Exception.Message
+#       $exit   = if ($LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 }
+#   }
+#   # ↑ 失敗 path で stderr を出すコマンド用 (例: gh release view 不在時 exit 1)
+#   # ↑ catch 内で $LASTEXITCODE が 0 に戻る環境があるため明示 fallback
 #
 #   # pattern: CAPTURE_STDOUT (stdout は変数に、stderr は破棄)
 #   $output = & native-cmd 2>$null
+#   # ↑ 「success path で stderr を出さない」コマンド限定 (例: vswhere)
+#   # ↑ SUPPRESS_BOTH と同じ制約: 失敗 path で stderr を出すと Stop trap が飛ぶ
 #
 #   # pattern: CAPTURE_STDOUT_PASS_STDERR (stdout は変数、stderr は console 直書き)
 #   $output = & native-cmd
@@ -150,8 +177,10 @@ $ErrorActionPreference = 'Stop'
 #   #   call で stderr も console に出したい意図で `2>&1` をつけてしまう typo
 #   #   として頻発するため anti-pattern として明示。redirect なしの PASS_THROUGH
 #   #   が正解 (stderr は自動で console 直行する)
-#   # ↑ 回避策は (a) Out-String を挟む = CAPTURE_DIAGNOSTIC、または
-#   #   (b) 2>&1 をやめる = SUPPRESS_BOTH / CAPTURE_STDOUT / *_PASS_STDERR 系
+#   # ↑ 回避策: (a) success exit が前提なら Out-String 挟む = CAPTURE_DIAGNOSTIC
+#   #          (b) 失敗 exit があり得るなら try/catch で囲む = TRY_CATCH_NATIVE
+#   #          (c) 2>&1 自体をやめる = SUPPRESS_BOTH / CAPTURE_STDOUT / *_PASS_STDERR 系
+#   #          (a) は exit 0 限定なので、失敗を扱うなら (b) が正解
 #
 # 例外:
 #   - 実 release 操作 (Invoke-GhRelease 内の gh release create / delete) は
@@ -709,25 +738,40 @@ function Assert-Preflight {
 
     # 既存リリースとのタグ衝突
     if (-not $SkipUpload) {
-        # pattern: SUPPRESS_BOTH (冒頭集約コメント参照)
-        # stdout も Out-Null で捨てるのは、release 存在時 gh が JSON を dump して
-        # preflight コンソールが汚れるのを防ぐため。
-        #
-        # 注: gh の exit code 契約に依存している。過去に gh は release 不在以外
-        #     (auth / network 等) でも非ゼロ exit する仕様変更があり、将来また
-        #     変わる可能性がある。より堅くしたい場合は --json id 等で structured
-        #     output を取って parse 結果で判定する。
-        & gh release view "v$Version" 2>$null | Out-Null
-        if ($LASTEXITCODE -eq 0) {
+        # pattern: TRY_CATCH_NATIVE (冒頭集約コメント参照)
+        # gh release view は release 不在時に exit 1 + stderr "release not found"
+        # を出す。PS 5.1 + Stop 環境では `2>$null` も `2>&1 | Out-String` も
+        # native command stderr の NativeCommandError 化 (Stop trap) を防げない
+        # ため、try/catch で受ける + 出力中の "release not found" 文字列で
+        # 「存在しない」を確証する形にする。これで gh の auth / network 等
+        # 別種の失敗 (exit 非ゼロ + 別 stderr) を「タグ衝突なし」と誤判定する
+        # H2 silent false-negative も同時に解消 (#141 のインライン解決)。
+        $releaseViewOutput = ''
+        $releaseViewExit   = 0
+        try {
+            # --json id: 存在時の JSON dump を最小化 (preflight console を汚さない)
+            $releaseViewOutput = & gh release view "v$Version" --json id 2>&1 | Out-String
+            $releaseViewExit   = $LASTEXITCODE
+        } catch {
+            $releaseViewOutput = $_.Exception.Message
+            $releaseViewExit   = if ($LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 }
+        }
+
+        if ($releaseViewExit -eq 0) {
             if ($Force) {
                 Write-Warn "タグ v$Version は既存だが -Force のため後で削除して作り直す"
                 $script:DeleteExistingRelease = $true
             } else {
                 Fail "GitHub Releases に v$Version が既存です。-Force で削除して作り直すか、別バージョンで実行してください。"
             }
-        } else {
+        } elseif ($releaseViewOutput -match 'release not found') {
             Write-Ok "タグ衝突なし: v$Version"
             $script:DeleteExistingRelease = $false
+        } else {
+            # 別種の失敗 (auth / network / API rate limit / gh install 破損 等)
+            # zip ビルド完了後の `gh release create` で fail するより、preflight で
+            # 早期 fail させて時間 / 計算資源を浪費しない
+            Fail "gh release view が予期せず失敗しました (exit $releaseViewExit):`n$releaseViewOutput"
         }
     }
 }


### PR DESCRIPTION
## 背景

本番 `.\Release.bat` 実行で preflight が:

```
gh.exe : release not found
+ FullyQualifiedErrorId : NativeCommandError
[FAIL] Release.ps1 が exit code 1 で終了
```

で停止し v0.1.0 が publish できない。

これは PR #140 のシニアレビュー round 8 で **H2 として識別 + #141 として deferred** していた問題が、本番 release で初めて発火した形。今回はインラインで本格対応。

## 根本原因

v1.0.6 までの `& gh release view "v$Version" 2>$null | Out-Null` は、PS 5.1 + `$ErrorActionPreference='Stop'` で **exit 非ゼロ + stderr 出力** の組合せを返す native command の NativeCommandError trap を防げない。`Out-String` 経由でも同じ trap を踏むことを isolated test で実証 (v1.0.6 catalog の機構説明は誤り)。

DRY-RUN で気付けなかったのは `-DryRun → -SkipUpload` auto promotion により当該コードパスがそもそも実行されなかったため。

## 修正

1. **`TRY_CATCH_NATIVE` パターン新設** + 該当 call site に適用
2. **`--json id` で structured parse** (#141 で当初提案していた解決): "release not found" の確実な検出 + 別種の失敗 (auth/network/API/install 破損 等) を preflight で早期 Fail
3. **catalog 全体の精度向上**: 「Out-String 経由でも exit 非ゼロ + stderr では trap が飛ぶ」制約を明記、各パターンの安全条件を再整理

詳細は CHANGELOG `[Release Tooling v1.0.7]` 参照。

## 検証

isolated test で:
- `exit=1`
- `BRANCH: not-found (OK)`
- `output: release not found`

を確認。

DRY-RUN は当該 path を skip するため、最終確認は merge 後の本番 release でユーザーが実施。

## 関連

Closes #141

## Test plan

- [ ] merge 後 `.\Release.bat` を実行
- [ ] preflight `タグ衝突なし: v0.1.0` で進む
- [ ] zip 化 + `gh release create` で v0.1.0 が GitHub Releases に公開される
- [ ] release notes に CHANGELOG `[Bundle v0.1.0]` セクションが入る