### PR TITLE
fix(manager): ゲーム編集の self-rename 例外を修正 (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1764,8 +1764,8 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 バージョン番号を変えずに（例: 起動オプションだけ編集して）OK を押すと、`game_versions.version` が `v` prefix 無し（例 `"1.0.0"`）で保存されているゲームで「フォルダリネーム失敗（ソース パスとターゲット パスを同じにすることはできません）」が出て保存できない不具合を修正。
 
-- 原因: rename skip guard (`EditGameForm.cs` 946 行) は raw 文字列比較 (`originalVer` vs `v.Version`) だが、フォルダ leaf は `ToVersionLeaf` で正規化 (`"1.0.0"` も `"v1.0.0"` も leaf `"v1.0.0"`)。raw 比較は不一致で skip されず、`OldDir == NewDir` の self-rename plan が作られ Phase 2 の `Directory.Move(同, 同)` が IOException → 失敗ダイアログ。衝突 check も `reservedOldDirs` に hit して素通りしていた。
-- 修正: `oldDir`/`newDir` 算出直後に `string.Equals(oldDir, newDir, OrdinalIgnoreCase)` なら rename plan から除外 (`continue`)。DB は後続の `UpdateGameVersion` ループが全 version を normalized 値で書き戻すため、disk を触らず DB だけ正規化される正しい挙動になる。
+- 原因: rename skip guard（renamePlan 構築ループの `originalVer` vs `v.Version` の raw 文字列比較）は生比較だが、フォルダ leaf は `ToVersionLeaf` で正規化 (`"1.0.0"` も `"v1.0.0"` も leaf `"v1.0.0"`)。raw 比較は不一致で skip されず、`oldDir == newDir` の self-rename plan が作られ Phase 2 の `Directory.Move(同, 同)` が IOException → 失敗ダイアログ。
+- 修正: (1) `oldDir`/`newDir` 算出直後に leaf 正規化後が同一 (`string.Equals(oldDir, newDir, OrdinalIgnoreCase)`) なら rename plan から除外 (`continue`)。(2) 同じ非対称が `reservedOldDirs` 構築ループにもあり（raw guard のままだと「rename されず空かない leaf」を予約済みとして登録し、別 version が同一 leaf を target にした衝突を Phase 1 衝突 check で見逃す）、こちらも leaf 比較に統一。DB は後続の `UpdateGameVersion` ループが全 version を normalized 値で書き戻すため、disk を触らず DB だけ正規化される正しい挙動になる。
 - 影響: `v` prefix 無しで DB 保存された既存ゲーム全般（バージョン未変更の編集が全て詰んでいた）。
 
 #### Bump 根拠 (v0.16.1 → v0.16.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1758,6 +1758,20 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ## Manager（管理ソフト）
 
+### [Manager v0.16.2] - 2026-05-21
+
+#### Fixed (#221 — ゲーム編集でバージョン未変更でも self-rename 例外)
+
+バージョン番号を変えずに（例: 起動オプションだけ編集して）OK を押すと、`game_versions.version` が `v` prefix 無し（例 `"1.0.0"`）で保存されているゲームで「フォルダリネーム失敗（ソース パスとターゲット パスを同じにすることはできません）」が出て保存できない不具合を修正。
+
+- 原因: rename skip guard (`EditGameForm.cs` 946 行) は raw 文字列比較 (`originalVer` vs `v.Version`) だが、フォルダ leaf は `ToVersionLeaf` で正規化 (`"1.0.0"` も `"v1.0.0"` も leaf `"v1.0.0"`)。raw 比較は不一致で skip されず、`OldDir == NewDir` の self-rename plan が作られ Phase 2 の `Directory.Move(同, 同)` が IOException → 失敗ダイアログ。衝突 check も `reservedOldDirs` に hit して素通りしていた。
+- 修正: `oldDir`/`newDir` 算出直後に `string.Equals(oldDir, newDir, OrdinalIgnoreCase)` なら rename plan から除外 (`continue`)。DB は後続の `UpdateGameVersion` ループが全 version を normalized 値で書き戻すため、disk を触らず DB だけ正規化される正しい挙動になる。
+- 影響: `v` prefix 無しで DB 保存された既存ゲーム全般（バージョン未変更の編集が全て詰んでいた）。
+
+#### Bump 根拠 (v0.16.1 → v0.16.2)
+
+SemVer pre-1.0 patch bump: bugfix のみ。
+
 ### [Manager v0.16.1] - 2026-05-20
 
 #### Changed (#200 — バックアップ履歴の「状態」列削除)

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -924,8 +924,15 @@ namespace TonePrism.Manager
                             Logger.Warn("[EditGameForm] (#158 round 8 Med #3) reservedOldDirs build: snapshot 不在 version id=" + vR.Id + " ('" + (vR.Version ?? "(null)") + "')、rename plan skip");
                             continue;
                         }
