### PR TITLE
improve(release): Wave 1-2 post-v0.1.0 — helper 一本化 + mojibake + upload progress (closes #145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@
 
 #### Known follow-up (post-v1.0.8 で対処予定)
 
-- **mojibake 完完了了**: msbuild 終了後の Write-Host で日本語が doubled rendering する PS 5.1 + chcp 65001 既知バグ。`[Console]::OutputEncoding` ピン留めで対処予定 (Wave 2)
+- **msbuild 後の日本語 doubled rendering**: 症状例 `完了` → `完完了了`。msbuild 終了後の `Write-Host` で日本語が二重描画される PS 5.1 + chcp 65001 既知バグ。`[Console]::OutputEncoding` ピン留めで対処予定 (Wave 2)
 - **upload progress**: `gh release create` が TTY 検出で進捗描画を OFF にするため、経過秒数表示で代替予定 (Wave 2)
+- **`Invoke-NativeWithCapture` 内 TODO**: (a) 引数 quoting helper 切り出し (`Invoke-ExternalProcess` と duplicate)、(b) `-TimeoutSeconds` 引数で network hang ガード — いずれも post v1.0.8 で対処
 - **既存 issue #142 / #143 / #144 / #146**: catalog 重複は本 v1.0.8 で大幅解消、`Release.bat` docstring 分離 / `Read-*` 命名 sweep / `$Context → $PostSync` は別途
 - **#145 (CAPTURE_DIAGNOSTIC ラベル拡張) を本 v1.0.8 で close**: パターン自体を anti-pattern に格下げしたため拡張議論不要に
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
   - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` パラメータを追加 (500ms 間隔で経過秒数を `\r` 上書き表示)
   - `Invoke-GhRelease` (gh release delete / create) を PASS_THROUGH → helper + ShowProgress に移行、zip サイズも表示 (`アップロード中 (zip 59 MB)... 12s 経過`)
   - 完了後は progress 行を消して、gh が stdout に出す release URL を `Write-Info` で再表示
+- **PR #148 round 17 シニアレビュー反映**:
+  - **[R17 #2] UTF8Encoding 一意ソース統一**: `Invoke-GhRelease` の `WriteAllText` (`tmpNotes` 書き込み) と `Write-FileUtf8NoBom` helper が `[System.Text.UTF8Encoding]::new($false)` を新規生成しており、本 PR の「`$script:Utf8NoBomEncoding` を一意ソースとして共有」設計に違反していた。両箇所を `$script:Utf8NoBomEncoding` 参照に置換、UTF-8 encoding instance を script 内で完全に一意化
+  - **[R17 #3] `$OutputEncoding` 再ピン留め不要の理由を明文化**: `Invoke-ExternalProcess` finally で `[Console]::OutputEncoding` だけ再ピン留めし `$OutputEncoding` (PS pipeline 側 encoding) は触らない理由 (PS 変数なので子プロセスから変更不可) をコメント追記、保守者が「漏れか?」と判断して不要な再ピン留めを追加する誤修正を防止
+  - **[R17 #4] `Invoke-NativeWithCapture` docstring 注 1 を vswhere `-utf8` 対応反映**: 旧記述「vswhere は ASCII 中心」は同 PR 内で追加した `-utf8` 化と乖離。「vswhere はデフォルト system codepage 出力なので、本 helper 経由の call site では `-utf8` を必ず付与」に更新、日本語 VS install path も正しく decode できる旨を明示
+  - **[R17 #5] ShowProgress を `IsOutputRedirected` で抑止**: 非 TTY (CI / log file redirect) では `\r` が行リセットとして機能せず、progress 更新ごとに改行付きで log に展開されてノイズになる。`[Console]::IsOutputRedirected` (取得失敗時は redirected 扱いで safe-side) で検出して live progress を skip、redirected 環境では従来の gh TTY-off モードと同じく完了まで無音 → URL 表示の動作に degrade
+  - **[R17 #1 (false positive)]** PR body Commits 数: reviewer は "(7)" と認識していたが、round 16 push 後の `gh pr edit` で既に "(8)" に更新済み、stale view を見ていた可能性。本 round では body 再更新 (commit 8 を含む) のみ
 - **PR #148 round 16 シニアレビュー反映**:
   - **[R16 #1] vswhere 失敗時の `$vsInstall` クリア**: round 15 で `Write-Info "PATH fallback に切替"` と宣言したのに、続く `$vsInstall = $vswhereResult.StdOut.Trim()` が無条件実行で「失敗時 stdout の部分出力」も後段 `Test-Path` 経路に流れる構造矛盾。`if/else` に分けて失敗 branch で `$vsInstall = ''` を明示、最終的に `Test-Path` で実害は止まるが、宣言と実装の意図不一致を解消
   - **[R16 #2] `WaitForExit()` の両 path 役割を明示**: 旧コメント「.NET 慣習との表面的対称性のみ」は非 ShowProgress 経路で誤誘導 (実際にはここがプロセス完了を明示待機する唯一のポイント)。「ShowProgress 経路 = no-op / 非 ShowProgress 経路 = 必須」と path 毎の役割を明記、削除不可の根拠を両 path で示す

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@
 
 ### [Release Tooling v1.0.8] - 2026-05-12
 
+#### Fixed
+
+- **msbuild 後の日本語 doubled rendering (Wave 2)**: 症状例 `完了` → `完完了了`、ASCII は影響なし、複数 Write-Host が 1 行に collapse。PS 5.1 + chcp 65001 環境で子プロセス (msbuild) がコンソールハンドル継承後にコンソール encoding を OEM 系に戻して去ることが原因の既知バグ。修正:
+  - script 冒頭で `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)` + `$OutputEncoding` を明示ピン留め
+  - `Invoke-ExternalProcess` の finally ブロックで再ピン留め (二重防御、msbuild 等の毎呼び出し後)
+  - 同じ try/finally で Process オブジェクトの Dispose() も追加 (handle leak 防止)
+- **upload progress が表示されない問題 (Wave 2)**: `gh release create` は TTY 検出で進捗描画を OFF にするため、PS から呼ぶと upload 中ずっと無音 → ハング懸念。修正:
+  - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` パラメータを追加 (500ms 間隔で経過秒数を `\r` 上書き表示)
+  - `Invoke-GhRelease` (gh release delete / create) を PASS_THROUGH → helper + ShowProgress に移行、zip サイズも表示 (`アップロード中 (zip 59 MB)... 12s 経過`)
+  - 完了後は progress 行を消して、gh が stdout に出す release URL を `Write-Info` で再表示
+
 #### Changed
 
 - **Native command 呼び出しを `Invoke-NativeWithCapture` helper に一本化 (Wave 1: trap pattern 整理)**: `gh release view` (v1.0.7) / `gh auth status` (Round 11 Critical #1) / `vswhere` (Round 11 Low) を Process 直叩きベースの helper に移行。catalog から「失敗 path で stderr を出すコマンドでは罠を踏む」パターン (`SUPPRESS_BOTH` / `CAPTURE_DIAGNOSTIC` / `TRY_CATCH_NATIVE`) を anti-pattern に格下げ
@@ -43,8 +54,6 @@
 
 #### Known follow-up (post-v1.0.8 で対処予定)
 
-- **msbuild 後の日本語 doubled rendering**: 症状例 `完了` → `完完了了`。msbuild 終了後の `Write-Host` で日本語が二重描画される PS 5.1 + chcp 65001 既知バグ。`[Console]::OutputEncoding` ピン留めで対処予定 (Wave 2)
-- **upload progress**: `gh release create` が TTY 検出で進捗描画を OFF にするため、経過秒数表示で代替予定 (Wave 2)
 - **`Invoke-NativeWithCapture` 内 TODO**: (a) 引数 quoting helper 切り出し (`Invoke-ExternalProcess` と duplicate)、(b) `-TimeoutSeconds` 引数で network hang ガード — いずれも post v1.0.8 で対処
 - **既存 issue #142 / #143 / #144 / #146**: catalog 重複は本 v1.0.8 で大幅解消、`Release.bat` docstring 分離 / `Read-*` 命名 sweep / `$Context → $PostSync` は別途
 - **#145 (CAPTURE_DIAGNOSTIC ラベル拡張) を本 v1.0.8 で close**: パターン自体を anti-pattern に格下げしたため拡張議論不要に

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@
   - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` パラメータを追加 (500ms 間隔で経過秒数を `\r` 上書き表示)
   - `Invoke-GhRelease` (gh release delete / create) を PASS_THROUGH → helper + ShowProgress に移行、zip サイズも表示 (`アップロード中 (zip 59 MB)... 12s 経過`)
   - 完了後は progress 行を消して、gh が stdout に出す release URL を `Write-Info` で再表示
+- **Wave 2 シニアレビュー反映 (M1-M3 + L1-L4)**:
+  - **M1**: catalog の PS 7.3+ 移行注意コメントから vswhere を削除 (Wave 1 で helper 化済みのため stale)、残る `&` イディオムは `Assert-WorkingTreeClean` の `git status --porcelain` のみと正確化
+  - **M2**: `Invoke-NativeWithCapture` docstring に「`$LASTEXITCODE` は更新されない、`.ExitCode` を使え」を明記。Process 直叩きの構造上 `&` の自動変数を avoid、caller が古い値を読む silent failure を防ぐ
+  - **M3**: ShowProgress の clear-line 幅を 70 ハードコード → `[Console]::WindowWidth - 1` で動的算出 (fallback 120)、ProgressMessage / 日本語 cell 幅 / elapsed 桁数に依存しない消去を実現
+  - **L1**: gh release create 成功時の URL 表示が gh の stdout フォーマット依存である旨をコメントに明記 (silent path だが exit code で成否は確実、URL は fatal ではないので allowed)
+  - **L2**: encoding pin コメントの「特に msbuild」断定を「Godot CLI / msbuild / nuget 等、`RedirectStandardOutput=$false` でコンソールハンドル継承するもの」に緩和。v0.1.0 で観察された発火例は msbuild 後だが、原因として等価候補
+  - **L3**: `$delResult.StdOut.Trim() ... $delResult.StdOut.TrimEnd()` の二重 trim を `-match '\S'` + 一時変数化で 1 回に
+  - **L4**: `Combined` の separator 判定コメントを 4 case 網羅 (stdout 空 / 末尾 `\n` あり / なし / stderr 空) に書き換え
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@
   - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` パラメータを追加 (500ms 間隔で経過秒数を `\r` 上書き表示)
   - `Invoke-GhRelease` (gh release delete / create) を PASS_THROUGH → helper + ShowProgress に移行、zip サイズも表示 (`アップロード中 (zip 59 MB)... 12s 経過`)
   - 完了後は progress 行を消して、gh が stdout に出す release URL を `Write-Info` で再表示
+- **PR #148 round 15 シニアレビュー反映**:
+  - **[R15 M1] 死参照訂正**: `Invoke-NativeWithCapture` のセクションヘッダコメント `(冒頭の \`2>&1\` trap セクション参照)` が v1.0.8 のセクション再構成で stale に。「冒頭の『Native command 呼び出しの方針』セクション参照」に修正
+  - **[R15 M2] WindowWidth fallback コメントと実装の divergence 解消**: コメント「0 以下を返す」と実装 `-lt 30` の食い違いを明文化。「30 未満」は WindowWidth=0 の非 console host と極端に狭い実コンソールの両方を catch する threshold である旨を明示
+  - **[R15 M3] vswhere の silent pass 解消**: コメントが「実行環境破損で stderr 出力する可能性」を挙げて Invoke-NativeWithCapture に移行していたにも関わらず ExitCode / StdErr を完全に無視していた silent pass を修正。vswhere 失敗時は `Write-Warn` で診断情報を出して PATH fallback に切替 (release は続行可能なため Fail にはしない)
+  - **[R15 L1] Combined 4 case コメント精度向上**: 第 4 case「stderr 空 → stdout のみ」は stdout 末尾改行なしのとき不正確 (実は `\n` が付く)。stdout 末尾改行の有無を主軸にした 2 分岐構造に書き換え、各分岐で stderr の各 case を入れ子で記述
+  - **[R15 L2] gh release delete dead code を future-proofing と明示**: 現行 gh では成功時 stdout 空なので `if ($delOut -match '\S')` ブランチは常に false。コメントを「現行は発火しない、gh 将来 version への future-proofing として残置」に書き換え、reader が「`Write-Ok` では不十分な case があるのか?」と誤解する path を防止
+  - **[R15 L3] CHANGELOG R13 L2/L3 フォーマット統一**: 他エントリの `**[R## L#] 見出し**: 説明文` 形式に揃える ( `↔` や文の ぶつ切りを解消)
 - **PR #148 round 14 シニアレビュー + Codex bot P2 反映**:
   - **[Codex P2] vswhere に `-utf8` フラグ追加**: `Invoke-NativeWithCapture` は stdout/stderr を UTF-8 として decode するが、vswhere は default で system codepage 出力。非 UTF-8 locale で日本語 VS install path 等 non-ASCII path が mojibake → 後段 `Test-Path` 失敗 → MSBuild 検出失敗の silent path に落ちる。`-utf8` を Arguments に追加して vswhere 出力を UTF-8 強制
   - **[Codex P2 ×2] `[Console]::OutputEncoding` を try/catch でガード**: non-console host (CI / headless / redirected execution) では console API setter が `IOException` を投げ、`$ErrorActionPreference='Stop'` 下で release 開始前に script abort する path。script 冒頭の pin + `Invoke-ExternalProcess` finally の再 pin 両方を try/catch でラップ、script-level `$script:Utf8NoBomEncoding` を一意ソースとして共有
@@ -52,10 +59,10 @@
   - **[R13 M1] `gh release delete` UX 退行**: 成功時 stdout/stderr 無音のため `if ($delOut -match '\S')` が false で ShowProgress 行消去後に「無の状態」。`Write-Ok "既存タグ v$Version を削除完了"` を無条件追加して旧 PASS_THROUGH UX を回復
   - **[R13 M2] PASS_THROUGH catalog のメカニズム乖離**: catalog の例示は `& native-cmd` 直書きだが現実装は `Invoke-ExternalProcess` (Process 直叩き)。「(a) 直 & 演算子版」「(b) helper 経由 (推奨)」の 2 実装に分割記述
   - **[R13 M3] `ShowProgress` パスで `WaitForExit()` 未呼び出し**: HasExited ループ後にも `WaitForExit()` 明示呼びを追加、両 path 合流点で対称化 (上記 R14 H1 でコメント内容を訂正)
-  - **[R13 L2]** ↔ R13 M3 説明文の `WindowWidth` 0 以下 fallback 条件を CHANGELOG にも記載
-  - **[R13 L3]** 引数 quoting の trailing backslash 制約を helper inline コメントとして明文化
-  - **[R13 L4]** `Invoke-ExternalProcess` にも Process.Start 失敗時 context 付き rethrow を追加、両 helper 対称化
-  - **[R13 L1 (保留)]** CHANGELOG 日付ポリシー (JST 統一 / UTC 統一 / PR merge 日) の策定は CHANGELOG 全体議論なので別途
+  - **[R13 L2] WindowWidth fallback 条件の記載追加**: R13 M3 説明文に「`[Console]::WindowWidth` が 0 以下を返す non-console host も同様に fallback 120」を追記、コード側との整合を明示 (round 15 M2 で更に「30 未満も含む」に精度向上)
+  - **[R13 L3] 引数 quoting backslash 制約のドキュメント化**: trailing backslash を持つパス引数 (`"C:\path\"`) は CommandLineToArgvW 規則上 `\"` が閉じ引用符として機能せず引数 parse 破損する既知制約を helper の inline コメントに明文化、現 call site は該当なし
+  - **[R13 L4] `Invoke-ExternalProcess` の Process.Start 失敗 rethrow**: `Invoke-NativeWithCapture` と同じ context 付き例外メッセージ粒度で対称化
+  - **[R13 L1 (保留)] CHANGELOG 日付ポリシー**: JST 統一 / UTC 統一 / PR merge 日のいずれかに統一する議論は CHANGELOG 全体に関わるため別途
 - **PR #148 round 12 (Wave 2) シニアレビュー反映**:
   - **[W2 M1]** catalog の PS 7.3+ 移行注意から vswhere を削除 (Wave 1 で helper 化済みのため stale)、残る `&` イディオムは `Assert-WorkingTreeClean` の `git status --porcelain` のみと正確化
   - **[W2 M2]** `Invoke-NativeWithCapture` docstring に「`$LASTEXITCODE` は更新されない、`.ExitCode` を使え」を明記

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@
   - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` パラメータを追加 (500ms 間隔で経過秒数を `\r` 上書き表示)
   - `Invoke-GhRelease` (gh release delete / create) を PASS_THROUGH → helper + ShowProgress に移行、zip サイズも表示 (`アップロード中 (zip 59 MB)... 12s 経過`)
   - 完了後は progress 行を消して、gh が stdout に出す release URL を `Write-Info` で再表示
+- **PR #148 シニアレビュー反映 (M1-M3 + L2-L4)**:
+  - **M1**: `gh release delete` は成功時 stdout/stderr 無音のため `if ($delOut -match '\S')` が false で ShowProgress 行消去後に「無の状態」になる UX 退行。明示的に `Write-Ok "既存タグ v$Version を削除完了"` を無条件追加して旧 PASS_THROUGH UX を回復
+  - **M2**: catalog の PASS_THROUGH 説明が `& native-cmd` 直書きの 1 形態に書かれていたが、現状の実装は `Invoke-ExternalProcess` (System.Diagnostics.Process 直叩き) なのでメカニズム乖離。「(a) 直 & 演算子版 (現状未使用)」「(b) `Invoke-ExternalProcess` helper 経由 (推奨)」の 2 実装に分けて記述、(a) は encoding 再ピン留め保護がない旨も注記
+  - **M3**: `ShowProgress` パスで `WaitForExit()` 未呼び出しだった非対称を解消。`HasExited` ループ終了後にも明示的に `WaitForExit()` (no-op だが .NET 慣習に従いパイプフラッシュを保証) を追加、両 path を対称化
+  - **L2**: M3 の CHANGELOG 説明文に「`[Console]::WindowWidth` が 0 以下を返す non-console host も同様に fallback 120」を追記、コード側 (`if ($clearWidth -lt 30) { $clearWidth = 120 }`) との整合を明示
+  - **L3**: 引数 quoting の trailing backslash 制約 (`"C:\path\"` → CommandLineToArgvW 解析破損) を helper の inline コメントとして明文化、現 call site (zip / 一時 notes / vswhere) はいずれも該当しないため安全、新規 call site でディレクトリパスを渡す際の注意として残す
+  - **L4**: `Invoke-ExternalProcess` にも `Process.Start` 失敗時の context 付き rethrow (`'$FilePath' の起動に失敗しました: ...`) を追加、`Invoke-NativeWithCapture` と例外メッセージ粒度を対称化
+  - **L1 (保留)**: CHANGELOG v1.0.7 / v1.0.8 の日付 `2026-05-12` (JST) は commit author date と一致。reviewer は UTC context (2026-05-11) で見ていた解釈ズレ。日付ポリシー (JST 統一 / UTC 統一 / PR merge 日) の策定は CHANGELOG 全体に関わるため別途
 - **Wave 2 シニアレビュー反映 (M1-M3 + L1-L4)**:
   - **M1**: catalog の PS 7.3+ 移行注意コメントから vswhere を削除 (Wave 1 で helper 化済みのため stale)、残る `&` イディオムは `Assert-WorkingTreeClean` の `git status --porcelain` のみと正確化
   - **M2**: `Invoke-NativeWithCapture` docstring に「`$LASTEXITCODE` は更新されない、`.ExitCode` を使え」を明記。Process 直叩きの構造上 `&` の自動変数を avoid、caller が古い値を読む silent failure を防ぐ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@
 
 `Release.ps1` / `Release.bat` / `Install.bat` (Phase 2 以降) / `Updater` (Phase 3 以降) 等の配布インフラの変更履歴。エンドユーザー向けではなく、開発者が「リリーススクリプトのこの挙動はいつから？」を辿るために残す。
 
+### [Release Tooling v1.0.8] - 2026-05-12
+
+#### Changed
+
+- **Native command 呼び出しを `Invoke-NativeWithCapture` helper に一本化 (Wave 1: trap pattern 整理)**: `gh release view` (v1.0.7) / `gh auth status` (Round 11 Critical #1) / `vswhere` (Round 11 Low) を Process 直叩きベースの helper に移行。catalog から「失敗 path で stderr を出すコマンドでは罠を踏む」パターン (`SUPPRESS_BOTH` / `CAPTURE_DIAGNOSTIC` / `TRY_CATCH_NATIVE`) を anti-pattern に格下げ
+  - **`Invoke-NativeWithCapture` helper 新設**: `System.Diagnostics.Process` で stdout/stderr/exit code を直接捕捉。PS の error stream を経由しないため NativeCommandError trap を構造的に回避。両 stream を async 読みでデッドロックも回避。返り値は `[PSCustomObject]` で `.StdOut` / `.StdErr` / `.ExitCode` / `.Combined` を提供 (Round 12 #1/3 のリネーム指摘もこの構造変更で自動解消)
+  - **catalog 大幅整理**: 6 個あった pattern を「Invoke-NativeWithCapture 推奨 + 3 個の安全な `&` pattern + anti-patterns」に再構成。Round 11 Low の命名軸統一 + Round 12 全般の意図明確化を満たす形に
+  - **`gh release view` の structured parse 表現訂正 (Round 11 High + Round 12 #2)**: `--json id` の効果は「存在時の stdout を最小化」のみで、parse はしていない。stderr 文字列マッチでの「不在 vs 別種失敗」判定は gh の英語メッセージ依存である旨をコメントに明記、本来の structured parse (`ConvertFrom-Json` + HTTP 404 判定 etc.) は将来課題として記録
+  - **Round 11/12 の Medium / Low 一括対処**: `$_.Exception.Message` 単一行依存 (helper で StdErr 直接取得に変更で解消)、`$releaseViewOutput` mixed content (helper で StdOut/StdErr 分離で解消)、`Out-String` 末尾改行 `.TrimEnd()` 化、elseif → ネスト if/else (exit code を一次軸、stderr を二次軸の構造に)、catalog ↔ call site 重複圧縮 (helper 化で per-site コメントが固有理由 1-2 行に)
+  - **`gh auth status` の同 trap も同時解消 (Round 11 Critical #1)**: v1.0.7 で CHANGELOG note として deferred していたものを Wave 1 で本対応
+- **PASS_THROUGH の「例外節」呼称を廃止**: 旧 catalog では「実 release 操作 (gh release create/delete) は例外」と書いていたが、PASS_THROUGH 自体を catalog の一級 pattern として再定義したため例外節は不要に。`Invoke-GhRelease` 内の 2 件のコメントから「例外節 -」を削除
+
+#### Known follow-up (post-v1.0.8 で対処予定)
+
+- **mojibake 完完了了**: msbuild 終了後の Write-Host で日本語が doubled rendering する PS 5.1 + chcp 65001 既知バグ。`[Console]::OutputEncoding` ピン留めで対処予定 (Wave 2)
+- **upload progress**: `gh release create` が TTY 検出で進捗描画を OFF にするため、経過秒数表示で代替予定 (Wave 2)
+- **既存 issue #142 / #143 / #144 / #146**: catalog 重複は本 v1.0.8 で大幅解消、`Release.bat` docstring 分離 / `Read-*` 命名 sweep / `$Context → $PostSync` は別途
+- **#145 (CAPTURE_DIAGNOSTIC ラベル拡張) を本 v1.0.8 で close**: パターン自体を anti-pattern に格下げしたため拡張議論不要に
+
 ### [Release Tooling v1.0.7] - 2026-05-12
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
   - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` パラメータを追加 (500ms 間隔で経過秒数を `\r` 上書き表示)
   - `Invoke-GhRelease` (gh release delete / create) を PASS_THROUGH → helper + ShowProgress に移行、zip サイズも表示 (`アップロード中 (zip 59 MB)... 12s 経過`)
   - 完了後は progress 行を消して、gh が stdout に出す release URL を `Write-Info` で再表示
+- **PR #148 round 16 シニアレビュー反映**:
+  - **[R16 #1] vswhere 失敗時の `$vsInstall` クリア**: round 15 で `Write-Info "PATH fallback に切替"` と宣言したのに、続く `$vsInstall = $vswhereResult.StdOut.Trim()` が無条件実行で「失敗時 stdout の部分出力」も後段 `Test-Path` 経路に流れる構造矛盾。`if/else` に分けて失敗 branch で `$vsInstall = ''` を明示、最終的に `Test-Path` で実害は止まるが、宣言と実装の意図不一致を解消
+  - **[R16 #2] `WaitForExit()` の両 path 役割を明示**: 旧コメント「.NET 慣習との表面的対称性のみ」は非 ShowProgress 経路で誤誘導 (実際にはここがプロセス完了を明示待機する唯一のポイント)。「ShowProgress 経路 = no-op / 非 ShowProgress 経路 = 必須」と path 毎の役割を明記、削除不可の根拠を両 path で示す
+  - **[R16 #3] `clearLine` 全角 cell 幅の注意書きを正確化**: 旧コメント「Japanese 文字 cell 幅によらず消し残しが出ない」は実装より強い保証に読める。実態は「現 ProgressMessage 長では WindowWidth-1 幅で覆える前提に依存」「全角 2 cell 幅を構造的に補正していない」を明文化、長文 ProgressMessage 追加時の修正 hint も併記
+  - **[R16 #4] CHANGELOG R13 ナンバリング順を整理**: R13 L1 (保留) を L4 の後から L2 の前 (= L1/L2/L3/L4 の自然順) に移動、後追い時のスキャンが直感的に
 - **PR #148 round 15 シニアレビュー反映**:
   - **[R15 M1] 死参照訂正**: `Invoke-NativeWithCapture` のセクションヘッダコメント `(冒頭の \`2>&1\` trap セクション参照)` が v1.0.8 のセクション再構成で stale に。「冒頭の『Native command 呼び出しの方針』セクション参照」に修正
   - **[R15 M2] WindowWidth fallback コメントと実装の divergence 解消**: コメント「0 以下を返す」と実装 `-lt 30` の食い違いを明文化。「30 未満」は WindowWidth=0 の非 console host と極端に狭い実コンソールの両方を catch する threshold である旨を明示
@@ -59,10 +64,10 @@
   - **[R13 M1] `gh release delete` UX 退行**: 成功時 stdout/stderr 無音のため `if ($delOut -match '\S')` が false で ShowProgress 行消去後に「無の状態」。`Write-Ok "既存タグ v$Version を削除完了"` を無条件追加して旧 PASS_THROUGH UX を回復
   - **[R13 M2] PASS_THROUGH catalog のメカニズム乖離**: catalog の例示は `& native-cmd` 直書きだが現実装は `Invoke-ExternalProcess` (Process 直叩き)。「(a) 直 & 演算子版」「(b) helper 経由 (推奨)」の 2 実装に分割記述
   - **[R13 M3] `ShowProgress` パスで `WaitForExit()` 未呼び出し**: HasExited ループ後にも `WaitForExit()` 明示呼びを追加、両 path 合流点で対称化 (上記 R14 H1 でコメント内容を訂正)
+  - **[R13 L1 (保留)] CHANGELOG 日付ポリシー**: JST 統一 / UTC 統一 / PR merge 日のいずれかに統一する議論は CHANGELOG 全体に関わるため別途
   - **[R13 L2] WindowWidth fallback 条件の記載追加**: R13 M3 説明文に「`[Console]::WindowWidth` が 0 以下を返す non-console host も同様に fallback 120」を追記、コード側との整合を明示 (round 15 M2 で更に「30 未満も含む」に精度向上)
   - **[R13 L3] 引数 quoting backslash 制約のドキュメント化**: trailing backslash を持つパス引数 (`"C:\path\"`) は CommandLineToArgvW 規則上 `\"` が閉じ引用符として機能せず引数 parse 破損する既知制約を helper の inline コメントに明文化、現 call site は該当なし
   - **[R13 L4] `Invoke-ExternalProcess` の Process.Start 失敗 rethrow**: `Invoke-NativeWithCapture` と同じ context 付き例外メッセージ粒度で対称化
-  - **[R13 L1 (保留)] CHANGELOG 日付ポリシー**: JST 統一 / UTC 統一 / PR merge 日のいずれかに統一する議論は CHANGELOG 全体に関わるため別途
 - **PR #148 round 12 (Wave 2) シニアレビュー反映**:
   - **[W2 M1]** catalog の PS 7.3+ 移行注意から vswhere を削除 (Wave 1 で helper 化済みのため stale)、残る `&` イディオムは `Assert-WorkingTreeClean` の `git status --porcelain` のみと正確化
   - **[W2 M2]** `Invoke-NativeWithCapture` docstring に「`$LASTEXITCODE` は更新されない、`.ExitCode` を使え」を明記

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,22 +41,29 @@
   - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` パラメータを追加 (500ms 間隔で経過秒数を `\r` 上書き表示)
   - `Invoke-GhRelease` (gh release delete / create) を PASS_THROUGH → helper + ShowProgress に移行、zip サイズも表示 (`アップロード中 (zip 59 MB)... 12s 経過`)
   - 完了後は progress 行を消して、gh が stdout に出す release URL を `Write-Info` で再表示
-- **PR #148 シニアレビュー反映 (M1-M3 + L2-L4)**:
-  - **M1**: `gh release delete` は成功時 stdout/stderr 無音のため `if ($delOut -match '\S')` が false で ShowProgress 行消去後に「無の状態」になる UX 退行。明示的に `Write-Ok "既存タグ v$Version を削除完了"` を無条件追加して旧 PASS_THROUGH UX を回復
-  - **M2**: catalog の PASS_THROUGH 説明が `& native-cmd` 直書きの 1 形態に書かれていたが、現状の実装は `Invoke-ExternalProcess` (System.Diagnostics.Process 直叩き) なのでメカニズム乖離。「(a) 直 & 演算子版 (現状未使用)」「(b) `Invoke-ExternalProcess` helper 経由 (推奨)」の 2 実装に分けて記述、(a) は encoding 再ピン留め保護がない旨も注記
-  - **M3**: `ShowProgress` パスで `WaitForExit()` 未呼び出しだった非対称を解消。`HasExited` ループ終了後にも明示的に `WaitForExit()` (no-op だが .NET 慣習に従いパイプフラッシュを保証) を追加、両 path を対称化
-  - **L2**: M3 の CHANGELOG 説明文に「`[Console]::WindowWidth` が 0 以下を返す non-console host も同様に fallback 120」を追記、コード側 (`if ($clearWidth -lt 30) { $clearWidth = 120 }`) との整合を明示
-  - **L3**: 引数 quoting の trailing backslash 制約 (`"C:\path\"` → CommandLineToArgvW 解析破損) を helper の inline コメントとして明文化、現 call site (zip / 一時 notes / vswhere) はいずれも該当しないため安全、新規 call site でディレクトリパスを渡す際の注意として残す
-  - **L4**: `Invoke-ExternalProcess` にも `Process.Start` 失敗時の context 付き rethrow (`'$FilePath' の起動に失敗しました: ...`) を追加、`Invoke-NativeWithCapture` と例外メッセージ粒度を対称化
-  - **L1 (保留)**: CHANGELOG v1.0.7 / v1.0.8 の日付 `2026-05-12` (JST) は commit author date と一致。reviewer は UTC context (2026-05-11) で見ていた解釈ズレ。日付ポリシー (JST 統一 / UTC 統一 / PR merge 日) の策定は CHANGELOG 全体に関わるため別途
-- **Wave 2 シニアレビュー反映 (M1-M3 + L1-L4)**:
-  - **M1**: catalog の PS 7.3+ 移行注意コメントから vswhere を削除 (Wave 1 で helper 化済みのため stale)、残る `&` イディオムは `Assert-WorkingTreeClean` の `git status --porcelain` のみと正確化
-  - **M2**: `Invoke-NativeWithCapture` docstring に「`$LASTEXITCODE` は更新されない、`.ExitCode` を使え」を明記。Process 直叩きの構造上 `&` の自動変数を avoid、caller が古い値を読む silent failure を防ぐ
-  - **M3**: ShowProgress の clear-line 幅を 70 ハードコード → `[Console]::WindowWidth - 1` で動的算出 (fallback 120)、ProgressMessage / 日本語 cell 幅 / elapsed 桁数に依存しない消去を実現
-  - **L1**: gh release create 成功時の URL 表示が gh の stdout フォーマット依存である旨をコメントに明記 (silent path だが exit code で成否は確実、URL は fatal ではないので allowed)
-  - **L2**: encoding pin コメントの「特に msbuild」断定を「Godot CLI / msbuild / nuget 等、`RedirectStandardOutput=$false` でコンソールハンドル継承するもの」に緩和。v0.1.0 で観察された発火例は msbuild 後だが、原因として等価候補
-  - **L3**: `$delResult.StdOut.Trim() ... $delResult.StdOut.TrimEnd()` の二重 trim を `-match '\S'` + 一時変数化で 1 回に
-  - **L4**: `Combined` の separator 判定コメントを 4 case 網羅 (stdout 空 / 末尾 `\n` あり / なし / stderr 空) に書き換え
+- **PR #148 round 14 シニアレビュー + Codex bot P2 反映**:
+  - **[Codex P2] vswhere に `-utf8` フラグ追加**: `Invoke-NativeWithCapture` は stdout/stderr を UTF-8 として decode するが、vswhere は default で system codepage 出力。非 UTF-8 locale で日本語 VS install path 等 non-ASCII path が mojibake → 後段 `Test-Path` 失敗 → MSBuild 検出失敗の silent path に落ちる。`-utf8` を Arguments に追加して vswhere 出力を UTF-8 強制
+  - **[Codex P2 ×2] `[Console]::OutputEncoding` を try/catch でガード**: non-console host (CI / headless / redirected execution) では console API setter が `IOException` を投げ、`$ErrorActionPreference='Stop'` 下で release 開始前に script abort する path。script 冒頭の pin + `Invoke-ExternalProcess` finally の再 pin 両方を try/catch でラップ、script-level `$script:Utf8NoBomEncoding` を一意ソースとして共有
+  - **[R14 H1] `WaitForExit()` コメントの自己矛盾を訂正**: 旧コメント「パイプバッファ完全フラッシュを保証」は誤り (WaitForExit no-arg のフラッシュ保証は `BeginOutputReadLine` 系の event-based async 読み取りに対するもので、本実装の `ReadToEndAsync` Task-based には適用されない)。実際のフラッシュ保証は `$outTask.Result` / `$errTask.Result` が EOF までブロックすることで提供。コメントを「`.Result` を削除すると出力切り捨てバグが発生するため touch しないこと」に書き換え
+  - **[R14 M1] CHANGELOG label 重複解消**: 同 v1.0.8 entry 内に「Wave 2 シニアレビュー反映 (M1-M3)」と「PR #148 シニアレビュー反映 (M1-M3)」が共存し M1-M3 が 2 セット存在、後追い不能だった。本 entry のラベルを「R14」「W2」「Codex P2」等の round 識別子付きに変更
+  - **[R14 L1] zip size 表示の小ファイル対応**: `[int]($bytes / 1MB)` は 1MB 未満で 0 表示になり破損誤解を招く。`if ge 1MB → MB / ge 1KB → KB / else B` の自動切替に変更、Phase 2 以降の Updater 単体 zip 等で発火する想定
+  - **[R14 L2] ShowProgress 中の Task リーク (Known follow-up)**: `ReadToEndAsync()` 開始後に ShowProgress ループ内で例外発生 → finally で Dispose() → Task が `ObjectDisposedException` で faulted のまま GC まで放置。実害ほぼなし (現状実行 path で発火経路なし) だが、post v1.0.8 で `-TimeoutSeconds` + CancellationToken 対応する際に合わせて整理
+- **PR #148 round 13 シニアレビュー反映**:
+  - **[R13 M1] `gh release delete` UX 退行**: 成功時 stdout/stderr 無音のため `if ($delOut -match '\S')` が false で ShowProgress 行消去後に「無の状態」。`Write-Ok "既存タグ v$Version を削除完了"` を無条件追加して旧 PASS_THROUGH UX を回復
+  - **[R13 M2] PASS_THROUGH catalog のメカニズム乖離**: catalog の例示は `& native-cmd` 直書きだが現実装は `Invoke-ExternalProcess` (Process 直叩き)。「(a) 直 & 演算子版」「(b) helper 経由 (推奨)」の 2 実装に分割記述
+  - **[R13 M3] `ShowProgress` パスで `WaitForExit()` 未呼び出し**: HasExited ループ後にも `WaitForExit()` 明示呼びを追加、両 path 合流点で対称化 (上記 R14 H1 でコメント内容を訂正)
+  - **[R13 L2]** ↔ R13 M3 説明文の `WindowWidth` 0 以下 fallback 条件を CHANGELOG にも記載
+  - **[R13 L3]** 引数 quoting の trailing backslash 制約を helper inline コメントとして明文化
+  - **[R13 L4]** `Invoke-ExternalProcess` にも Process.Start 失敗時 context 付き rethrow を追加、両 helper 対称化
+  - **[R13 L1 (保留)]** CHANGELOG 日付ポリシー (JST 統一 / UTC 統一 / PR merge 日) の策定は CHANGELOG 全体議論なので別途
+- **PR #148 round 12 (Wave 2) シニアレビュー反映**:
+  - **[W2 M1]** catalog の PS 7.3+ 移行注意から vswhere を削除 (Wave 1 で helper 化済みのため stale)、残る `&` イディオムは `Assert-WorkingTreeClean` の `git status --porcelain` のみと正確化
+  - **[W2 M2]** `Invoke-NativeWithCapture` docstring に「`$LASTEXITCODE` は更新されない、`.ExitCode` を使え」を明記
+  - **[W2 M3]** ShowProgress の clear-line 幅を 70 ハードコード → `[Console]::WindowWidth - 1` で動的算出 (fallback 120)
+  - **[W2 L1]** gh release create 成功時の URL 表示が gh の stdout フォーマット依存である旨をコメントに明記
+  - **[W2 L2]** encoding pin コメントの「特に msbuild」断定を「Godot CLI / msbuild / nuget 等」に緩和
+  - **[W2 L3]** `.Trim() / .TrimEnd()` 二重呼び解消 (`-match '\S'` + 一時変数化)
+  - **[W2 L4]** `Combined` separator 判定コメントを 4 case 網羅に書き換え
 
 #### Changed
 

--- a/Release.ps1
+++ b/Release.ps1
@@ -95,9 +95,12 @@ $ErrorActionPreference = 'Stop'
 # ============================================================================
 # Console output encoding を UTF-8 (no BOM) にピン留め
 # ============================================================================
-# PS 5.1 + chcp 65001 環境では、子プロセス (特に msbuild) がコンソールハンドル
-# を継承して走った後、後続の Write-Host で日本語が doubled rendering される
-# 既知バグがある (症状例: `完了` → `完完了了`、ASCII は影響なし)。
+# PS 5.1 + chcp 65001 環境では、子プロセス (Invoke-ExternalProcess 経由の
+# Godot CLI / msbuild / nuget 等、RedirectStandardOutput=$false でコンソール
+# ハンドルを継承するもの) が走った後、後続の Write-Host で日本語が doubled
+# rendering される既知バグがある (症状例: `完了` → `完完了了`、ASCII は影響なし)。
+# 観察例として本番 v0.1.0 release では msbuild 後に発火を確認、ただし原因として
+# Godot / nuget も同じ条件を満たすので等価候補。
 # `[Console]::OutputEncoding` を UTF-8 (no BOM) で明示ピン留めしておく + 各
 # Invoke-ExternalProcess 呼び出し後に再ピン留めすることで発火を防ぐ。
 # `$OutputEncoding` は PS pipeline → native command への送信時の encoding。
@@ -168,12 +171,14 @@ $OutputEncoding           = [System.Text.UTF8Encoding]::new($false)
 # PS 7.3+ 移行時の注意 (現状未対応):
 #   PS 7.3 以降は $PSNativeCommandUseErrorActionPreference (default $true) が
 #   追加され、`& native-cmd` の非ゼロ exit code 自体が ErrorActionPreference に
-#   従って terminating error 化する。本スクリプトの「`&` + $LASTEXITCODE 判定」
-#   イディオム (Assert-WorkingTreeClean の git status, vswhere の失敗パス等) は
-#   PS 7.3+ では `if ($LASTEXITCODE -ne 0)` に到達せず abort する。
-#   移行時には以下のいずれかが必須:
+#   従って terminating error 化する。本スクリプトで残る `&` イディオムは
+#   Assert-WorkingTreeClean の `git status --porcelain` のみ。これは PS 7.3+ で
+#   `if ($LASTEXITCODE -ne 0)` に到達せず abort する。
+#   (Invoke-NativeWithCapture / Invoke-ExternalProcess は Process 直叩きのため
+#    $PSNativeCommandUseErrorActionPreference の影響を受けず、移行後も安全)
+#   PS 7 移行時には以下のいずれかが必須:
 #     (a) script 冒頭で $PSNativeCommandUseErrorActionPreference = $false に固定
-#     (b) すべての `&` 系を Invoke-NativeWithCapture (Process 直叩き) に移行
+#     (b) 残った `&` 系 (git status) も Invoke-NativeWithCapture に移行
 #   現状は PS 5.1 を前提とした実装。
 # ============================================================================
 
@@ -294,9 +299,13 @@ function Invoke-NativeWithCapture {
           ExitCode - プロセスの終了コード (int)
           Combined - StdOut + "`n" + StdErr 連結 (検索用、stdout 末尾の改行有無で
                      joining 境界がぶれないよう明示 separator)
-        注: 子プロセス側が UTF-8 で書く前提。`gh` は UTF-8 だが、`vswhere` は ASCII
+        注 1: 子プロセス側が UTF-8 で書く前提。`gh` は UTF-8 だが、`vswhere` は ASCII
         中心、msbuild / nuget は OEM 系 codepage を出す可能性あり (本 helper は現状
         gh / vswhere のみで使用)。
+        注 2: 本関数は System.Diagnostics.Process 直叩きのため、PS 自動変数の
+        `$LASTEXITCODE` は **更新されない**。caller は必ず返り値の `.ExitCode` を
+        参照すること。helper 呼び出し直後に `if ($LASTEXITCODE -ne 0)` と書くと、
+        その前の `&` 呼び出しの古い値を読む silent failure path になるため厳禁。
     #>
     param(
         [Parameter(Mandatory)][string]$FilePath,
@@ -342,15 +351,21 @@ function Invoke-NativeWithCapture {
         if ($ShowProgress) {
             # 進捗描画なしコマンド (gh release create 等) のための擬似 progress。
             # 500ms 間隔で経過秒数を `\r` 上書き表示 (CR で行頭戻り、新しい数字で上書き)
+            # clear 幅は console window 幅から動的算出: ProgressMessage 長 / Japanese
+            # 文字 cell 幅 / elapsed 桁数によらず消し残しが出ない。WindowWidth 取得
+            # 失敗時 (ISE 等の非 console host) は 120 で fallback (cmd.exe / Windows
+            # Terminal の典型幅 80 を超える safe margin)
+            $clearWidth = try { [Console]::WindowWidth - 1 } catch { 120 }
+            if ($clearWidth -lt 30) { $clearWidth = 120 }
+            $clearLine = ' ' * $clearWidth
             $start = Get-Date
             while (-not $proc.HasExited) {
                 $elapsed = [int]((Get-Date) - $start).TotalSeconds
-                # 末尾 spaces は前回より短くなった場合の残骸を消すための padding
-                Write-Host -NoNewline "`r    $ProgressMessage ${elapsed}s 経過          "
+                Write-Host -NoNewline "`r    $ProgressMessage ${elapsed}s 経過"
                 Start-Sleep -Milliseconds 500
             }
             # progress 行を完全に消して cursor を行頭へ (後続の出力が綺麗に流れる)
-            Write-Host -NoNewline "`r$(' ' * 70)`r"
+            Write-Host -NoNewline "`r$clearLine`r"
         } else {
             $proc.WaitForExit()
         }
@@ -364,8 +379,12 @@ function Invoke-NativeWithCapture {
             throw "Invoke-NativeWithCapture: '$FilePath' の出力読み取りに失敗しました: $($_.Exception.Message)"
         }
 
-        # Combined の separator: stdout 末尾改行の有無に関わらず確実に行境界を
-        # 入れて、^pattern 系 regex が join 境界で取りこぼさないようにする
+        # Combined の separator 判定 (4 case 網羅):
+        #   stdout 空                          → $stderr そのまま (separator 不要、
+        #                                        Combined 先頭が stderr なので `^` regex は effective)
+        #   stdout 有 + 末尾 \n あり           → 単純連結 (改行はすでに含まれる)
+        #   stdout 有 + 末尾 \n なし + stderr → `\n` を明示挟む (^pattern 取りこぼし防止)
+        #   stderr 空                          → 上記いずれかで stdout のみ
         if ($stdout -and -not $stdout.EndsWith("`n")) {
             $combined = $stdout + "`n" + $stderr
         } else {
@@ -1013,9 +1032,10 @@ function Invoke-ExternalProcess {
         $exitCode = $proc.ExitCode
     } finally {
         if ($null -ne $proc) { $proc.Dispose() }
-        # msbuild など子プロセスが OutputEncoding を OEM に戻して去ると、後続の
-        # Write-Host で日本語が doubled rendering される PS 5.1 バグの予防的再ピン留め
-        # (script 冒頭の pin と二重防御)
+        # Invoke-ExternalProcess 経由の子プロセス (Godot CLI / msbuild / nuget) が
+        # コンソール encoding を OEM 系に戻して去ると、後続 Write-Host で日本語が
+        # doubled rendering される PS 5.1 バグの予防的再ピン留め (script 冒頭の
+        # pin と二重防御)
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
     }
     return $exitCode
@@ -1253,7 +1273,8 @@ function Invoke-GhRelease {
         if ($delResult.ExitCode -ne 0) {
             Fail "既存 release の削除に失敗しました:`n$($delResult.Combined.TrimEnd())"
         }
-        if ($delResult.StdOut.Trim()) { Write-Info $delResult.StdOut.TrimEnd() }
+        $delOut = $delResult.StdOut.TrimEnd()
+        if ($delOut -match '\S') { Write-Info $delOut }
     }
 
     # CHANGELOG から抽出した Bundle セクション本文を --notes に渡す
@@ -1268,8 +1289,14 @@ function Invoke-GhRelease {
         if ($uploadResult.ExitCode -ne 0) {
             Fail "gh release create に失敗しました:`n$($uploadResult.Combined.TrimEnd())"
         }
-        # 成功時、gh は release URL を stdout に dump するのでユーザーに表示
-        if ($uploadResult.StdOut.Trim()) { Write-Info $uploadResult.StdOut.TrimEnd() }
+        # 成功時、gh は release URL を stdout に dump するのでユーザーに表示。
+        # 注: gh の将来 version で stdout フォーマットが変わると URL が表示されない
+        # silent path になるが、成功は exit code で確実に取れているため fatal で
+        # はない (`Write-Ok "公開完了"` は出る、URL は手動で confirm 可能)。
+        # 同型の脆弱性は gh release view の "release not found" stderr マッチ側でも
+        # 抱えており、本格的な structured 検出は別 issue 系で対処予定。
+        $uploadOut = $uploadResult.StdOut.TrimEnd()
+        if ($uploadOut -match '\S') { Write-Info $uploadOut }
     } finally {
         Remove-Item $tmpNotes.FullName -Force -ErrorAction SilentlyContinue
     }

--- a/Release.ps1
+++ b/Release.ps1
@@ -93,99 +93,64 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 # ============================================================================
-# Native command の `2>&1` trap (PS 5.1 + $ErrorActionPreference='Stop' 環境)
+# Native command 呼び出しの方針 (v1.0.8 で再整理)
 # ============================================================================
-# このスクリプトでは git / gh / msbuild / nuget 等の native command を呼び出すが、
-# `2>&1` で stderr を success stream に merge すると PS 5.1 + Stop モードでは
-# native command の stderr 出力が NativeCommandError の terminating error として
-# 扱われ、本来「正常系」のはずの path で script が止まる。
+# 経緯: PS 5.1 + $ErrorActionPreference='Stop' 下では、`&` 演算子 + native
+# command の組み合わせで「exit 非ゼロ + stderr 出力」を返すコマンドが
+# NativeCommandError の terminating error を発生させる。
+# v1.0.6 までは `2>$null` / `2>&1 | Out-String` 系で回避できると考えていたが、
+# v1.0.7 で実証された通り PS の error stream への ErrorRecord 化が redirect
+# よりも先に発火するため redirect は防御にならない。v1.0.8 で
+# `Invoke-NativeWithCapture` ヘルパー (System.Diagnostics.Process 直叩き) に
+# 一本化、`&` 系の patterns は「success exit が確証できる場合のみ」に格下げ。
 #
-# 機構: $ErrorActionPreference='Stop' は success stream に流れる ErrorRecord を
-# terminating error として扱う。`2>&1` は stderr の string output を ErrorRecord
-# として success stream に流すため Stop の判定対象になる。一方 Out-String を経由
-# すると ErrorRecord が string 化される。(PS 5.1 で確認。PS 7.x は stream 処理
-# 仕様が異なるため要再検証)
+# 採用ガイドライン (call site では「pattern: 名前」で参照):
 #
-# !! 重要な制約 (v1.0.7 で訂正): !!
-#   Out-String 経由でも、native command が **exit 非ゼロ + stderr 出力** という
-#   組み合わせを返した場合は Stop の trap が飛ぶ。これは PS が native command 用
-#   に別途生成する NativeCommandError ErrorRecord が Out-String の pipeline 化
-#   よりも先 (exit code 確定時点) に作られるため。
-#   - success path で stderr を出すコマンド (例: gh auth status exit 0): OK
-#   - 失敗 path で stderr を出すコマンド (例: gh release view exit 1): NG
-#   後者には TRY_CATCH_NATIVE を使う必要がある。
+#   1. Invoke-NativeWithCapture (RECOMMENDED for any failable command)
+#      $result = Invoke-NativeWithCapture -FilePath 'gh' -Arguments @('release','view','v1.0','--json','id')
+#      # → $result.StdOut / $result.StdErr / $result.ExitCode / $result.Combined
+#      # System.Diagnostics.Process で PS error stream を経由しないため罠なし。
+#      # 失敗 path で stderr を出すコマンドは必ずこれ (gh release view / gh auth status 等)。
 #
-# PS 7.3+ 移行時の追加注意 (現状未対応):
+#   2. pattern: CAPTURE_STDOUT_PASS_STDERR
+#      $output = & native-cmd        # stdout は変数 capture、stderr は console 直書き
+#      # exit code チェック必須 ($output が空でも非ゼロ exit を見落とさないため)
+#      # 例: git status --porcelain (Assert-WorkingTreeClean)
+#
+#   3. pattern: PASS_THROUGH
+#      & native-cmd                  # stdout/stderr 両方 console 直書き、変数 capture なし
+#      # exit code チェック必須 (成否を判定する唯一の信号が exit code のみ)
+#      # 例: gh release create / delete (出力をユーザーに見せたい時)
+#
+#   4. pattern: CAPTURE_STDOUT (success exit が確証できるコマンド限定)
+#      $output = & native-cmd 2>$null
+#      # 失敗 path で stderr を出すコマンドでは Stop trap、Invoke-NativeWithCapture を使う
+#      # 例: vswhere -property installationPath (検索 hit なしは exit 0)
+#
+# ANTI-PATTERNS (使用禁止):
+#
+#   X. STOP_TRAP — & cmd 2>&1 / $var = & cmd 2>&1
+#      stderr が ErrorRecord として success stream に流れ Stop trap 発火。
+#      回避: Invoke-NativeWithCapture へ移行。
+#
+#   X. SUPPRESS_BOTH — & cmd 2>$null | Out-Null (v1.0.6 で踏み抜き廃止)
+#   X. CAPTURE_DIAGNOSTIC — $out = & cmd 2>&1 | Out-String (v1.0.8 で廃止)
+#      どちらも「失敗 path で stderr を出すコマンド」で同じ trap を踏む。
+#      Invoke-NativeWithCapture へ移行。
+#
+#   X. TRY_CATCH_NATIVE (v1.0.7 のみ存在、v1.0.8 で廃止)
+#      Invoke-NativeWithCapture が同じ目的を関数化したため不要。
+#
+# PS 7.3+ 移行時の注意 (現状未対応):
 #   PS 7.3 以降は $PSNativeCommandUseErrorActionPreference (default $true) が
 #   追加され、`& native-cmd` の非ゼロ exit code 自体が ErrorActionPreference に
-#   従って terminating error 化する。本スクリプトの「2>&1 を外して $LASTEXITCODE で
-#   判定」というイディオム (例: Assert-WorkingTreeClean の git status, vswhere の
-#   失敗パス等) は、PS 7.3+ では `if ($LASTEXITCODE -ne 0)` に到達せず、エラー
-#   メッセージや context 情報を出す前に script 自体が abort する経路に変わる。
-#   将来 PS 7 移行する場合は以下のいずれか必須:
+#   従って terminating error 化する。本スクリプトの「`&` + $LASTEXITCODE 判定」
+#   イディオム (Assert-WorkingTreeClean の git status, vswhere の失敗パス等) は
+#   PS 7.3+ では `if ($LASTEXITCODE -ne 0)` に到達せず abort する。
+#   移行時には以下のいずれかが必須:
 #     (a) script 冒頭で $PSNativeCommandUseErrorActionPreference = $false に固定
-#     (b) 各 $LASTEXITCODE チェックを try/catch でラップ
+#     (b) すべての `&` 系を Invoke-NativeWithCapture (Process 直叩き) に移行
 #   現状は PS 5.1 を前提とした実装。
-#
-# パターン早見表 (call site では「pattern: 名前」で参照する):
-#
-#   # pattern: SUPPRESS_BOTH (stderr / stdout 両方破棄、exit code のみ判定)
-#   & native-cmd 2>$null | Out-Null
-#   # ↑ 「success path で stderr を出さない」コマンド限定 (例: vswhere)
-#   # ↑ 失敗 path で stderr を出すコマンドは NativeCommandError trap が飛ぶ
-#   #   (v1.0.6 の gh release view で本番踏み → v1.0.7 で TRY_CATCH_NATIVE 化)
-#
-#   # pattern: CAPTURE_DIAGNOSTIC (success exit + stderr 出力を文字列化保持)
-#   $output = & native-cmd 2>&1 | Out-String
-#   # ↑ success path で stderr を出すコマンド限定 (例: gh auth status exit 0)
-#   # ↑ 失敗 path で stderr を出すと Stop trap 発火、TRY_CATCH_NATIVE 必須
-#
-#   # pattern: TRY_CATCH_NATIVE (失敗 exit + stderr 出力を安全に捕捉)
-#   $output = ''; $exit = 0
-#   try {
-#       $output = & native-cmd 2>&1 | Out-String
-#       $exit   = $LASTEXITCODE
-#   } catch {
-#       $output = $_.Exception.Message
-#       $exit   = if ($LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 }
-#   }
-#   # ↑ 失敗 path で stderr を出すコマンド用 (例: gh release view 不在時 exit 1)
-#   # ↑ catch 内で $LASTEXITCODE が 0 に戻る環境があるため明示 fallback
-#
-#   # pattern: CAPTURE_STDOUT (stdout は変数に、stderr は破棄)
-#   $output = & native-cmd 2>$null
-#   # ↑ 「success path で stderr を出さない」コマンド限定 (例: vswhere)
-#   # ↑ SUPPRESS_BOTH と同じ制約: 失敗 path で stderr を出すと Stop trap が飛ぶ
-#
-#   # pattern: CAPTURE_STDOUT_PASS_STDERR (stdout は変数、stderr は console 直書き)
-#   $output = & native-cmd
-#   # ↑ stderr は親 console に直行 (ErrorRecord 化されないので Stop しない)
-#   # ↑ stdout は通常の string array として変数に capture される
-#   # ↑ exit code チェック必須 (出力が空でも $LASTEXITCODE 非ゼロのまま誤判定防止)
-#
-#   # pattern: PASS_THROUGH (console 直書き、変数 capture なし)
-#   & native-cmd
-#   # ↑ stdout/stderr 両方とも親 console に直行
-#   # ↑ exit code チェック必須 (成否を判定する唯一の信号が exit code のみのため)
-#
-#   # ANTI-PATTERN: STOP_TRAP (Stop モードで terminating error が飛ぶ)
-#   & native-cmd 2>&1                # 変数 capture なし版
-#   $var = & native-cmd 2>&1         # 変数 capture あり版
-#   # ↑ どちらも同じ罠。本質は `2>&1` 自体: stderr が ErrorRecord として success
-#   #   stream に流れ、$ErrorActionPreference='Stop' の判定対象になる
-#   # ↑ 「変数 capture なし版」は通常書く理由がないが、副作用 only の native
-#   #   call で stderr も console に出したい意図で `2>&1` をつけてしまう typo
-#   #   として頻発するため anti-pattern として明示。redirect なしの PASS_THROUGH
-#   #   が正解 (stderr は自動で console 直行する)
-#   # ↑ 回避策: (a) success exit が前提なら Out-String 挟む = CAPTURE_DIAGNOSTIC
-#   #          (b) 失敗 exit があり得るなら try/catch で囲む = TRY_CATCH_NATIVE
-#   #          (c) 2>&1 自体をやめる = SUPPRESS_BOTH / CAPTURE_STDOUT / *_PASS_STDERR 系
-#   #          (a) は exit 0 限定なので、失敗を扱うなら (b) が正解
-#
-# 例外:
-#   - 実 release 操作 (Invoke-GhRelease 内の gh release create / delete) は
-#     PASS_THROUGH を採用する。出力をユーザーに見せて何が起きているか追える
-#     ようにするのが目的 (preflight 中の SUPPRESS_BOTH とは方針が逆)
 # ============================================================================
 
 # -Offline / -DryRun は upload を行わないので preflight の gh 関連チェックも
@@ -277,6 +242,65 @@ function Fail       { param([string]$Message)
 function Get-ToolPath { param([string]$Name)
     $cmd = Get-Command $Name -ErrorAction SilentlyContinue
     if ($cmd) { return $cmd.Source } else { return $null }
+}
+
+# ============================================================================
+# Native command の罠なし呼び出し (冒頭の `2>&1` trap セクション参照)
+# ============================================================================
+
+function Invoke-NativeWithCapture {
+    <#
+    .SYNOPSIS
+        Native command を実行し、stdout / stderr / exit code を罠なく取得する。
+    .DESCRIPTION
+        PowerShell の call operator `&` は「exit 非ゼロ + stderr 出力」の native
+        command で NativeCommandError を生成し、$ErrorActionPreference='Stop' 下で
+        terminating error として throw する。`2>&1 | Out-String` も同じ罠を踏む
+        (Out-String が処理する前に PS の error stream で trap が発火)。本関数は
+        System.Diagnostics.Process で stdout/stderr を直接捕捉し、PS の error
+        pipeline を経由しないため罠を完全に回避できる。
+
+        失敗 path で stderr を出すコマンド (例: gh release view 不在時 exit 1 +
+        "release not found"、gh auth status 未認証時 exit 1) の preflight 系
+        チェックは本関数を使うこと。
+    .OUTPUTS
+        PSCustomObject:
+          StdOut   - 標準出力 (string、UTF-8 でデコード)
+          StdErr   - 標準エラー (string、UTF-8 でデコード)
+          ExitCode - プロセスの終了コード (int)
+          Combined - StdOut + StdErr 連結 (検索用)
+    #>
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+    # 引数 quoting は Invoke-ExternalProcess と同じ規則 (DRY 化候補だが現状は単純なので duplicate)
+    $quoted = $Arguments | ForEach-Object {
+        if ($_ -match '\s|"') { '"' + ($_ -replace '"', '\"') + '"' } else { $_ }
+    }
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName               = $FilePath
+    $psi.Arguments              = $quoted -join ' '
+    $psi.UseShellExecute        = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $psi.StandardErrorEncoding  = [System.Text.Encoding]::UTF8
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    # 両 stream を async で読みデッドロック回避 (片方のバッファが満杯になると child が block する)
+    $outTask = $proc.StandardOutput.ReadToEndAsync()
+    $errTask = $proc.StandardError.ReadToEndAsync()
+    $proc.WaitForExit()
+    $stdout = $outTask.Result
+    $stderr = $errTask.Result
+
+    return [PSCustomObject]@{
+        StdOut   = $stdout
+        StdErr   = $stderr
+        ExitCode = $proc.ExitCode
+        Combined = $stdout + $stderr
+    }
 }
 
 # ============================================================================
@@ -533,8 +557,12 @@ function Resolve-MsBuild {
     $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (-not (Test-Path $vswhere)) { $vswhere = "$env:ProgramFiles\Microsoft Visual Studio\Installer\vswhere.exe" }
     if (Test-Path $vswhere) {
-        # pattern: CAPTURE_STDOUT (冒頭集約コメント参照)
-        $vsInstall = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath 2>$null
+        # vswhere は検索 hit なし時に exit 0 + 空 stdout を返すが、実行環境破損
+        # (権限 / インストーラ破損 等) で stderr 出力する可能性もあるため
+        # Invoke-NativeWithCapture で罠なく capture
+        $vswhereResult = Invoke-NativeWithCapture -FilePath $vswhere `
+            -Arguments @('-latest', '-products', '*', '-requires', 'Microsoft.Component.MSBuild', '-property', 'installationPath')
+        $vsInstall = $vswhereResult.StdOut.Trim()
         if ($vsInstall) {
             $vsCands = @(
                 (Join-Path $vsInstall 'MSBuild\Current\Bin\MSBuild.exe'),
@@ -692,24 +720,20 @@ function Assert-Preflight {
             Fail "gh (GitHub CLI) が見つかりません。`n        https://cli.github.com/ からインストールするか、-SkipUpload で upload を抑止してください。"
         }
         Write-Ok "gh: $gh"
-        # pattern: CAPTURE_DIAGNOSTIC (冒頭集約コメント参照)
-        # gh auth status は失敗原因が多様 (未認証 / token expiry / network / proxy /
-        # gh 自体の install 破損)、Fail メッセージに stderr ダンプを含めて切り分け可能にする
-        $authStatusOutput = & gh auth status 2>&1 | Out-String
-        if ($LASTEXITCODE -ne 0) {
-            Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$authStatusOutput"
+        # gh auth status は未認証時 exit 1 + stderr 出力 → Invoke-NativeWithCapture で
+        # 罠なく捕捉。失敗原因は多様 (未認証 / token expiry / network / proxy /
+        # gh install 破損)、Combined を Fail メッセージに含めて切り分け可能にする
+        $authResult = Invoke-NativeWithCapture -FilePath 'gh' -Arguments @('auth', 'status')
+        if ($authResult.ExitCode -ne 0) {
+            Fail "gh 認証に失敗しました (`gh auth login` を実行 / network / proxy / token expiry 等を確認)。`n$($authResult.Combined.TrimEnd())"
         }
         Write-Ok "gh 認証 OK"
-        # gh は exit 0 でも stderr に early warning を出すことがある (token scope
-        # 不足の予兆 / token expiry 近接通知 等)。失敗してないので Fail はしないが、
-        # リリース担当に気付かせる。
-        #
-        # 検出は `^warning:` (gh の公式 warning prefix) のみに絞る。token expiry の
-        # 特殊形式までカバーする regex は false positive を増やし、かつ gh の出力
-        # フォーマット変更に脆弱。本格的な structured 検出は別 issue (#141 系) で
-        # JSON parse に寄せる方針なので、ここでは過信を生む特殊形式を持たない。
-        if ($authStatusOutput -match '(?im)^warning:') {
-            Write-Warn "gh auth status からの警告 (release 実行自体は継続):`n$authStatusOutput"
+        # gh は exit 0 でも stderr に early warning を出すことがある (token scope 不足の
+        # 予兆 / token expiry 近接通知 等)。Fail はしないが、リリース担当に気付かせる。
+        # 検出は `^warning:` (gh 公式の warning prefix) のみに絞る (token expiry 特殊形式
+        # まで網羅する regex は false positive 多 + gh 出力フォーマット変更に脆弱)。
+        if ($authResult.Combined -match '(?im)^warning:') {
+            Write-Warn "gh auth status からの警告 (release 実行自体は継続):`n$($authResult.Combined.TrimEnd())"
         }
     }
 
@@ -738,40 +762,34 @@ function Assert-Preflight {
 
     # 既存リリースとのタグ衝突
     if (-not $SkipUpload) {
-        # pattern: TRY_CATCH_NATIVE (冒頭集約コメント参照)
-        # gh release view は release 不在時に exit 1 + stderr "release not found"
-        # を出す。PS 5.1 + Stop 環境では `2>$null` も `2>&1 | Out-String` も
-        # native command stderr の NativeCommandError 化 (Stop trap) を防げない
-        # ため、try/catch で受ける + 出力中の "release not found" 文字列で
-        # 「存在しない」を確証する形にする。これで gh の auth / network 等
-        # 別種の失敗 (exit 非ゼロ + 別 stderr) を「タグ衝突なし」と誤判定する
-        # H2 silent false-negative も同時に解消 (#141 のインライン解決)。
-        $releaseViewOutput = ''
-        $releaseViewExit   = 0
-        try {
-            # --json id: 存在時の JSON dump を最小化 (preflight console を汚さない)
-            $releaseViewOutput = & gh release view "v$Version" --json id 2>&1 | Out-String
-            $releaseViewExit   = $LASTEXITCODE
-        } catch {
-            $releaseViewOutput = $_.Exception.Message
-            $releaseViewExit   = if ($LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 }
-        }
+        # gh release view は release 不在時に exit 1 + stderr "release not found" を出す。
+        # Invoke-NativeWithCapture で stdout/stderr/exit を罠なく分離捕捉。
+        # `--json id`: 存在時の stdout を最小化 (capture 文字列が小さくなる、parse はしない)。
+        # 存在判定は exit code を一次軸、stderr 文字列マッチは「不在 vs 別種失敗」の識別のみ。
+        $releaseResult = Invoke-NativeWithCapture -FilePath 'gh' `
+            -Arguments @('release', 'view', "v$Version", '--json', 'id')
 
-        if ($releaseViewExit -eq 0) {
+        if ($releaseResult.ExitCode -eq 0) {
+            # 既存 release あり
             if ($Force) {
                 Write-Warn "タグ v$Version は既存だが -Force のため後で削除して作り直す"
                 $script:DeleteExistingRelease = $true
             } else {
                 Fail "GitHub Releases に v$Version が既存です。-Force で削除して作り直すか、別バージョンで実行してください。"
             }
-        } elseif ($releaseViewOutput -match 'release not found') {
-            Write-Ok "タグ衝突なし: v$Version"
-            $script:DeleteExistingRelease = $false
         } else {
-            # 別種の失敗 (auth / network / API rate limit / gh install 破損 等)
-            # zip ビルド完了後の `gh release create` で fail するより、preflight で
-            # 早期 fail させて時間 / 計算資源を浪費しない
-            Fail "gh release view が予期せず失敗しました (exit $releaseViewExit):`n$releaseViewOutput"
+            # exit 非ゼロ → 不在 or 別種失敗。stderr の英文字列で識別
+            # (注: gh の i18n / 文言変更で取りこぼし可能性あり、その時は再 trapping。
+            #  本格的な structured 検出は --json + ConvertFrom-Json + HTTP 404 判定 etc.)
+            if ($releaseResult.StdErr -match 'release not found') {
+                Write-Ok "タグ衝突なし: v$Version"
+                $script:DeleteExistingRelease = $false
+            } else {
+                # 別種の失敗 (auth / network / API rate limit / gh install 破損 等)
+                # zip ビルド完了後の gh release create で fail するより、preflight で
+                # 早期 fail させて時間 / 計算資源を浪費しない
+                Fail "gh release view が予期せず失敗しました (exit $($releaseResult.ExitCode)):`n$($releaseResult.Combined.TrimEnd())"
+            }
         }
     }
 }
@@ -1134,7 +1152,7 @@ function Invoke-GhRelease {
 
     if ($script:DeleteExistingRelease) {
         Write-Info "既存タグ v$Version を削除"
-        # pattern: PASS_THROUGH (例外節 - 冒頭集約コメント参照)
+        # pattern: PASS_THROUGH (冒頭集約コメント参照)
         # 実 release 操作中の gh 出力はユーザーに見せる方針
         & gh release delete "v$Version" --yes --cleanup-tag
         if ($LASTEXITCODE -ne 0) { Fail "既存 release の削除に失敗しました" }
@@ -1145,7 +1163,7 @@ function Invoke-GhRelease {
     $tmpNotes = New-TemporaryFile
     try {
         [System.IO.File]::WriteAllText($tmpNotes.FullName, $script:ReleaseNotesText, [System.Text.UTF8Encoding]::new($false))
-        # pattern: PASS_THROUGH (例外節 - 冒頭集約コメント参照)
+        # pattern: PASS_THROUGH (冒頭集約コメント参照)
         # upload 進捗等を見せたいので redirect しない
         & gh release create "v$Version" $ZipPath --notes-file $tmpNotes.FullName --title "v$Version"
         if ($LASTEXITCODE -ne 0) { Fail "gh release create に失敗しました" }

--- a/Release.ps1
+++ b/Release.ps1
@@ -379,8 +379,11 @@ function Invoke-NativeWithCapture {
         if ($ShowProgress) {
             # 進捗描画なしコマンド (gh release create 等) のための擬似 progress。
             # 500ms 間隔で経過秒数を `\r` 上書き表示 (CR で行頭戻り、新しい数字で上書き)
-            # clear 幅は console window 幅から動的算出: ProgressMessage 長 / Japanese
-            # 文字 cell 幅 / elapsed 桁数によらず消し残しが出ない。
+            # clear 幅は console window 幅から動的算出。現在の ProgressMessage 長
+            # (~20 chars + zip サイズ + elapsed) では全角文字含めても WindowWidth-1
+            # 幅の空白で覆える前提に依存している (全角文字の 2 cell 幅を構造的に
+            # 補正してはいない、長文 ProgressMessage を追加する場合は実 cell 幅
+            # 計算 = ASCII 1 + 全角 2 への切替を検討する)。
             # Fallback 条件 (どちらも 120 cells に置換):
             #   - WindowWidth 取得が例外を投げる (ISE 等の非 console host)
             #   - WindowWidth - 1 が 30 未満 (例: WindowWidth=0 を返す non-console host /
@@ -397,15 +400,17 @@ function Invoke-NativeWithCapture {
             # progress 行を完全に消して cursor を行頭へ (後続の出力が綺麗に流れる)
             Write-Host -NoNewline "`r$clearLine`r"
         }
-        # 両 path 合流点。ShowProgress 経路は HasExited で抜けて WaitForExit() は
-        # no-op、非 ShowProgress 経路はここで完了待機。
+        # 両 path 合流点の WaitForExit() の役割は path 毎に異なる:
+        #   ShowProgress 経路: HasExited ループ後の no-op、表面的対称性のみ
+        #   非 ShowProgress 経路: プロセス完了を明示待機する唯一のポイント
+        # どちらも削除不可。前者は対称性 / 保険、後者は機能上の必須。
+        #
         # 注: WaitForExit() (no-arg) のパイプバッファフラッシュ保証は
         # BeginOutputReadLine / BeginErrorReadLine (event-based 非同期) に対する
         # ものであり、本実装が使う ReadToEndAsync (Task-based) には適用されない。
-        # 実際のフラッシュ保証は直後の $outTask.Result / $errTask.Result が提供する
-        # (これらはストリームが EOF に達するまでブロックする)。
-        # WaitForExit() を残しているのは .NET 慣習との表面的な対称性のみ、
-        # `.Result` を削除すると出力切り捨てバグが発生するため touch しないこと
+        # 実際のフラッシュ保証は直後の $outTask.Result / $errTask.Result が EOF まで
+        # ブロックすることで提供される。`.Result` を削除すると出力切り捨てバグが
+        # 発生するため touch しないこと
         $proc.WaitForExit()
 
         # AggregateException (faulted task) は明示メッセージで rethrow し、何が
@@ -716,8 +721,13 @@ function Resolve-MsBuild {
             $vswhereStderr = $vswhereResult.StdErr.TrimEnd()
             if ($vswhereStderr -match '\S') { Write-Warn $vswhereStderr }
             Write-Info "PATH fallback に切替えて MSBuild を探します"
+            # 失敗時の StdOut は意図的に破棄: 部分出力 (権限エラーで途中まで吐いた
+            # 不完全 path 等) を後段の Test-Path 経路に流すと「PATH fallback に切替」
+            # 宣言と矛盾、`if ($vsInstall)` ブロックを silent skip するために明示クリア
+            $vsInstall = ''
+        } else {
+            $vsInstall = $vswhereResult.StdOut.Trim()
         }
-        $vsInstall = $vswhereResult.StdOut.Trim()
         if ($vsInstall) {
             $vsCands = @(
                 (Join-Path $vsInstall 'MSBuild\Current\Bin\MSBuild.exe'),

--- a/Release.ps1
+++ b/Release.ps1
@@ -132,14 +132,23 @@ $OutputEncoding           = [System.Text.UTF8Encoding]::new($false)
 #      # exit code チェック必須 ($output が空でも非ゼロ exit を見落とさないため)
 #      # 例: git status --porcelain (Assert-WorkingTreeClean)
 #
-#   3. pattern: PASS_THROUGH
-#      & native-cmd                  # stdout/stderr 両方 console 直書き、変数 capture なし
-#      # exit code チェック必須 (成否を判定する唯一の信号が exit code のみ)
-#      # 例: Invoke-ExternalProcess 経由 (Godot CLI export / msbuild / nuget restore)。
-#      #     大量の verbose 出力をリアルタイムで見せたい長時間処理向け。
-#      # 注: gh release create/delete は v1.0.7 まで PASS_THROUGH だったが、TTY 検出で
-#      #     進捗 OFF + 完了まで無音になる UX 問題のため v1.0.8 で
-#      #     Invoke-NativeWithCapture -ShowProgress に移行
+#   3. pattern: PASS_THROUGH — 2 実装あり、機能は同等だが内部メカニズムが違う
+#
+#      (a) 直 & 演算子版 (現状本 script 内で使用なし):
+#          & native-cmd               # stdout/stderr 両方 console 直書き、変数 capture なし
+#          # exit code チェック必須 (成否を判定する唯一の信号が exit code のみ)
+#          # 注: PS 5.1 + chcp 65001 で子プロセスが OutputEncoding を OEM に戻す
+#          #     既知バグの再ピン留め保護がない。短時間の単発呼び出し向け
+#
+#      (b) Invoke-ExternalProcess helper 経由 (推奨、現状の全 PASS_THROUGH 系):
+#          $exitCode = Invoke-ExternalProcess -FilePath $cmd -Arguments @(...)
+#          # 内部は [System.Diagnostics.Process]::Start + WaitForExit + Dispose
+#          # 引数 quoting + finally で [Console]::OutputEncoding を UTF-8 に再ピン留め
+#          # 大量 verbose 出力 + 長時間処理向け (Godot CLI export / msbuild / nuget restore)
+#
+#      注: gh release create/delete は v1.0.7 まで (a) PASS_THROUGH だったが、TTY 検出
+#          で進捗 OFF + 完了まで無音になる UX 問題のため v1.0.8 で
+#          Invoke-NativeWithCapture -ShowProgress に移行
 #
 # ANTI-PATTERNS (使用禁止) — いずれも踏み抜き履歴と deprecation 時点を 2 値で記録:
 #
@@ -316,8 +325,15 @@ function Invoke-NativeWithCapture {
         [string]$ProgressMessage = "実行中..."
     )
     # 引数 quoting は Invoke-ExternalProcess と同じ規則
+    # 既知制約: trailing backslash を持つパス引数 (例: "C:\path\") は壊れる。
+    #   `"C:\path\"` に変換すると CommandLineToArgvW の規則上 `\"` が閉じ引用符と
+    #   して機能せず、引数のパースが破損する (\ × N + " → \ × (N/2) + " デコード)。
+    #   現 call site (zip / 一時 notes / vswhere) はいずれも trailing backslash を
+    #   持たないため安全。新規 call site でディレクトリパスを渡す場合は要注意。
     # TODO (post v1.0.8): 共通化候補。MSVC argv 規則の特殊ケース (\ を引用直前) で
-    #                     2 箇所が silent に divergence する危険がある
+    #                     Invoke-ExternalProcess との 2 箇所が silent に divergence
+    #                     する危険、共通 helper 切り出し時に CommandLineToArgvW 規則
+    #                     準拠 (\ × N + " → \\ × N + \") に置換
     $quoted = $Arguments | ForEach-Object {
         if ($_ -match '\s|"') { '"' + ($_ -replace '"', '\"') + '"' } else { $_ }
     }
@@ -353,8 +369,8 @@ function Invoke-NativeWithCapture {
             # 500ms 間隔で経過秒数を `\r` 上書き表示 (CR で行頭戻り、新しい数字で上書き)
             # clear 幅は console window 幅から動的算出: ProgressMessage 長 / Japanese
             # 文字 cell 幅 / elapsed 桁数によらず消し残しが出ない。WindowWidth 取得
-            # 失敗時 (ISE 等の非 console host) は 120 で fallback (cmd.exe / Windows
-            # Terminal の典型幅 80 を超える safe margin)
+            # 失敗時 (ISE 等の非 console host) は 120 で fallback、WindowWidth が
+            # 0 以下を返す non-console host も同様に 120 で fallback
             $clearWidth = try { [Console]::WindowWidth - 1 } catch { 120 }
             if ($clearWidth -lt 30) { $clearWidth = 120 }
             $clearLine = ' ' * $clearWidth
@@ -366,9 +382,11 @@ function Invoke-NativeWithCapture {
             }
             # progress 行を完全に消して cursor を行頭へ (後続の出力が綺麗に流れる)
             Write-Host -NoNewline "`r$clearLine`r"
-        } else {
-            $proc.WaitForExit()
         }
+        # 両 path 対称化: HasExited で抜けた場合も .NET 慣習に従い WaitForExit() を
+        # 明示呼びしてパイプバッファ完全フラッシュを保証 (no-arg 版は無限待機だが
+        # HasExited=$true なので即 return、no-op)
+        $proc.WaitForExit()
 
         # AggregateException (faulted task) は明示メッセージで rethrow し、何が
         # 失敗したか caller に伝える
@@ -1027,7 +1045,14 @@ function Invoke-ExternalProcess {
 
     $proc = $null
     try {
-        $proc = [System.Diagnostics.Process]::Start($psi)
+        # Process.Start 失敗 (file not found / 権限不足) を Invoke-NativeWithCapture
+        # と同じ pattern で何を起動しようとしたかを含むメッセージで rethrow、
+        # 両 helper の例外メッセージ粒度を対称化
+        try {
+            $proc = [System.Diagnostics.Process]::Start($psi)
+        } catch {
+            throw "Invoke-ExternalProcess: '$FilePath' の起動に失敗しました: $($_.Exception.Message)"
+        }
         $proc.WaitForExit()
         $exitCode = $proc.ExitCode
     } finally {
@@ -1273,6 +1298,10 @@ function Invoke-GhRelease {
         if ($delResult.ExitCode -ne 0) {
             Fail "既存 release の削除に失敗しました:`n$($delResult.Combined.TrimEnd())"
         }
+        # gh release delete は成功時 stdout/stderr ともに無音なので、
+        # ShowProgress 行が消えた後の「無の状態」を避けるため明示的な完了表示
+        # (gh の将来 version で出力するようになった場合は追加で Write-Info)
+        Write-Ok "既存タグ v$Version を削除完了"
         $delOut = $delResult.StdOut.TrimEnd()
         if ($delOut -match '\S') { Write-Info $delOut }
     }

--- a/Release.ps1
+++ b/Release.ps1
@@ -295,7 +295,7 @@ function Get-ToolPath { param([string]$Name)
 }
 
 # ============================================================================
-# Native command の罠なし呼び出し (冒頭の `2>&1` trap セクション参照)
+# Native command の罠なし呼び出し (冒頭の「Native command 呼び出しの方針」セクション参照)
 # ============================================================================
 
 function Invoke-NativeWithCapture {
@@ -380,9 +380,11 @@ function Invoke-NativeWithCapture {
             # 進捗描画なしコマンド (gh release create 等) のための擬似 progress。
             # 500ms 間隔で経過秒数を `\r` 上書き表示 (CR で行頭戻り、新しい数字で上書き)
             # clear 幅は console window 幅から動的算出: ProgressMessage 長 / Japanese
-            # 文字 cell 幅 / elapsed 桁数によらず消し残しが出ない。WindowWidth 取得
-            # 失敗時 (ISE 等の非 console host) は 120 で fallback、WindowWidth が
-            # 0 以下を返す non-console host も同様に 120 で fallback
+            # 文字 cell 幅 / elapsed 桁数によらず消し残しが出ない。
+            # Fallback 条件 (どちらも 120 cells に置換):
+            #   - WindowWidth 取得が例外を投げる (ISE 等の非 console host)
+            #   - WindowWidth - 1 が 30 未満 (例: WindowWidth=0 を返す non-console host /
+            #     極端に狭い実コンソール)。30 は ProgressMessage 等が最低限収まる threshold
             $clearWidth = try { [Console]::WindowWidth - 1 } catch { 120 }
             if ($clearWidth -lt 30) { $clearWidth = 120 }
             $clearLine = ' ' * $clearWidth
@@ -415,12 +417,15 @@ function Invoke-NativeWithCapture {
             throw "Invoke-NativeWithCapture: '$FilePath' の出力読み取りに失敗しました: $($_.Exception.Message)"
         }
 
-        # Combined の separator 判定 (4 case 網羅):
-        #   stdout 空                          → $stderr そのまま (separator 不要、
-        #                                        Combined 先頭が stderr なので `^` regex は effective)
-        #   stdout 有 + 末尾 \n あり           → 単純連結 (改行はすでに含まれる)
-        #   stdout 有 + 末尾 \n なし + stderr → `\n` を明示挟む (^pattern 取りこぼし防止)
-        #   stderr 空                          → 上記いずれかで stdout のみ
+        # Combined の separator 判定 (stdout の末尾改行を軸に 2 分岐):
+        #   stdout 空 or 末尾 \n あり  → 単純連結 ($stdout + $stderr)
+        #     - stdout 空 + stderr 有  → $stderr そのまま (Combined 先頭 = stderr、^regex effective)
+        #     - 末尾 \n あり + stderr 有 → 改行はすでに含まれる
+        #     - stderr 空              → $stdout だけ (trailing \n 有無は stdout 次第)
+        #   stdout 末尾 \n なし        → `\n` を明示挟む ($stdout + "`n" + $stderr)
+        #     - stderr 有              → ^pattern 取りこぼし防止
+        #     - stderr 空              → Combined 末尾に trailing \n が付く (caller が
+        #                                TrimEnd() で吸収する想定、現 call site は全て適用済み)
         if ($stdout -and -not $stdout.EndsWith("`n")) {
             $combined = $stdout + "`n" + $stderr
         } else {
@@ -696,14 +701,22 @@ function Resolve-MsBuild {
     if (-not (Test-Path $vswhere)) { $vswhere = "$env:ProgramFiles\Microsoft Visual Studio\Installer\vswhere.exe" }
     if (Test-Path $vswhere) {
         # vswhere は検索 hit なし時に exit 0 + 空 stdout を返すが、実行環境破損
-        # (権限 / インストーラ破損 等) で stderr 出力する可能性もあるため
-        # Invoke-NativeWithCapture で罠なく capture。
+        # (権限 / インストーラ破損 等) で exit 非ゼロ + stderr 出力する可能性もある。
         # `-utf8` 必須: Invoke-NativeWithCapture は stdout を UTF-8 として decode する
         # ため、vswhere の default (system codepage) 出力だと non-UTF-8 locale で
         # non-ASCII install path (日本語 VS install path 等) が mojibake → 後段の
         # Test-Path が失敗 → MSBuild 検出失敗の path に落ちる
         $vswhereResult = Invoke-NativeWithCapture -FilePath $vswhere `
             -Arguments @('-latest', '-products', '*', '-requires', 'Microsoft.Component.MSBuild', '-property', 'installationPath', '-utf8')
+        # vswhere 失敗時は warn して PATH fallback path に落とす (Fail にはしない —
+        # PATH に msbuild があれば release は続行できるため)。コメント上で「stderr
+        # 出力する可能性」を挙げた以上、その出力をユーザーに届けないと silent pass
+        if ($vswhereResult.ExitCode -ne 0) {
+            Write-Warn "vswhere が exit $($vswhereResult.ExitCode) で終了 (権限 / VS Installer 破損等の可能性):"
+            $vswhereStderr = $vswhereResult.StdErr.TrimEnd()
+            if ($vswhereStderr -match '\S') { Write-Warn $vswhereStderr }
+            Write-Info "PATH fallback に切替えて MSBuild を探します"
+        }
         $vsInstall = $vswhereResult.StdOut.Trim()
         if ($vsInstall) {
             $vsCands = @(
@@ -1330,8 +1343,9 @@ function Invoke-GhRelease {
         }
         # gh release delete は成功時 stdout/stderr ともに無音なので、
         # ShowProgress 行が消えた後の「無の状態」を避けるため明示的な完了表示
-        # (gh の将来 version で出力するようになった場合は追加で Write-Info)
         Write-Ok "既存タグ v$Version を削除完了"
+        # 下記は future-proofing (現行 gh では成功時 stdout 空のため発火しない、
+        # 将来 version が完了メッセージ等を出力するようになった場合に表示)
         $delOut = $delResult.StdOut.TrimEnd()
         if ($delOut -match '\S') { Write-Info $delOut }
     }

--- a/Release.ps1
+++ b/Release.ps1
@@ -93,6 +93,18 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 # ============================================================================
+# Console output encoding を UTF-8 (no BOM) にピン留め
+# ============================================================================
+# PS 5.1 + chcp 65001 環境では、子プロセス (特に msbuild) がコンソールハンドル
+# を継承して走った後、後続の Write-Host で日本語が doubled rendering される
+# 既知バグがある (症状例: `完了` → `完完了了`、ASCII は影響なし)。
+# `[Console]::OutputEncoding` を UTF-8 (no BOM) で明示ピン留めしておく + 各
+# Invoke-ExternalProcess 呼び出し後に再ピン留めすることで発火を防ぐ。
+# `$OutputEncoding` は PS pipeline → native command への送信時の encoding。
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding           = [System.Text.UTF8Encoding]::new($false)
+
+# ============================================================================
 # Native command 呼び出しの方針 (v1.0.8 で再整理)
 # ============================================================================
 # 経緯: PS 5.1 + $ErrorActionPreference='Stop' 下では、`&` 演算子 + native
@@ -120,7 +132,11 @@ $ErrorActionPreference = 'Stop'
 #   3. pattern: PASS_THROUGH
 #      & native-cmd                  # stdout/stderr 両方 console 直書き、変数 capture なし
 #      # exit code チェック必須 (成否を判定する唯一の信号が exit code のみ)
-#      # 例: gh release create / delete (出力をユーザーに見せたい時)
+#      # 例: Invoke-ExternalProcess 経由 (Godot CLI export / msbuild / nuget restore)。
+#      #     大量の verbose 出力をリアルタイムで見せたい長時間処理向け。
+#      # 注: gh release create/delete は v1.0.7 まで PASS_THROUGH だったが、TTY 検出で
+#      #     進捗 OFF + 完了まで無音になる UX 問題のため v1.0.8 で
+#      #     Invoke-NativeWithCapture -ShowProgress に移行
 #
 # ANTI-PATTERNS (使用禁止) — いずれも踏み抜き履歴と deprecation 時点を 2 値で記録:
 #
@@ -284,7 +300,11 @@ function Invoke-NativeWithCapture {
     #>
     param(
         [Parameter(Mandatory)][string]$FilePath,
-        [string[]]$Arguments = @()
+        [string[]]$Arguments = @(),
+        # gh release create のように TTY 検出で進捗描画を OFF にするコマンド向け。
+        # ハングしてないことを示す経過秒数を `\r` 上書きで表示。
+        [switch]$ShowProgress,
+        [string]$ProgressMessage = "実行中..."
     )
     # 引数 quoting は Invoke-ExternalProcess と同じ規則
     # TODO (post v1.0.8): 共通化候補。MSVC argv 規則の特殊ケース (\ を引用直前) で
@@ -318,7 +338,22 @@ function Invoke-NativeWithCapture {
         # → TODO (post v1.0.8): -TimeoutSeconds 引数 + WaitForExit($ms) への移行
         $outTask = $proc.StandardOutput.ReadToEndAsync()
         $errTask = $proc.StandardError.ReadToEndAsync()
-        $proc.WaitForExit()
+
+        if ($ShowProgress) {
+            # 進捗描画なしコマンド (gh release create 等) のための擬似 progress。
+            # 500ms 間隔で経過秒数を `\r` 上書き表示 (CR で行頭戻り、新しい数字で上書き)
+            $start = Get-Date
+            while (-not $proc.HasExited) {
+                $elapsed = [int]((Get-Date) - $start).TotalSeconds
+                # 末尾 spaces は前回より短くなった場合の残骸を消すための padding
+                Write-Host -NoNewline "`r    $ProgressMessage ${elapsed}s 経過          "
+                Start-Sleep -Milliseconds 500
+            }
+            # progress 行を完全に消して cursor を行頭へ (後続の出力が綺麗に流れる)
+            Write-Host -NoNewline "`r$(' ' * 70)`r"
+        } else {
+            $proc.WaitForExit()
+        }
 
         # AggregateException (faulted task) は明示メッセージで rethrow し、何が
         # 失敗したか caller に伝える
@@ -971,9 +1006,19 @@ function Invoke-ExternalProcess {
     $psi.RedirectStandardOutput = $false  # コンソールに直接出力
     $psi.RedirectStandardError = $false
 
-    $proc = [System.Diagnostics.Process]::Start($psi)
-    $proc.WaitForExit()
-    return $proc.ExitCode
+    $proc = $null
+    try {
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.WaitForExit()
+        $exitCode = $proc.ExitCode
+    } finally {
+        if ($null -ne $proc) { $proc.Dispose() }
+        # msbuild など子プロセスが OutputEncoding を OEM に戻して去ると、後続の
+        # Write-Host で日本語が doubled rendering される PS 5.1 バグの予防的再ピン留め
+        # (script 冒頭の pin と二重防御)
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    }
+    return $exitCode
 }
 
 function Build-Launcher {
@@ -1202,10 +1247,13 @@ function Invoke-GhRelease {
 
     if ($script:DeleteExistingRelease) {
         Write-Info "既存タグ v$Version を削除"
-        # pattern: PASS_THROUGH (冒頭集約コメント参照)
-        # 実 release 操作中の gh 出力はユーザーに見せる方針
-        & gh release delete "v$Version" --yes --cleanup-tag
-        if ($LASTEXITCODE -ne 0) { Fail "既存 release の削除に失敗しました" }
+        $delResult = Invoke-NativeWithCapture -FilePath 'gh' `
+            -Arguments @('release', 'delete', "v$Version", '--yes', '--cleanup-tag') `
+            -ShowProgress -ProgressMessage "既存 release を削除中..."
+        if ($delResult.ExitCode -ne 0) {
+            Fail "既存 release の削除に失敗しました:`n$($delResult.Combined.TrimEnd())"
+        }
+        if ($delResult.StdOut.Trim()) { Write-Info $delResult.StdOut.TrimEnd() }
     }
 
     # CHANGELOG から抽出した Bundle セクション本文を --notes に渡す
@@ -1213,10 +1261,15 @@ function Invoke-GhRelease {
     $tmpNotes = New-TemporaryFile
     try {
         [System.IO.File]::WriteAllText($tmpNotes.FullName, $script:ReleaseNotesText, [System.Text.UTF8Encoding]::new($false))
-        # pattern: PASS_THROUGH (冒頭集約コメント参照)
-        # upload 進捗等を見せたいので redirect しない
-        & gh release create "v$Version" $ZipPath --notes-file $tmpNotes.FullName --title "v$Version"
-        if ($LASTEXITCODE -ne 0) { Fail "gh release create に失敗しました" }
+        $zipSizeMb = [int]((Get-Item $ZipPath).Length / 1MB)
+        $uploadResult = Invoke-NativeWithCapture -FilePath 'gh' `
+            -Arguments @('release', 'create', "v$Version", $ZipPath, '--notes-file', $tmpNotes.FullName, '--title', "v$Version") `
+            -ShowProgress -ProgressMessage "アップロード中 (zip $zipSizeMb MB)..."
+        if ($uploadResult.ExitCode -ne 0) {
+            Fail "gh release create に失敗しました:`n$($uploadResult.Combined.TrimEnd())"
+        }
+        # 成功時、gh は release URL を stdout に dump するのでユーザーに表示
+        if ($uploadResult.StdOut.Trim()) { Write-Info $uploadResult.StdOut.TrimEnd() }
     } finally {
         Remove-Item $tmpNotes.FullName -Force -ErrorAction SilentlyContinue
     }

--- a/Release.ps1
+++ b/Release.ps1
@@ -320,9 +320,13 @@ function Invoke-NativeWithCapture {
           ExitCode - プロセスの終了コード (int)
           Combined - StdOut + "`n" + StdErr 連結 (検索用、stdout 末尾の改行有無で
                      joining 境界がぶれないよう明示 separator)
-        注 1: 子プロセス側が UTF-8 で書く前提。`gh` は UTF-8 だが、`vswhere` は ASCII
-        中心、msbuild / nuget は OEM 系 codepage を出す可能性あり (本 helper は現状
-        gh / vswhere のみで使用)。
+        注 1: 子プロセス側が UTF-8 で書く前提。`gh` はデフォルトで UTF-8。
+        `vswhere` はデフォルト system codepage 出力なので、本 helper 経由の
+        call site では `-utf8` フラグを必ず付与して UTF-8 出力を強制する
+        (Resolve-MsBuild 内、日本語 VS install path 等の非 ASCII path も正しく
+        decode)。msbuild / nuget は OEM 系 codepage を出す可能性があるため
+        本 helper は使わず、Invoke-ExternalProcess (直 console 出力 + encoding
+        再ピン留め) 経由で扱う。
         注 2: 本関数は System.Diagnostics.Process 直叩きのため、PS 自動変数の
         `$LASTEXITCODE` は **更新されない**。caller は必ず返り値の `.ExitCode` を
         参照すること。helper 呼び出し直後に `if ($LASTEXITCODE -ne 0)` と書くと、
@@ -376,7 +380,12 @@ function Invoke-NativeWithCapture {
         $outTask = $proc.StandardOutput.ReadToEndAsync()
         $errTask = $proc.StandardError.ReadToEndAsync()
 
-        if ($ShowProgress) {
+        # 非 TTY (CI / log file redirect 等) では `\r` が行リセットとして機能せず、
+        # progress 更新ごとに改行付きで log に展開されてノイズになる。
+        # IsOutputRedirected で検出して live progress を抑止 (取得自体が例外を投げる
+        # 非 console host も同様に redirected 扱いで skip = 安全側)
+        $isRedirected = try { [Console]::IsOutputRedirected } catch { $true }
+        if ($ShowProgress -and -not $isRedirected) {
             # 進捗描画なしコマンド (gh release create 等) のための擬似 progress。
             # 500ms 間隔で経過秒数を `\r` 上書き表示 (CR で行頭戻り、新しい数字で上書き)
             # clear 幅は console window 幅から動的算出。現在の ProgressMessage 長
@@ -1009,8 +1018,7 @@ function Write-FileUtf8NoBom {
     param([string]$Path, [string]$Content)
     # Godot ConfigFile / project.godot は BOM を識別子として解釈してパースエラーを起こすため
     # UTF-8 BOM なしで書き出す
-    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
-    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+    [System.IO.File]::WriteAllText($Path, $Content, $script:Utf8NoBomEncoding)
 }
 
 function Set-ManifestVersions {
@@ -1108,7 +1116,9 @@ function Invoke-ExternalProcess {
         # pin と二重防御)。
         # 非 console host (CI / headless 等) で console API が IOException を投げる
         # ケースを try/catch で吸収 — finally は外部ツール呼び出しの度に走るため
-        # ガードなしだと release flow が abort する
+        # ガードなしだと release flow が abort する。
+        # 注: $OutputEncoding (PS variable、pipeline → native command 送信側) は
+        # 子プロセスから変更不可なので再ピン留め不要、script 冒頭の代入が継続有効
         try {
             [Console]::OutputEncoding = $script:Utf8NoBomEncoding
         } catch {
@@ -1364,7 +1374,7 @@ function Invoke-GhRelease {
     # 一時ファイル経由にする (CLI 引数の改行 / 引用符 escape を避けるため)
     $tmpNotes = New-TemporaryFile
     try {
-        [System.IO.File]::WriteAllText($tmpNotes.FullName, $script:ReleaseNotesText, [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText($tmpNotes.FullName, $script:ReleaseNotesText, $script:Utf8NoBomEncoding)
         # zip サイズは MB / KB を自動切替で表示 (小さいファイル時に `0 MB` 表示で
         # 破損誤解を避ける、Phase 2 以降の Updater 単体 zip 等で発火する想定)
         $zipBytes = (Get-Item $ZipPath).Length

--- a/Release.ps1
+++ b/Release.ps1
@@ -122,24 +122,32 @@ $ErrorActionPreference = 'Stop'
 #      # exit code チェック必須 (成否を判定する唯一の信号が exit code のみ)
 #      # 例: gh release create / delete (出力をユーザーに見せたい時)
 #
-#   4. pattern: CAPTURE_STDOUT (success exit が確証できるコマンド限定)
-#      $output = & native-cmd 2>$null
-#      # 失敗 path で stderr を出すコマンドでは Stop trap、Invoke-NativeWithCapture を使う
-#      # 例: vswhere -property installationPath (検索 hit なしは exit 0)
-#
-# ANTI-PATTERNS (使用禁止):
+# ANTI-PATTERNS (使用禁止) — いずれも踏み抜き履歴と deprecation 時点を 2 値で記録:
 #
 #   X. STOP_TRAP — & cmd 2>&1 / $var = & cmd 2>&1
 #      stderr が ErrorRecord として success stream に流れ Stop trap 発火。
+#      初回 deprecate from v1.0.0 (script 新設時点)。
 #      回避: Invoke-NativeWithCapture へ移行。
 #
-#   X. SUPPRESS_BOTH — & cmd 2>$null | Out-Null (v1.0.6 で踏み抜き廃止)
-#   X. CAPTURE_DIAGNOSTIC — $out = & cmd 2>&1 | Out-String (v1.0.8 で廃止)
-#      どちらも「失敗 path で stderr を出すコマンド」で同じ trap を踏む。
-#      Invoke-NativeWithCapture へ移行。
+#   X. SUPPRESS_BOTH — & cmd 2>$null | Out-Null
+#      踏み抜き: v1.0.6 (本番 release で gh release view が trap 発火)
+#      deprecation: v1.0.8 (anti-pattern として正式格下げ)
+#      「2>$null で stderr を捨てれば trap 防げる」前提が誤りだった
 #
-#   X. TRY_CATCH_NATIVE (v1.0.7 のみ存在、v1.0.8 で廃止)
-#      Invoke-NativeWithCapture が同じ目的を関数化したため不要。
+#   X. CAPTURE_DIAGNOSTIC — $out = & cmd 2>&1 | Out-String
+#      踏み抜き: v1.0.7 (gh release view の "release not found" stderr で trap)
+#      deprecation: v1.0.8 (anti-pattern として正式格下げ)
+#      「Out-String を経由すれば Stop の判定対象外」前提が誤りだった
+#
+#   X. CAPTURE_STDOUT — $out = & cmd 2>$null
+#      踏み抜き履歴なし、deprecation: v1.0.8
+#      SUPPRESS_BOTH と同じ構造 (2>$null) を持つため同じ trap 形状。
+#      本 script では vswhere で使用していたが v1.0.8 で helper に移行、
+#      残存 call site ゼロのため anti-pattern 化
+#
+#   X. TRY_CATCH_NATIVE — try { & cmd 2>&1 | Out-String } catch { ... }
+#      導入: v1.0.7 (CAPTURE_DIAGNOSTIC の trap 回避策として)
+#      deprecation: v1.0.8 (Invoke-NativeWithCapture が同目的を関数化したため不要)
 #
 # PS 7.3+ 移行時の注意 (現状未対応):
 #   PS 7.3 以降は $PSNativeCommandUseErrorActionPreference (default $true) が
@@ -265,16 +273,22 @@ function Invoke-NativeWithCapture {
         チェックは本関数を使うこと。
     .OUTPUTS
         PSCustomObject:
-          StdOut   - 標準出力 (string、UTF-8 でデコード)
-          StdErr   - 標準エラー (string、UTF-8 でデコード)
+          StdOut   - 標準出力 (string、UTF-8 として decode)
+          StdErr   - 標準エラー (string、UTF-8 として decode)
           ExitCode - プロセスの終了コード (int)
-          Combined - StdOut + StdErr 連結 (検索用)
+          Combined - StdOut + "`n" + StdErr 連結 (検索用、stdout 末尾の改行有無で
+                     joining 境界がぶれないよう明示 separator)
+        注: 子プロセス側が UTF-8 で書く前提。`gh` は UTF-8 だが、`vswhere` は ASCII
+        中心、msbuild / nuget は OEM 系 codepage を出す可能性あり (本 helper は現状
+        gh / vswhere のみで使用)。
     #>
     param(
         [Parameter(Mandatory)][string]$FilePath,
         [string[]]$Arguments = @()
     )
-    # 引数 quoting は Invoke-ExternalProcess と同じ規則 (DRY 化候補だが現状は単純なので duplicate)
+    # 引数 quoting は Invoke-ExternalProcess と同じ規則
+    # TODO (post v1.0.8): 共通化候補。MSVC argv 規則の特殊ケース (\ を引用直前) で
+    #                     2 箇所が silent に divergence する危険がある
     $quoted = $Arguments | ForEach-Object {
         if ($_ -match '\s|"') { '"' + ($_ -replace '"', '\"') + '"' } else { $_ }
     }
@@ -287,19 +301,53 @@ function Invoke-NativeWithCapture {
     $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
     $psi.StandardErrorEncoding  = [System.Text.Encoding]::UTF8
 
-    $proc = [System.Diagnostics.Process]::Start($psi)
-    # 両 stream を async で読みデッドロック回避 (片方のバッファが満杯になると child が block する)
-    $outTask = $proc.StandardOutput.ReadToEndAsync()
-    $errTask = $proc.StandardError.ReadToEndAsync()
-    $proc.WaitForExit()
-    $stdout = $outTask.Result
-    $stderr = $errTask.Result
+    $proc = $null
+    try {
+        # Process.Start 自体が Win32Exception を出す path (file not found / 権限不足)。
+        # caller は Get-ToolPath で事前 check しているが、helper 単体としても
+        # 例外メッセージに何を実行しようとしたか含める
+        try {
+            $proc = [System.Diagnostics.Process]::Start($psi)
+        } catch {
+            throw "Invoke-NativeWithCapture: '$FilePath' の起動に失敗しました: $($_.Exception.Message)"
+        }
 
-    return [PSCustomObject]@{
-        StdOut   = $stdout
-        StdErr   = $stderr
-        ExitCode = $proc.ExitCode
-        Combined = $stdout + $stderr
+        # 両 stream を async で読みデッドロック回避 (片方のバッファが満杯になると
+        # child が block する)。WaitForExit() は timeout なし → network hang する
+        # コマンド (gh API 呼び出し) では preflight が無限待機する path が残る
+        # → TODO (post v1.0.8): -TimeoutSeconds 引数 + WaitForExit($ms) への移行
+        $outTask = $proc.StandardOutput.ReadToEndAsync()
+        $errTask = $proc.StandardError.ReadToEndAsync()
+        $proc.WaitForExit()
+
+        # AggregateException (faulted task) は明示メッセージで rethrow し、何が
+        # 失敗したか caller に伝える
+        try {
+            $stdout = $outTask.Result
+            $stderr = $errTask.Result
+        } catch {
+            throw "Invoke-NativeWithCapture: '$FilePath' の出力読み取りに失敗しました: $($_.Exception.Message)"
+        }
+
+        # Combined の separator: stdout 末尾改行の有無に関わらず確実に行境界を
+        # 入れて、^pattern 系 regex が join 境界で取りこぼさないようにする
+        if ($stdout -and -not $stdout.EndsWith("`n")) {
+            $combined = $stdout + "`n" + $stderr
+        } else {
+            $combined = $stdout + $stderr
+        }
+
+        return [PSCustomObject]@{
+            StdOut   = $stdout
+            StdErr   = $stderr
+            ExitCode = $proc.ExitCode
+            Combined = $combined
+        }
+    } finally {
+        # Process オブジェクトは Dispose 必須 (handle leak 防止)
+        if ($null -ne $proc) {
+            $proc.Dispose()
+        }
     }
 }
 
@@ -732,8 +780,10 @@ function Assert-Preflight {
         # 予兆 / token expiry 近接通知 等)。Fail はしないが、リリース担当に気付かせる。
         # 検出は `^warning:` (gh 公式の warning prefix) のみに絞る (token expiry 特殊形式
         # まで網羅する regex は false positive 多 + gh 出力フォーマット変更に脆弱)。
-        if ($authResult.Combined -match '(?im)^warning:') {
-            Write-Warn "gh auth status からの警告 (release 実行自体は継続):`n$($authResult.Combined.TrimEnd())"
+        # warning は実態として stderr 出力なので StdErr を直接見る (Combined だと
+        # stdout 末尾改行有無で行境界がブレうる)
+        if ($authResult.StdErr -match '(?im)^warning:') {
+            Write-Warn "gh auth status からの警告 (release 実行自体は継続):`n$($authResult.StdErr.TrimEnd())"
         }
     }
 

--- a/Release.ps1
+++ b/Release.ps1
@@ -104,8 +104,20 @@ $ErrorActionPreference = 'Stop'
 # `[Console]::OutputEncoding` を UTF-8 (no BOM) で明示ピン留めしておく + 各
 # Invoke-ExternalProcess 呼び出し後に再ピン留めすることで発火を防ぐ。
 # `$OutputEncoding` は PS pipeline → native command への送信時の encoding。
-[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
-$OutputEncoding           = [System.Text.UTF8Encoding]::new($false)
+#
+# 非 console host ガード: CI / headless / redirected 実行コンテキストでは
+# `[Console]::OutputEncoding` setter が IOException を投げ、$ErrorActionPreference='Stop'
+# 環境では release 開始前に script が hard abort する。try/catch で吸収。
+# (script-level の $script:Utf8NoBomEncoding を一意ソースとして共有、
+#  Invoke-ExternalProcess の finally でも同じインスタンスを再代入)
+$script:Utf8NoBomEncoding = [System.Text.UTF8Encoding]::new($false)
+try {
+    [Console]::OutputEncoding = $script:Utf8NoBomEncoding
+} catch {
+    # non-console host では console API は使えないが、$OutputEncoding (PS 変数) は
+    # 引き続き設定可能、native command pipeline 送信側は UTF-8 のまま維持される
+}
+$OutputEncoding = $script:Utf8NoBomEncoding
 
 # ============================================================================
 # Native command 呼び出しの方針 (v1.0.8 で再整理)
@@ -383,9 +395,15 @@ function Invoke-NativeWithCapture {
             # progress 行を完全に消して cursor を行頭へ (後続の出力が綺麗に流れる)
             Write-Host -NoNewline "`r$clearLine`r"
         }
-        # 両 path 対称化: HasExited で抜けた場合も .NET 慣習に従い WaitForExit() を
-        # 明示呼びしてパイプバッファ完全フラッシュを保証 (no-arg 版は無限待機だが
-        # HasExited=$true なので即 return、no-op)
+        # 両 path 合流点。ShowProgress 経路は HasExited で抜けて WaitForExit() は
+        # no-op、非 ShowProgress 経路はここで完了待機。
+        # 注: WaitForExit() (no-arg) のパイプバッファフラッシュ保証は
+        # BeginOutputReadLine / BeginErrorReadLine (event-based 非同期) に対する
+        # ものであり、本実装が使う ReadToEndAsync (Task-based) には適用されない。
+        # 実際のフラッシュ保証は直後の $outTask.Result / $errTask.Result が提供する
+        # (これらはストリームが EOF に達するまでブロックする)。
+        # WaitForExit() を残しているのは .NET 慣習との表面的な対称性のみ、
+        # `.Result` を削除すると出力切り捨てバグが発生するため touch しないこと
         $proc.WaitForExit()
 
         # AggregateException (faulted task) は明示メッセージで rethrow し、何が
@@ -679,9 +697,13 @@ function Resolve-MsBuild {
     if (Test-Path $vswhere) {
         # vswhere は検索 hit なし時に exit 0 + 空 stdout を返すが、実行環境破損
         # (権限 / インストーラ破損 等) で stderr 出力する可能性もあるため
-        # Invoke-NativeWithCapture で罠なく capture
+        # Invoke-NativeWithCapture で罠なく capture。
+        # `-utf8` 必須: Invoke-NativeWithCapture は stdout を UTF-8 として decode する
+        # ため、vswhere の default (system codepage) 出力だと non-UTF-8 locale で
+        # non-ASCII install path (日本語 VS install path 等) が mojibake → 後段の
+        # Test-Path が失敗 → MSBuild 検出失敗の path に落ちる
         $vswhereResult = Invoke-NativeWithCapture -FilePath $vswhere `
-            -Arguments @('-latest', '-products', '*', '-requires', 'Microsoft.Component.MSBuild', '-property', 'installationPath')
+            -Arguments @('-latest', '-products', '*', '-requires', 'Microsoft.Component.MSBuild', '-property', 'installationPath', '-utf8')
         $vsInstall = $vswhereResult.StdOut.Trim()
         if ($vsInstall) {
             $vsCands = @(
@@ -1060,8 +1082,16 @@ function Invoke-ExternalProcess {
         # Invoke-ExternalProcess 経由の子プロセス (Godot CLI / msbuild / nuget) が
         # コンソール encoding を OEM 系に戻して去ると、後続 Write-Host で日本語が
         # doubled rendering される PS 5.1 バグの予防的再ピン留め (script 冒頭の
-        # pin と二重防御)
-        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        # pin と二重防御)。
+        # 非 console host (CI / headless 等) で console API が IOException を投げる
+        # ケースを try/catch で吸収 — finally は外部ツール呼び出しの度に走るため
+        # ガードなしだと release flow が abort する
+        try {
+            [Console]::OutputEncoding = $script:Utf8NoBomEncoding
+        } catch {
+            # non-console host では再ピン留め不要 (そもそも doubled rendering は
+            # 対話端末でしか起きないため、CI 等では skip OK)
+        }
     }
     return $exitCode
 }
@@ -1311,10 +1341,19 @@ function Invoke-GhRelease {
     $tmpNotes = New-TemporaryFile
     try {
         [System.IO.File]::WriteAllText($tmpNotes.FullName, $script:ReleaseNotesText, [System.Text.UTF8Encoding]::new($false))
-        $zipSizeMb = [int]((Get-Item $ZipPath).Length / 1MB)
+        # zip サイズは MB / KB を自動切替で表示 (小さいファイル時に `0 MB` 表示で
+        # 破損誤解を避ける、Phase 2 以降の Updater 単体 zip 等で発火する想定)
+        $zipBytes = (Get-Item $ZipPath).Length
+        $zipSize  = if ($zipBytes -ge 1MB) {
+            "$([math]::Round($zipBytes / 1MB, 1)) MB"
+        } elseif ($zipBytes -ge 1KB) {
+            "$([math]::Round($zipBytes / 1KB, 1)) KB"
+        } else {
+            "$zipBytes B"
+        }
         $uploadResult = Invoke-NativeWithCapture -FilePath 'gh' `
             -Arguments @('release', 'create', "v$Version", $ZipPath, '--notes-file', $tmpNotes.FullName, '--title', "v$Version") `
-            -ShowProgress -ProgressMessage "アップロード中 (zip $zipSizeMb MB)..."
+            -ShowProgress -ProgressMessage "アップロード中 (zip $zipSize)..."
         if ($uploadResult.ExitCode -ne 0) {
             Fail "gh release create に失敗しました:`n$($uploadResult.Combined.TrimEnd())"
         }


### PR DESCRIPTION
## 背景

v0.1.0 publish 直後の改善ブランチ。Release Tooling v1.0.7 シニアレビュー
round 11 / 12 で挙がった構造的課題と、v0.1.0 本番 release で観察された UX
問題を解消する。1 PR 1 bump 原則に従い全て `Release Tooling v1.0.8` 1 entry
に統合 (Wave 1 + Wave 2 + 後続シニアレビュー round 12〜17)。

## サマリ
- **Native command 呼び出しを `Invoke-NativeWithCapture` (Process 直叩き) helper に一本化** (Wave 1)
  - PS 5.1 + Stop 環境の NativeCommandError trap を構造的に回避
  - 3 call site (`gh release view` / `gh auth status` / `vswhere`) を移行
  - catalog 6 → 4 個 (+ helper) に整理、`SUPPRESS_BOTH` / `CAPTURE_DIAGNOSTIC` / `TRY_CATCH_NATIVE` を anti-pattern に格下げ
- **mojibake 修正** (Wave 2)
  - PS 5.1 + chcp 65001 で msbuild 等の子プロセス後に日本語が doubled rendering されるバグ (`完了` → `完完了了`)
  - `$script:Utf8NoBomEncoding` を一意ソースとして script 冒頭 + `Invoke-ExternalProcess` finally で二重ピン留め
  - non-console host (CI / headless) での IOException を try/catch でガード (round 14 Codex P2)
- **upload progress 追加** (Wave 2)
  - `gh release create` は TTY 検出で進捗 OFF → upload 中無音だった
  - `Invoke-NativeWithCapture` に `-ShowProgress` / `-ProgressMessage` 追加、500ms 間隔で `\r` 上書き表示
  - 完了後は line clear → release URL を `Write-Info` で表示
  - zip サイズは MB / KB 自動切替で表示 (round 14 L1)
  - 非 TTY (CI / log redirect) では `\r` ノイズ防止のため live progress 自動 skip (round 17 #5)
- **vswhere の堅牢化**:
  - `-utf8` フラグ追加で非 UTF-8 locale 対応 (round 14 Codex P2)
  - ExitCode 確認 + StdErr 診断表示 + PATH fallback (round 15 M3)
  - 失敗時の `$vsInstall` 明示クリアで「PATH fallback 宣言」と分岐の意図一致 (round 16 #1)

## Commits (9)
\`\`\`
e0e8af8 refactor(release): PR #148 round 17 シニアレビュー対応 — Medium 2 + Low 2
4c90f7b refactor(release): PR #148 round 16 シニアレビュー対応 — #1-#4
4e9f2ab refactor(release): PR #148 round 15 シニアレビュー対応 — M1-M3 + L1-L3
ef33ba5 fix(release): PR #148 round 14 + Codex bot P2 対応 — IOException ガード等
76dcde6 refactor(release): PR #148 シニアレビュー対応 — M1-M3 + L2-L4
4fa44fc refactor(release): Wave 2 シニアレビュー対応 — M1-M3 + L1-L4
350a8d0 feat(release): Wave 2 — mojibake fix + upload progress
ce818de refactor(release): Wave 1 シニアレビュー対応 — helper resource 管理 + catalog 整合
3765966 refactor(release): Wave 1 — Invoke-NativeWithCapture helper に一本化 (closes #145)
\`\`\`

## 検証

- isolated test で helper の両 path (exists / not-found) を verify
- DRY-RUN 全工程通過、ExpectedFiles 8/8、mojibake regex grep で 0 hit、MSBuild detected: True (vswhere -utf8 でも正常)、vswhere warn 発火なし (healthy 環境)
- 実機 `.\Release.bat` で `gh 認証 OK` + `v0.1.0 既存検出 → Fail` 経路確認
- Write-FileUtf8NoBom (Set-ManifestVersions の project.godot / export_presets.cfg 書き込み) も `$script:Utf8NoBomEncoding` 経由で正常動作確認

upload progress 本体の動作確認は v0.1.0 が既に publish 済みで重複が打てないため、次回 Bundle bump 時 (Phase 2 完成等) の release で実機確認予定。

## 関連

Closes #145 (CAPTURE_DIAGNOSTIC ラベル拡張 → パターン自体を anti-pattern に格下げで議論不要に)

Known follow-up (CHANGELOG に明記済み):
- \`Invoke-NativeWithCapture\` の引数 quoting helper 共通化 + \`-TimeoutSeconds\` 引数追加 + ShowProgress Task リーク対処 (CancellationToken)
- #142 (catalog vs per-site) — Wave 1 で大部分解消、残り議論
- #143 (Release.bat docstring 分離)
- #144 (Read-* 命名規約 sweep)
- #146 (\$Context → \$PostSync switch)
- CHANGELOG 日付ポリシー (JST 統一 / UTC 統一 / PR merge 日) の策定

## Test plan

- [x] DRY-RUN: 全 ==> section 通過、ExpectedFiles 8/8
- [x] mojibake: 全出力で `完完|了了|成成|果果|物物|ココ|ピピ|ーー` 0 hit
- [x] vswhere -utf8: DRY-RUN で MSBuild detected: True (regression なし)
- [x] vswhere ExitCode check: healthy 環境で warn 発火なし、失敗時 \$vsInstall 明示クリア
- [x] UTF8Encoding 一意ソース: `$script:Utf8NoBomEncoding` 1 箇所のみで instance 化、3 utilize 点 (Console pin / WriteAllText / Write-FileUtf8NoBom) で参照
- [x] helper exists path: \`gh release view v0.1.0\` で ExitCode=0 + StdOut が JSON
- [x] helper not-found path: \`gh release view v9.9.9\` で ExitCode=1 + StdErr に "release not found"
- [x] preflight 実機: \`gh 認証 OK\` + \`v0.1.0 既存検出 Fail\` で構造変更後も同等動作確認
- [ ] upload progress: 次回 release で実機確認 (v0.1.0 重複不可のため deferred)
- [ ] 非 TTY progress skip: CI / log redirect での実機確認 (Phase 2 以降の CI 化時)