### PR TITLE
chore(release): Bundle v0.6.0 entry + Manager v0.13.1 (アップデート再起動予告 dialog 追加)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1678,33 +1678,42 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ### [Manager v0.13.1] - 2026-05-19
 
-#### Added (#170 followup — アップデート時の再起動予告 dialog + Updater console 出現の予告)
+#### Added (#170 followup — アップデート時の再起動予告 dialog)
 
 「今すぐアップデート」flow の ProcessingDialog (= zip DL + staging + Updater spawn) 完了直後、
-`Application.Exit` 呼出前に新 `MessageBox` を追加して **Manager 再起動 + Updater console 出現を予告**:
+`Application.Exit` 呼出前に新 `MessageBox` を追加して **Manager 再起動を予告**:
 
 > ダウンロードと展開が完了しました。
 > これから Manager を一旦終了して、新しいバージョンで自動的に再起動します。
 > 再起動には数秒〜数十秒かかる場合があります (= 共有フォルダ越しの場合は長くなります)。
 >
-> 【ご注意】処理中、黒い画面 (コマンドプロンプトのようなウィンドウ) が一時的に表示されます。
-> これはアップデート用のツール (Updater) の進捗表示で、自動で閉じます。
-> 閉じないでそのままお待ちください。
->
 > 新しい Manager が起動したら、「✓ アップデート完了」のお知らせが表示されます。
 
 旧実装 (= v0.13.0 以前) は ProcessingDialog 閉じた直後に Manager が silent に消える挙動で、
-user 視点で「あれ?何が起きた?」になりやすかった (= 突然 Manager が消えてから Updater 経由で
-数秒〜数十秒待たされる + 黒い console window が突然出る)。Updater.exe は
-`UpdaterClient.cs:90` で **CreateNoWindow=false** に設定 (= 進捗 / debug log が見える方が user
-安心という設計判断、Companions/Updater 経由)、本 dialog で「黒い画面が出る = 正常」を予告して
-user の不安 (= ウイルス疑い / 強制終了したくなる衝動) を抑える。
+user 視点で「あれ?何が起きた?」になりやすかった。本 dialog で「これから一旦終了 → 自動再起動」を
+明示してから user の OK で確定終了する flow に変更、再起動完了後の sentinel 経由
+「✓ アップデート完了」 dialog (= Bundle v0.4.0 から存在) と組み合わせて開始 → 終了 → 完了の
+**3 段階通知** を user に提供。
 
-本 dialog で「これから一旦終了 → 自動再起動 + 黒い画面が一時表示」を明示してから user の OK で
-確定終了する flow に変更、再起動完了後の sentinel 経由「✓ アップデート完了」 dialog
-(= Bundle v0.4.0 から存在) と組み合わせて開始 → 終了 → 完了の **3 段階通知** を user に提供。
+#### Changed (#170 followup — Updater spawn 時の空 console window を hidden 化)
 
-bump 判断: UI 改善 (= 既存 flow に dialog 1 つ追加)、behavior の core path には影響なし、
+`UpdaterClient.cs:90` の `CreateNoWindow` を `false` → `true` に変更。
+
+旧設計は「Updater console を visible にして user 安心感 + 進捗 visible」だったが、実態は
+`RedirectStandardOutput=true` で stdout/stderr が Manager の pipe に吸われて
+**visible console が常に empty** (= 黒い空 box が表示されるだけで「ウイルスかな?」「強制終了したい」
+UX 悪化の温床) だった。「visible 設定だが output は redirect されて見えない」という矛盾した状態を
+fix。
+
+Updater output は以下で完全 trace 可能、情報損失ゼロ:
+- (a) file log `<install>/logs/updater/updater_<PC>_<datetime>.log`
+- (b) Manager の `OutputDataReceived` / `ErrorDataReceived` 経由 Logger.Info / Logger.Warn 出力
+
+旧 round 5 で本 dialog 文言に「黒い画面が一時的に表示されます」予告を追加していたが、本 fix で
+そもそも黒い画面が出なくなったため文言から削除 (= round 6 で簡潔化)。
+
+bump 判断: UI 改善 (= 既存 flow に dialog 1 つ追加 + Updater spawn の `CreateNoWindow` 値変更)、
+behavior の core path には影響なし (= Updater logic / file ops / restart 流れは無変更)、
 SemVer 上 patch (v0.13.0 → v0.13.1)。
 
 ### [Manager v0.13.0] - 2026-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@
 
 リリース zip 全体に付与する独立バージョン。GitHub Releases の本文として `Release.ps1` がこのセクションを抜き出して使う。エンドユーザー（来場スタッフ / 顧問の先生 / 部員）向けの **summary** を書く。技術詳細は `## Launcher` / `## Manager` / `## Release Tooling` 等の別セクションを参照。詳細仕様は [SPECIFICATION.md §3.7.7](SPECIFICATION.md) を参照。
 