-                        if (string.Equals(origR, vR.Version, StringComparison.OrdinalIgnoreCase)) continue;
-                        reservedOldDirs.Add(System.IO.Path.Combine(gameFolder, ToVersionLeaf(origR)));
+                        // (#221) raw 文字列比較ではなく leaf 正規化後で「実際に rename されるか」を判定する。
+                        // v prefix 有無や大文字 V のみの差 ("1.0.0"/"V1.0.0" vs "v1.0.0") は raw 不一致だが
+                        // ToVersionLeaf で同一 leaf に畳まれ rename されない = この slot は空かない。raw guard の
+                        // ままだと「空かない leaf」を予約済み (rename で空く予定) として登録してしまい、別 version
+                        // が同一 leaf を target にした衝突を下の Phase 1 衝突 check で見逃す非対称が生じる
+                        // (renamePlan ループは leaf 同一を skip するのに、こちらは登録してしまう)。
+                        string oldLeafR = ToVersionLeaf(origR);
+                        if (string.Equals(oldLeafR, ToVersionLeaf(vR.Version), StringComparison.OrdinalIgnoreCase)) continue;
+                        reservedOldDirs.Add(System.IO.Path.Combine(gameFolder, oldLeafR));
                     }
                     foreach (var item in cmbVersionList.Items)
                     {
@@ -952,9 +959,10 @@ namespace TonePrism.Manager
                         string newDir = System.IO.Path.Combine(gameFolder, newLeaf);
 
                         // (#221) ToVersionLeaf 正規化後に old/new が同一フォルダになるケースは disk rename 不要。
-                        // 例: DB の version が "1.0.0" (v prefix 無し) で VersionString getter は "v1.0.0" を
-                        // 返すと、946 行の raw 文字列比較 guard は不一致 (skip されない) だが
-                        // ToVersionLeaf はどちらも "v1.0.0" → OldDir == NewDir の self-rename plan が作られ、
+                        // 例: DB の version が "1.0.0" (v prefix 無し) のゲームは、save 時に
+                        // SemverInputControl.VersionString が v.Version へ正規化形 "v1.0.0" を書き戻すため、
+                        // 上の raw 文字列比較 guard (originalVer vs v.Version) は不一致で skip されないが、
+                        // ToVersionLeaf はどちらも "v1.0.0" → oldDir == newDir の self-rename plan が作られ、
                         // Phase 2 の Directory.Move(oldDir, newDir) が "source == dest" 例外で
                         // 「フォルダリネーム失敗」になっていた (バージョン未変更の編集が全て詰む)。
                         // 下の UpdateGameVersion ループが全 version を normalized 値で DB 書き戻すので、

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -951,6 +951,16 @@ namespace TonePrism.Manager
                         string oldDir = System.IO.Path.Combine(gameFolder, oldLeaf);
                         string newDir = System.IO.Path.Combine(gameFolder, newLeaf);
 
+                        // (#221) ToVersionLeaf 正規化後に old/new が同一フォルダになるケースは disk rename 不要。
+                        // 例: DB の version が "1.0.0" (v prefix 無し) で VersionString getter は "v1.0.0" を
+                        // 返すと、946 行の raw 文字列比較 guard は不一致 (skip されない) だが
+                        // ToVersionLeaf はどちらも "v1.0.0" → OldDir == NewDir の self-rename plan が作られ、
+                        // Phase 2 の Directory.Move(oldDir, newDir) が "source == dest" 例外で
+                        // 「フォルダリネーム失敗」になっていた (バージョン未変更の編集が全て詰む)。
+                        // 下の UpdateGameVersion ループが全 version を normalized 値で DB 書き戻すので、
+                        // ここで rename plan から除外すれば disk は触らず DB だけ正規化される正しい挙動になる。
+                        if (string.Equals(oldDir, newDir, StringComparison.OrdinalIgnoreCase)) continue;
+
                         // (#158 round 6 M-2) reservedOldDirs に含まれる newDir は他 plan の oldDir、
                         // = rename 実行で空く予定なので衝突 skip。それ以外 (= 純粋に既存 disk フォルダ)
                         // のみ真の衝突として block する。

--- a/Manager/Properties/AssemblyInfo.cs
+++ b/Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.16.1.0")]
-[assembly: AssemblyFileVersion("0.16.1.0")]
+[assembly: AssemblyVersion("0.16.2.0")]
+[assembly: AssemblyFileVersion("0.16.2.0")]


### PR DESCRIPTION
## Summary
- ゲーム編集でバージョンを変更していなくても「フォルダリネーム失敗（source == dest）」例外が出てバージョン未変更の編集が全て詰む不具合を修正 (#221)。
- 原因: rename skip guard が raw 文字列比較なのに対し、フォルダ leaf は `ToVersionLeaf` で正規化される。DB の version が v prefix 無し（例 `1.0.0`）のゲームでは guard をすり抜け、`OldDir == NewDir` の self-rename plan が作られ `Directory.Move(同, 同)` が例外になっていた。
- 修正: `ToVersionLeaf` 正規化後に `oldDir == newDir` なら rename plan から除外（`continue`）。後続の `UpdateGameVersion` ループが正規化値で DB へ書き戻すので、disk は触らず DB 側だけ正規化される正しい挙動になる。
- Manager v0.16.1 → v0.16.2。

## Test plan
- [x] v prefix 無し version（例 `Only_Up` の `1.0.0`）のゲームを「ゲーム編集」でバージョン未変更のまま OK → 例外が出ず保存できることを実機確認
- [ ] v prefix 有り version のゲームでバージョン未変更編集 → 従来どおり成功（リグレッション無し）
- [ ] バージョンを実際に変更した編集 → フォルダ rename が正しく行われる

🤖 Generated with [Claude Code](https://claude.com/claude-code)