### PR TITLE
ゲーム中のランチャー誤前面化を自動復旧してから警告 (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1252,6 +1252,20 @@ minor bump 判断: SemVer pre-1.0 原則 (= 0.x で breaking change は minor bu
 
 ## Launcher（ランチャー本体）
 
+### [Launcher v0.8.1] - 2026-05-25
+
+#### Changed (#219 — ゲーム中のランチャー誤前面化を自動復旧)
+
+#216 (前面化異常検知) のフォローアップ。従来は「異常検知 → 即スタッフ警告」だったのを、**警告の前にゲーム窓を強制前面化して自己修復を試み、リトライを尽くしても background のままなら警告**する二段構えに変更。
+
+- `GameSession._update_anomaly_detection`: 異常がデバウンス (2s) を超えて確定したら、即 `ErrorManager.show_error` せず `LauncherAgent.focus(running_pid)` でゲーム窓を強制前面化。`ANOMALY_RECOVERY_INTERVAL_MS` (500ms) 間隔で最大 `ANOMALY_RECOVERY_MAX_ATTEMPTS` (3) 回リトライし、次 probe で復旧 (ゲーム前面) を確認できたら警告なしでリセット。尽きても background ならスタッフ警告 (`GAME_LAUNCHER_FOREGROUND_ANOMALY`) を出す。
+- Windows の foreground-lock 制限で `SetForegroundWindow` が効かないケース (タスクバー点滅のみ等) があるため、復旧は 100% 保証せず「トライ → 失敗時のみ警告」を前提とする。
+- 意図的な前面化 (中断オーバーレイ表示 #30 / quit 中) は既存の whitelist (`OverlayManager.is_open() or _quitting`) で異常カウントから除外済み (#219 タスク項目4)。
+
+#### Bump 根拠 (v0.8.0 → v0.8.1)
+
+既存 #216 セーフガードの挙動強化 (自己修復の追加) で新規 UI/機能面はないため SemVer patch (`version.gd` PATCH 0→1)。
+
 ### [Launcher v0.8.0] - 2026-05-22
 
 #### Added (#30 — ゲーム実行中の中断オーバーレイメニュー)

--- a/Launcher/scripts/game_session.gd
+++ b/Launcher/scripts/game_session.gd
@@ -298,7 +298,9 @@ func _launcher_is_foreground() -> bool:
 	return w != null and w.has_focus()
 
 
-## プレイ中の前面化異常を検知する。異常 = ランチャー前面 かつ ゲームが前面でない、がデバウンス継続。
+## プレイ中の前面化異常を検知し、確定後はまず強制前面化で自己修復を試み、リトライを尽くしても復旧
+## しなければスタッフ警告へエスカレーションする (#216 検知 + #219 自己修復)。
+## 異常 = ランチャー前面 かつ ゲームが前面でない、がデバウンス継続。
 func _update_anomaly_detection(launcher_foreground: bool, res: int) -> void:
 	var game_not_front := (res == LauncherAgent.WindowState.NOT_VISIBLE
 		or res == LauncherAgent.WindowState.VISIBLE_BACKGROUND)
@@ -318,11 +320,14 @@ func _update_anomaly_detection(launcher_foreground: bool, res: int) -> void:
 				if _last_recovery_ms == 0 or now - _last_recovery_ms >= ANOMALY_RECOVERY_INTERVAL_MS:
 					_recovery_attempts += 1
 					_last_recovery_ms = now
-					if _probe_available:
-						LauncherAgent.focus(running_pid)
+					# 呼び出し元 (_process) が _probe_available 真を保証済み。
+					LauncherAgent.focus(running_pid)
+					# print 使用は意図的: autoload `Logger` は Godot 組み込み `Logger` クラスと名前衝突し
+					# GDScript から `Logger.info()` を呼べない (#85 で明示 API 移行予定)。print は log tail で INFO 分類。
 					print("[GameSession] 前面化異常 → ゲーム窓を強制前面化で自己修復を試行 (%d/%d)" % [_recovery_attempts, ANOMALY_RECOVERY_MAX_ATTEMPTS])
 				# まだ警告は出さない (次 probe で復旧したか確認。復旧すれば else 分岐でリセット)。
-			else:
+			elif now - _last_recovery_ms >= ANOMALY_RECOVERY_INTERVAL_MS:
+				# 全リトライ後も INTERVAL 経過して復旧せず (最終試行にも検証猶予を与えてから警告)。
 				if not _anomaly_logged:
 					_anomaly_logged = true
 					push_warning("[GameSession] ランチャー前面化異常を検出、自己修復に失敗 (PID %d 生存中、要スタッフ対応)" % running_pid)

--- a/Launcher/scripts/game_session.gd
+++ b/Launcher/scripts/game_session.gd
@@ -16,7 +16,10 @@ signal game_exited()           ## プロセス終了 (自然終了 / quit)
 
 # 可視ウィンドウ未検出でも「起動中」で固まらないよう強制 PLAYING にするまでの時間 (初回スキャン対策で長め)。
 const PLAYING_FALLBACK_TIMEOUT_MS: int = 60000
-const ANOMALY_DEBOUNCE_MS: int = 2000  # 前面化異常を発報するまでの継続時間 (一瞬の Alt-Tab 除外)
+const ANOMALY_DEBOUNCE_MS: int = 2000  # 前面化異常を「異常」と判定するまでの継続時間 (一瞬の Alt-Tab 除外)
+# #219: 異常確定後、スタッフ警告の前にゲーム窓の強制前面化で自己修復を試みる二段構え。
+const ANOMALY_RECOVERY_MAX_ATTEMPTS: int = 3  # 強制前面化のリトライ上限。尽きても background なら警告へ
+const ANOMALY_RECOVERY_INTERVAL_MS: int = 500  # リトライ間隔 (focus 反映 + 次 probe 更新を待つ)
 # Companion ハンドシェイク待ちの上限 (起動直後にゲームを起動した race 対策)。超過したら probe 無しで継続。
 const PROBE_HANDSHAKE_TIMEOUT_MS: int = 5000
 # quit() で taskkill 発行後、これだけ経ってもプロセスが消えない場合は終了失敗とみなして固着を解く
@@ -34,6 +37,8 @@ var _anomaly_armed: bool = false
 var _anomaly_since_ms: int = 0
 var _anomaly_active: bool = false
 var _anomaly_logged: bool = false
+var _recovery_attempts: int = 0    # #219: 今回の異常エピソードでの強制前面化リトライ回数
+var _last_recovery_ms: int = 0     # 直近の強制前面化時刻 (リトライ間隔の判定用)
 var _launch_time_ms: int = 0
 var _probe_failure_logged: bool = false
 # 終了後の遷移先: true=スクリーンセーバー / false=ゲーム選択画面。退出メニュー選択で true。
@@ -274,6 +279,8 @@ func _reset_probe_state() -> void:
 	_anomaly_since_ms = 0
 	_anomaly_active = false
 	_anomaly_logged = false
+	_recovery_attempts = 0
+	_last_recovery_ms = 0
 	_probe_failure_logged = false
 	_launch_time_ms = Time.get_ticks_msec()
 
@@ -298,16 +305,33 @@ func _update_anomaly_detection(launcher_foreground: bool, res: int) -> void:
 	var anomaly := launcher_foreground and game_not_front
 
 	if anomaly:
+		var now := Time.get_ticks_msec()
 		if _anomaly_since_ms == 0:
-			_anomaly_since_ms = Time.get_ticks_msec()
-		elif not _anomaly_active and Time.get_ticks_msec() - _anomaly_since_ms >= ANOMALY_DEBOUNCE_MS:
-			if not _anomaly_logged:
-				_anomaly_logged = true
-				push_warning("[GameSession] ランチャー前面化異常を検出 (PID %d 生存中、要スタッフ対応)" % running_pid)
-			_anomaly_active = ErrorManager.show_error(ErrorCode.GAME_LAUNCHER_FOREGROUND_ANOMALY)
+			_anomaly_since_ms = now
+			_recovery_attempts = 0
+			_last_recovery_ms = 0
+		elif not _anomaly_active and now - _anomaly_since_ms >= ANOMALY_DEBOUNCE_MS:
+			# 異常確定。#219: まずゲーム窓の強制前面化で自己修復を試み、リトライを尽くしても
+			# background のままなら従来どおりスタッフ警告を出す (Windows の foreground-lock で
+			# focus が効かないケースがあるため「トライ → 失敗時のみ警告」の二段構え)。
+			if _recovery_attempts < ANOMALY_RECOVERY_MAX_ATTEMPTS:
+				if _last_recovery_ms == 0 or now - _last_recovery_ms >= ANOMALY_RECOVERY_INTERVAL_MS:
+					_recovery_attempts += 1
+					_last_recovery_ms = now
+					if _probe_available:
+						LauncherAgent.focus(running_pid)
+					print("[GameSession] 前面化異常 → ゲーム窓を強制前面化で自己修復を試行 (%d/%d)" % [_recovery_attempts, ANOMALY_RECOVERY_MAX_ATTEMPTS])
+				# まだ警告は出さない (次 probe で復旧したか確認。復旧すれば else 分岐でリセット)。
+			else:
+				if not _anomaly_logged:
+					_anomaly_logged = true
+					push_warning("[GameSession] ランチャー前面化異常を検出、自己修復に失敗 (PID %d 生存中、要スタッフ対応)" % running_pid)
+				_anomaly_active = ErrorManager.show_error(ErrorCode.GAME_LAUNCHER_FOREGROUND_ANOMALY)
 	else:
 		_anomaly_since_ms = 0
 		_anomaly_logged = false
+		_recovery_attempts = 0
+		_last_recovery_ms = 0
 		if _anomaly_active:
 			_anomaly_active = false
 			print("[GameSession] ランチャー前面化異常が解消、エラーをクリア")

--- a/Launcher/version.gd
+++ b/Launcher/version.gd
@@ -12,7 +12,7 @@ class_name Version
 
 const MAJOR: int = 0
 const MINOR: int = 8
-const PATCH: int = 0
+const PATCH: int = 1
 
 static func get_version_string() -> String:
 	return "v%d.%d.%d" % [MAJOR, MINOR, PATCH]


### PR DESCRIPTION
## Summary
#216（前面化異常検知）のフォローアップ。従来は「異常検知 → 即スタッフ警告」だったのを、**警告の前にゲーム窓を強制前面化して自己修復を試み、失敗時のみ警告**する二段構えにする。

## 変更
`GameSession._update_anomaly_detection`:
1. 前面化異常がデバウンス（2s）を超えて確定。
2. 即 `ErrorManager.show_error` せず `LauncherAgent.focus(running_pid)` でゲーム窓を強制前面化。
3. `ANOMALY_RECOVERY_INTERVAL_MS`(500ms) 間隔で最大 `ANOMALY_RECOVERY_MAX_ATTEMPTS`(3) 回リトライ。
4. 次 probe で復旧（ゲーム前面）を確認できれば**警告なしでリセット**。尽きても background なら従来どおり警告。

## 注意点
- Windows の foreground-lock 制限で `SetForegroundWindow` が効かない（タスクバー点滅のみ等）ケースがあるため、復旧は 100% 保証せず「トライ → 失敗時のみ警告」が前提（#218 spike 項目4 の挙動）。
- 意図的な前面化（中断オーバーレイ #30 / quit 中）は既存の whitelist（`OverlayManager.is_open() or _quitting`）で異常カウントから除外済み（#219 タスク項目4）。

## バージョン
- Launcher v0.8.0 → **v0.8.1**（既存 #216 セーフガードの挙動強化、新規 UI/機能面なしのため patch）

## Test plan
- [ ] ゲーム実行中にランチャーを Alt+Tab で前面化 → 自動でゲームが前面へ戻り、警告が出ないこと
- [ ] foreground-lock で復帰できない状況（再現できれば）でリトライ 3 回後に警告が出ること
- [ ] 中断メニュー（HOME/Guide）表示中は誤検知・誤復旧しないこと

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)