+### [Bundle v0.6.0] - 2026-05-19
+
+**Manager の設定タブを大幅に整理 + 自動バックアップの進捗を画面右下に表示** (#170)。Bundle v0.5.0 受入テストで見つかった 5 つの UX / 安全性課題をまとめて改善。
+
+主な変更:
+- **自動バックアップの進捗が画面右下に表示** されるようになりました (例: 「✓ 自動バックアップ完了: toneprism_20260519_120000.db」、完了 7 秒で自動消去)。旧仕様は左下「ゲーム数: N 件」が一時的に上書きされて消える挙動だったのを、左右 2 zone に分離して同時表示できるように。
+- **設定タブを大幅整理** — 「バックアップ」「ログ」「データベース」「バージョン情報」の 4 section 構成に再編。これまで個別 dialog や hardcode だった以下の設定がすべて設定タブから一画面で変更可能に:
+  - バックアップ: 保存先 / 自動間隔 (時間 or 日 単位選択) / 保持世代数 / **自動バックアップの ON/OFF**
+  - ログ: 保存先 / 保存日数 (1-365 日)
+- **アップデート画面のリリースノート表示が正確に**: GitHub から最新版情報が取れない時 (= 通信エラー / API 利用上限) でも、現在実行中の Bundle 版の release notes を `<install>/CHANGELOG.md` から正しく表示するように (= 旧仕様は古いキャッシュの release notes が「これから適用される変更」として誤表示)。
+- **「データベースリセット」ボタンを赤色** で表示し、誤操作リスク低減。
+
+その他の改善:
+- 自動アップデート check が現在版 (= キャッシュより新しい版) を検出した時、TTL (6 時間) 内でも GitHub に再問い合わせするように (= 「最新版 v0.4.0」表示が古いまま固定化される問題を解消)
+- アップデート関連 / 設定変更の race safety 強化 (= LAN 上の他 PC が同時操作中の DB write を CheckBeforeWrite で検出)
+
+- Launcher: 変更なし (v0.6.1 同梱)
+- Manager: v0.12.1 → v0.13.0 (UI 大幅 brushup、5 課題 bundle + 4 round review 対応)
+- Updater: 変更なし (v0.2.1 同梱)
+- Release Tooling: 変更なし (v0.1.19 同梱)
+
+**[v0.5.0 をインストール済みの方へ]** Manager の「アップデート」タブから「今すぐアップデート」で適用してください (= Bundle v0.5.0 で自動アップデート復帰済)。**ゲームデータ (DB、ゲーム、バックアップ、回答、ログ) は自動で保護されます**。
+
 ### [Bundle v0.5.0] - 2026-05-19
 
 **プロジェクト名称を `ゲームセンターTONE Prism (GCTonePrism)` → `TonePrism` に統一** (#168)。他校・他団体への配布も視野に入れた汎用化 rename で、**exe filename / DB filename / namespace / UI 文字列 / repo URL まで全件 sync**:
@@ -2924,6 +2947,7 @@ Release.ps1 の $FooterSentinel 定数も同期更新すること。
 
 <!-- GCTONEPRISM-CHANGELOG-FOOTER-BEGIN-V1 -->
 
+[Bundle v0.6.0]: https://github.com/ken1208git/TonePrism/releases/tag/v0.6.0
 [Bundle v0.5.0]: https://github.com/ken1208git/TonePrism/releases/tag/v0.5.0
 [Bundle v0.4.0]: https://github.com/ken1208git/TonePrism/releases/tag/v0.4.0
 [Bundle v0.3.1]: https://github.com/ken1208git/TonePrism/releases/tag/v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - アップデート関連 / 設定変更の race safety 強化 (= LAN 上の他 PC が同時操作中の DB write を CheckBeforeWrite で検出)
 
 - Launcher: 変更なし (v0.6.1 同梱)
-- Manager: v0.12.1 → v0.13.0 (UI 大幅 brushup、5 課題 bundle + 4 round review 対応)
+- Manager: v0.12.1 → v0.13.1 (UI 大幅 brushup、5 課題 bundle + 4 round review 対応 + アップデート時の再起動予告 dialog 追加)
 - Updater: 変更なし (v0.2.1 同梱)
 - Release Tooling: 変更なし (v0.1.19 同梱)
 
@@ -1675,6 +1675,27 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 ---
 
 ## Manager（管理ソフト）
+
+### [Manager v0.13.1] - 2026-05-19
+
+#### Added (#170 followup — アップデート時の再起動予告 dialog)
+
+「今すぐアップデート」flow の ProcessingDialog (= zip DL + staging + Updater spawn) 完了直後、
+`Application.Exit` 呼出前に新 `MessageBox` を追加して **Manager 再起動を予告**:
+
+> ダウンロードと展開が完了しました。
+> これから Manager を一旦終了して、新しいバージョンで自動的に再起動します。
+> 再起動には数秒〜数十秒かかる場合があります (= 共有フォルダ越しの場合は長くなります)。
+> 新しい Manager が起動したら、「✓ アップデート完了」のお知らせが表示されます。
+
+旧実装 (= v0.13.0 以前) は ProcessingDialog 閉じた直後に Manager が silent に消える挙動で、
+user 視点で「あれ?何が起きた?」になりやすかった (= 突然 Manager が消えてから Updater 経由で
+数秒〜数十秒待たされる)。本 dialog で「これから一旦終了 → 自動再起動」を明示してから
+user の OK で確定終了する flow に変更、再起動完了後の sentinel 経由「✓ アップデート完了」
+dialog (= Bundle v0.4.0 から存在) と組み合わせて開始 → 終了 → 完了の 3 段階通知を user に提供。
+
+bump 判断: UI 改善 (= 既存 flow に dialog 1 つ追加)、behavior の core path には影響なし、
+SemVer 上 patch (v0.13.0 → v0.13.1)。
 
 ### [Manager v0.13.0] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1678,21 +1678,31 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ### [Manager v0.13.1] - 2026-05-19
 
-#### Added (#170 followup — アップデート時の再起動予告 dialog)
+#### Added (#170 followup — アップデート時の再起動予告 dialog + Updater console 出現の予告)
 
 「今すぐアップデート」flow の ProcessingDialog (= zip DL + staging + Updater spawn) 完了直後、
-`Application.Exit` 呼出前に新 `MessageBox` を追加して **Manager 再起動を予告**:
+`Application.Exit` 呼出前に新 `MessageBox` を追加して **Manager 再起動 + Updater console 出現を予告**:
 
 > ダウンロードと展開が完了しました。
 > これから Manager を一旦終了して、新しいバージョンで自動的に再起動します。
 > 再起動には数秒〜数十秒かかる場合があります (= 共有フォルダ越しの場合は長くなります)。
+>
+> 【ご注意】処理中、黒い画面 (コマンドプロンプトのようなウィンドウ) が一時的に表示されます。
+> これはアップデート用のツール (Updater) の進捗表示で、自動で閉じます。
+> 閉じないでそのままお待ちください。
+>
 > 新しい Manager が起動したら、「✓ アップデート完了」のお知らせが表示されます。
 
 旧実装 (= v0.13.0 以前) は ProcessingDialog 閉じた直後に Manager が silent に消える挙動で、
 user 視点で「あれ?何が起きた?」になりやすかった (= 突然 Manager が消えてから Updater 経由で
-数秒〜数十秒待たされる)。本 dialog で「これから一旦終了 → 自動再起動」を明示してから
-user の OK で確定終了する flow に変更、再起動完了後の sentinel 経由「✓ アップデート完了」
-dialog (= Bundle v0.4.0 から存在) と組み合わせて開始 → 終了 → 完了の 3 段階通知を user に提供。
+数秒〜数十秒待たされる + 黒い console window が突然出る)。Updater.exe は
+`UpdaterClient.cs:90` で **CreateNoWindow=false** に設定 (= 進捗 / debug log が見える方が user
+安心という設計判断、Companions/Updater 経由)、本 dialog で「黒い画面が出る = 正常」を予告して
+user の不安 (= ウイルス疑い / 強制終了したくなる衝動) を抑える。
+
+本 dialog で「これから一旦終了 → 自動再起動 + 黒い画面が一時表示」を明示してから user の OK で
+確定終了する flow に変更、再起動完了後の sentinel 経由「✓ アップデート完了」 dialog
+(= Bundle v0.4.0 から存在) と組み合わせて開始 → 終了 → 完了の **3 段階通知** を user に提供。
 
 bump 判断: UI 改善 (= 既存 flow に dialog 1 つ追加)、behavior の core path には影響なし、
 SemVer 上 patch (v0.13.0 → v0.13.1)。

--- a/Manager/Controls/UpdateSectionPanel.cs
+++ b/Manager/Controls/UpdateSectionPanel.cs
@@ -465,10 +465,18 @@ namespace TonePrism.Manager.Controls
                     // 消える挙動 (= user 視点で「あれ?何が起きた?」になりやすい)。本 dialog で
                     // 「これから Manager を一旦終了 → 新版で自動起動」を明示してから user の OK で
                     // 確定終了。新 Manager 起動時には sentinel 経由で「✓ アップデート完了」 dialog が出る。
+                    //
+                    // (#170 followup round 5) Updater.exe は CreateNoWindow=false (UpdaterClient.cs:90) で
+                    // **黒い console window を visible** で表示する設計 (= 進捗 / debug log が見える方が user
+                    // 安心という設計判断)。dialog 文言に「黒い画面」の出現を明示しないと「ウイルスかな?」と
+                    // 誤解されるリスクあり、本 round で予告文を追加。
                     MessageBox.Show(this,
                         "ダウンロードと展開が完了しました。\n\n" +
                         "これから Manager を一旦終了して、新しいバージョンで自動的に再起動します。\n" +
                         "再起動には数秒〜数十秒かかる場合があります (= 共有フォルダ越しの場合は長くなります)。\n\n" +
+                        "【ご注意】処理中、黒い画面 (コマンドプロンプトのようなウィンドウ) が一時的に表示されます。\n" +
+                        "これはアップデート用のツール (Updater) の進捗表示で、自動で閉じます。\n" +
+                        "閉じないでそのままお待ちください。\n\n" +
                         "新しい Manager が起動したら、「✓ アップデート完了」のお知らせが表示されます。",
                         "Manager を再起動します",
                         MessageBoxButtons.OK,

--- a/Manager/Controls/UpdateSectionPanel.cs
+++ b/Manager/Controls/UpdateSectionPanel.cs
@@ -466,17 +466,13 @@ namespace TonePrism.Manager.Controls
                     // 「これから Manager を一旦終了 → 新版で自動起動」を明示してから user の OK で
                     // 確定終了。新 Manager 起動時には sentinel 経由で「✓ アップデート完了」 dialog が出る。
                     //
-                    // (#170 followup round 5) Updater.exe は CreateNoWindow=false (UpdaterClient.cs:90) で
-                    // **黒い console window を visible** で表示する設計 (= 進捗 / debug log が見える方が user
-                    // 安心という設計判断)。dialog 文言に「黒い画面」の出現を明示しないと「ウイルスかな?」と
-                    // 誤解されるリスクあり、本 round で予告文を追加。
+                    // (#170 followup round 6) 旧 round 5 の「黒い画面」予告文は削除。
+                    // UpdaterClient.cs:90 を CreateNoWindow=true に変更したため、Updater の console window
+                    // が visible で表示されなくなった (= 旧実装で出てた「空の黒い box」UX 悪化を fix)。
                     MessageBox.Show(this,
                         "ダウンロードと展開が完了しました。\n\n" +
                         "これから Manager を一旦終了して、新しいバージョンで自動的に再起動します。\n" +
                         "再起動には数秒〜数十秒かかる場合があります (= 共有フォルダ越しの場合は長くなります)。\n\n" +
-                        "【ご注意】処理中、黒い画面 (コマンドプロンプトのようなウィンドウ) が一時的に表示されます。\n" +
-                        "これはアップデート用のツール (Updater) の進捗表示で、自動で閉じます。\n" +
-                        "閉じないでそのままお待ちください。\n\n" +
                         "新しい Manager が起動したら、「✓ アップデート完了」のお知らせが表示されます。",
                         "Manager を再起動します",
                         MessageBoxButtons.OK,

--- a/Manager/Controls/UpdateSectionPanel.cs
+++ b/Manager/Controls/UpdateSectionPanel.cs
@@ -460,7 +460,20 @@ namespace TonePrism.Manager.Controls
                 Services.Logger.Info("[UpdateSectionPanel] ProcessingDialog 結果: DialogResult=" + dialog.DialogResult + " spawnedUpdater=" + spawnedUpdater);
                 if (dialog.DialogResult == DialogResult.OK && spawnedUpdater)
                 {
-                    Services.Logger.Info("[UpdateSectionPanel] Updater spawn 成功、Application.Exit を呼ぶ");
+                    // (#170 followup) ダウンロード + staging 完了直後の再起動予告 dialog。
+                    // 旧実装は ProcessingDialog 閉じてから即 Application.Exit で Manager が silent に
+                    // 消える挙動 (= user 視点で「あれ?何が起きた?」になりやすい)。本 dialog で
+                    // 「これから Manager を一旦終了 → 新版で自動起動」を明示してから user の OK で
+                    // 確定終了。新 Manager 起動時には sentinel 経由で「✓ アップデート完了」 dialog が出る。
+                    MessageBox.Show(this,
+                        "ダウンロードと展開が完了しました。\n\n" +
+                        "これから Manager を一旦終了して、新しいバージョンで自動的に再起動します。\n" +
+                        "再起動には数秒〜数十秒かかる場合があります (= 共有フォルダ越しの場合は長くなります)。\n\n" +
+                        "新しい Manager が起動したら、「✓ アップデート完了」のお知らせが表示されます。",
+                        "Manager を再起動します",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
+                    Services.Logger.Info("[UpdateSectionPanel] Updater spawn 成功、再起動予告 dialog 確認後 Application.Exit を呼ぶ");
                     // Updater は spawn 済、Manager プロセスの終了待機を開始している。Application.Exit で
                     // message loop を抜けると `finally Logger.Shutdown` 経由で正常 exit、Updater の Step 1/4
                     // polling が抜けて Manager dir 置換 + 新 Manager.exe 起動に進む。

--- a/Manager/Properties/AssemblyInfo.cs
+++ b/Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.13.0.0")]
-[assembly: AssemblyFileVersion("0.13.0.0")]
+[assembly: AssemblyVersion("0.13.1.0")]
+[assembly: AssemblyFileVersion("0.13.1.0")]

--- a/Manager/Services/UpdaterClient.cs
+++ b/Manager/Services/UpdaterClient.cs
@@ -87,7 +87,13 @@ namespace TonePrism.Manager.Services
                     FileName = updaterExe,
                     Arguments = argLine,
                     UseShellExecute = false,
-                    CreateNoWindow = false,           // Updater は console window を持つ短命プロセス、ユーザーに見える方が安心
+                    // (#170 followup) `CreateNoWindow = true` に変更 (旧: false)。
+                    // 旧設計は「Updater console を visible にして user 安心感 + 進捗 visible」だったが、
+                    // 実態は **RedirectStandardOutput=true で stdout/stderr が pipe に吸われて visible console が常に empty**。
+                    // 黒い空 box が表示されるだけで「ウイルスかな?」「強制終了したい」UX 悪化の温床だった。
+                    // 本 fix で hidden 化、Updater output は (a) file log `<install>/logs/updater/*.log` +
+                    // (b) Manager 経由 redirected stdout 経由 Logger 出力 で完全 trace 可能、情報損失ゼロ。
+                    CreateNoWindow = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     StandardOutputEncoding = Encoding.UTF8,


### PR DESCRIPTION
## Summary
Bundle v0.6.0 リリース実行前の prep + 追加で Manager v0.13.0 → v0.13.1 patch bump。
当初は CHANGELOG entry のみだったが、user 要望「アプデ後に再起動しますみたいなダイアログほしい」を release 前に統合して 1 PR 化。

本 PR を merge 後、`Release.bat` を実行することで `TonePrism_v0.6.0.zip` 生成 + GitHub Releases upload。

## 含まれる変更

### 1. Manager v0.13.1: アップデート再起動予告 dialog (新規)
`UpdateSectionPanel.btnUpdateNow_Click` の ProcessingDialog (= zip DL + staging + Updater spawn) 完了直後、`Application.Exit` 呼出前に新 MessageBox 1 つ追加:

> ダウンロードと展開が完了しました。
> これから Manager を一旦終了して、新しいバージョンで自動的に再起動します。
> 再起動には数秒〜数十秒かかる場合があります (= 共有フォルダ越しの場合は長くなります)。
> 新しい Manager が起動したら、「✓ アップデート完了」のお知らせが表示されます。

旧 flow は `ProcessingDialog 閉じる → 即 Application.Exit` で Manager が silent に消える挙動 (= 「あれ?何が起きた?」UX)。本 dialog で「これから一旦終了 → 自動再起動」を明示してから user の OK で確定終了。再起動完了後の sentinel 経由「✓ アップデート完了」 dialog と組合せて **開始確認 → 再起動予告 → 完了通知** の 3 段階通知 flow に。

#### Manager version bump
- AssemblyInfo.cs: 0.13.0.0 → 0.13.1.0
- CHANGELOG: `## Manager v0.13.1` 新 entry 追加 (UI 改善、SemVer patch、behavior core path 無変更)

### 2. `## Bundle v0.6.0` entry (CHANGELOG 最上段に追加)
エンドユーザー (来場スタッフ / 顧問 / 部員) 向けの release summary。`Release.ps1` がこのセクションを抜き出して GitHub Releases 本文に流す:
- 自動バックアップ進捗を画面右下に表示 (status bar 2 zone 分離、Manager v0.13.0)
- 設定タブ大幅整理 (4 section 構成: バックアップ / ログ / DB / バージョン情報)
- バックアップ: 保存先 / 自動間隔 (時間 or 日 単位選択) / 世代数 / **ON/OFF**
- ログ: 保存先 / 保存日数 (1-365 日)
- アップデート画面リリースノートを local CHANGELOG 優先 fallback で正確化
- データベースリセットボタン赤色化
- **アップデート時の再起動予告 dialog** (Manager v0.13.1)
- cache version stale 強制 refresh (「v0.4.0 固定」表示問題解消)
- Update check 系 race safety 強化

### Component bump summary
- Launcher: 変更なし (v0.6.1 同梱)
- Manager: v0.12.1 → **v0.13.1** (UI brushup + 再起動予告 dialog)
- Updater: 変更なし (v0.2.1 同梱)
- Release Tooling: 変更なし (v0.1.19 同梱)

### Bundle bump 判断
AGENTS.md 規約「Minor: いずれかの component で機能追加」→ Manager が機能追加 → Bundle v0.5.0 → **v0.6.0** (minor)

### 末尾 link def
```
[Bundle v0.6.0]: https://github.com/ken1208git/TonePrism/releases/tag/v0.6.0
```

## 影響範囲
- Manager UI に MessageBox 1 つ追加、他の flow / race / timing は無変更
- DB schema / 配布物 layout / API 一切無変更
- Release.bat 実行準備が整った状態

## Test plan
- [x] `## Bundle v0.6.0` entry が `## Bundle` section 最上段に挿入
- [x] `## Manager v0.13.1` entry が `## Manager` section 最上段に挿入
- [x] 末尾 `[Bundle v0.6.0]:` link def が footer block 先頭に追加 (降順維持)
- [x] AssemblyInfo.cs の AssemblyVersion / AssemblyFileVersion が `0.13.1.0` で sync
- [x] `dotnet build TonePrism_Manager.csproj -c Debug` 成功 (0 error)
- [ ] (本 PR merge 後) main pull → `Release.bat` 実行 → `TonePrism_v0.6.0.zip` 生成 + GitHub Releases upload
- [ ] (release 後) v0.5.0 install → 「アップデート」タブから「今すぐアップデート」→ **再起動予告 dialog が新規表示** → OK → Manager 再起動 → 完了 dialog 表示の 3 段階通知を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)