### PR TITLE
fix: 累積コードレビュー指摘の対応 (Launcher / Manager / Release Tooling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,15 @@
 
 **注意 (#160 で section 責務分離)**: `Updater` 等の **runtime exe 群** (= SPEC §2.4 Companions 配置) の changelog は本 section ではなく **`## Companions`** (旧 `## Updater (Companions/Updater)`、本 PR で section 名を一般化) に記載する。本 section は build / 配布スクリプトのみ対象。Bundle v0.4.0 以前 (= 本 PR merge 前) の Updater 変更履歴は `## Release Tooling` の過去 entry (= round 1〜8 review 詳細等) に retain、retroactive consolidation は scope creep のため見送り (= PR #159 round 4 「SPEC 1 PR 1 bump 規約」導入時と同 pattern)。
 
+### [Release Tooling v0.1.22] - 2026-05-27
+
+#### Fixed (累積コードレビュー指摘の対応)
+
+- **`Clear-OldGodot` の version ソートを文字列辞書順 → `[version]` 数値比較に修正**: 旧 `Sort-Object Name -Descending` は文字列順のため Godot が `4.10.x` 系に達すると `4.9.x` を「より新しい」と誤判定し、最新版を古い版として削除する時限バグだった (現状 4.6.x のみで未発火)。`Where-Object { $_.Name -as [version] }` で非 version dir を削除対象から除外しつつ (cast 例外で cleanup phase が落ちるのも防ぐ)、`Sort-Object { [version]$_.Name }` で数値比較に変更。
+- **起動バナーの `(Phase 1)` 表記を削除**: Phase 2 / 3 完成済 (`.DESCRIPTION` と整合) なのにバナーだけ旧 Phase 表記が残り、実行者の誤読源になっていた。
+
+bump 判断: 配布スクリプトの bugfix のみ。patch (v0.1.21 → v0.1.22)。Bundle への反映は次回リリース実行時。
+
 ### [Release Tooling v0.1.21] - 2026-05-21
 
 #### Added (#101 / #216 — WindowProbe の build / 配布統合)
@@ -1259,6 +1268,19 @@ minor bump 判断: SemVer pre-1.0 原則 (= 0.x で breaking change は minor bu
 
 ## Launcher（ランチャー本体）
 
+### [Launcher v0.9.1] - 2026-05-27
+
+#### Fixed (累積コードレビュー指摘の対応)
+
+- **DB オープン失敗の silent success を解消** (`database_manager.gd`): `db.open_db()` の戻り値を無視し、後続の `if db == null` が常に false の dead code だったため、パス不正 / 権限不足 / ロック等で DB を開けなくても `open()` が `true` を返していた。戻り値で判定し、失敗時は `db = null` をセットして `false` を返すよう修正。これにより「DB を開けないのにゲーム 0 件として正常起動」する経路が塞がれる。
+- **ゲーム起動失敗時のログを ERROR レベル化** (`game_session.gd`): 実行ファイル未検出 / プロセス起動失敗の経路が `print("❌ …")` だったのを、同ファイルの既存パターンに揃えて `push_error` に変更 (ログのレベルフィルタで追跡可能に)。
+- **画面遷移失敗時に復帰演出フラグを汚さないようガード** (`playing.gd`): `change_scene_to_file` の戻り値を確認し、失敗時は `AppState.returning_from_game` / `returning_from_quit` を設定せず early return。成功時のフラグ設定は deferred 遷移より前なので新シーンの `_ready` から正しく参照される。
+- `version.gd` の stale なマイルストーンコメントを削除し、ファイル責務の記述に置換。
+
+#### Bump 根拠 (v0.9.0 → v0.9.1)
+
+bugfix のみのため SemVer patch (`version.gd` PATCH 0→1)。挙動変更は失敗経路の早期検知 / ログ精度向上に限定、正常系は不変。
+
 ### [Launcher v0.9.0] - 2026-05-27
 
 #### Added (#74 — サービスモード / 機能23)
@@ -1863,6 +1885,17 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 ---
 
 ## Manager（管理ソフト）
+
+### [Manager v0.16.3] - 2026-05-27
+
+#### Fixed (累積コードレビュー指摘の対応)
+
+- **`GameRepository.ReadGameInfo` の `arguments` 読み取りで silent な握り潰しを解消**: `try { … } catch { }` で例外を完全に飲み込んでおり、コメント「GetAll uses display_version alias which doesn't include arguments」も誤り (GetAll / GetById 双方の SELECT に `arguments` を含む)。catch を削除して直接読み取りに変更。将来 SELECT から `arguments` が誤って外れても例外が表面化するようになり、`Arguments` の隠れた null 化経路を排除。
+- **`DatabaseConnection.ExecuteWithRetry<T>` の到達不能 `return default(T)` を例外に変更**: ループは「成功で return」「最終 retry で throw」のいずれかで必ず抜けるため到達しないが、万一 `maxRetries<=0` 等で到達した場合に `null` / `0` を silent に返さず `InvalidOperationException` を投げるよう変更 (将来の制御フロー変更時の silent failure 予防)。
+
+#### Bump 根拠 (v0.16.2 → v0.16.3)
+
+SemVer pre-1.0 patch bump: bugfix のみ。挙動変更は隠れた失敗経路の顕在化に限定、正常系は不変。
 
 ### [Manager v0.16.2] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1901,6 +1901,7 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 - **`games.arguments` の追加を `CreateTables()` 内アドホック ALTER から `MigrateV13ToV14` に移設** (`CurrentDbVersion` 13 → 14)。旧実装は (a) `user_version` に連動せず毎起動 `PRAGMA table_info` で存在チェックして足す野良 migration で、(b) 失敗を `catch` で握り潰していた (AGENTS.md「`CreateTables()` を編集したら必ず `MigrateVxToVy`、スキーマ drift の温床」に違反)。version chain に正規化し、失敗時は例外を伝播させて transaction を rollback するよう変更。
 - **最終スキーマは不変**: 新規 DB は `CREATE TABLE games` で従来どおり `arguments` を持ち、`MigrateV13ToV14` は `TableHasColumn` で idempotent (= 列がある DB では no-op)。`ExpectedSchema` / SPEC §7.3 とも差分なし。retrofit が必要なのは arguments 列を持たない旧 DB のみ。
+- **v0 (versioning 導入前) DB の retrofit を維持** (Codex P1): `user_version=0` の旧 DB は `CheckAndMigrateDatabase` の早期 stamp path で chain を skip するため、`MigrateV13ToV14` をその path 内でも明示実行。これで旧実装 (`CreateTables` 内 retrofit) と同じ v0 カバレッジを保ち、列欠落のまま `no such column: arguments` で落ちる回帰を防ぐ。
 - `MigrateGamesTable` (games の `supported_connection` / `version` 追加) は `games.arguments` を参照しないことを確認済みで、retrofit を chain (= `MigrateGamesTable` の後) に移しても初期化中の依存は発生しない。
 
 #### Bump 根拠 (v0.16.2 → v0.16.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1277,9 +1277,13 @@ minor bump 判断: SemVer pre-1.0 原則 (= 0.x で breaking change は minor bu
 - **画面遷移失敗時に復帰演出フラグを汚さないようガード** (`playing.gd`): `change_scene_to_file` の戻り値を確認し、失敗時は `AppState.returning_from_game` / `returning_from_quit` を設定せず early return。成功時のフラグ設定は deferred 遷移より前なので新シーンの `_ready` から正しく参照される。
 - `version.gd` の stale なマイルストーンコメントを削除し、ファイル責務の記述に置換。
 
+#### Changed
+
+- **対応 DB スキーマを v13 → v14 に追従** (`database_manager.gd` `CURRENT_DB_VERSION`)。v14 は Manager 側で `games.arguments` を正規 migration 化しただけで最終スキーマは不変、Launcher は `arguments` を既に扱えるため定数追従のみ (マイグレーション不要、§8.2 #5 の共有定数規約)。これで本番 DB(v14) 起動時の「対応版より新しい」警告とサービスモードの DB バージョン非一致表示を防ぐ。
+
 #### Bump 根拠 (v0.9.0 → v0.9.1)
 
-bugfix のみのため SemVer patch (`version.gd` PATCH 0→1)。挙動変更は失敗経路の早期検知 / ログ精度向上に限定、正常系は不変。
+bugfix + DB 対応版数の追従のため SemVer patch (`version.gd` PATCH 0→1)。挙動変更は失敗経路の早期検知 / ログ精度向上に限定、DB 追従は読み取り専用で破壊的変更なし。
 
 ### [Launcher v0.9.0] - 2026-05-27
 
@@ -1893,9 +1897,15 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 - **`GameRepository.ReadGameInfo` の `arguments` 読み取りで silent な握り潰しを解消**: `try { … } catch { }` で例外を完全に飲み込んでおり、コメント「GetAll uses display_version alias which doesn't include arguments」も誤り (GetAll / GetById 双方の SELECT に `arguments` を含む)。catch を削除して直接読み取りに変更。将来 SELECT から `arguments` が誤って外れても例外が表面化するようになり、`Arguments` の隠れた null 化経路を排除。
 - **`DatabaseConnection.ExecuteWithRetry<T>` の到達不能 `return default(T)` を例外に変更**: ループは「成功で return」「最終 retry で throw」のいずれかで必ず抜けるため到達しないが、万一 `maxRetries<=0` 等で到達した場合に `null` / `0` を silent に返さず `InvalidOperationException` を投げるよう変更 (将来の制御フロー変更時の silent failure 予防)。
 
+#### Changed (スキーマ drift 解消: games.arguments を正規 migration 化、DB v13 → v14)
+
+- **`games.arguments` の追加を `CreateTables()` 内アドホック ALTER から `MigrateV13ToV14` に移設** (`CurrentDbVersion` 13 → 14)。旧実装は (a) `user_version` に連動せず毎起動 `PRAGMA table_info` で存在チェックして足す野良 migration で、(b) 失敗を `catch` で握り潰していた (AGENTS.md「`CreateTables()` を編集したら必ず `MigrateVxToVy`、スキーマ drift の温床」に違反)。version chain に正規化し、失敗時は例外を伝播させて transaction を rollback するよう変更。
+- **最終スキーマは不変**: 新規 DB は `CREATE TABLE games` で従来どおり `arguments` を持ち、`MigrateV13ToV14` は `TableHasColumn` で idempotent (= 列がある DB では no-op)。`ExpectedSchema` / SPEC §7.3 とも差分なし。retrofit が必要なのは arguments 列を持たない旧 DB のみ。
+- `MigrateGamesTable` (games の `supported_connection` / `version` 追加) は `games.arguments` を参照しないことを確認済みで、retrofit を chain (= `MigrateGamesTable` の後) に移しても初期化中の依存は発生しない。
+
 #### Bump 根拠 (v0.16.2 → v0.16.3)
 
-SemVer pre-1.0 patch bump: bugfix のみ。挙動変更は隠れた失敗経路の顕在化に限定、正常系は不変。
+SemVer pre-1.0 patch bump: bugfix + 内部マイグレーション hygiene のみ。`games.arguments` 移設は最終スキーマ不変 (= ユーザー影響なし) で、隠れた失敗経路の顕在化に限定。DB v13 → v14 bump は migration を版数管理下に置くためで、新規 install / 既存 DB ともに挙動互換。
 
 ### [Manager v0.16.2] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@
 
 #### Fixed (累積コードレビュー指摘の対応)
 
-- **`Clear-OldGodot` の version ソートを文字列辞書順 → `[version]` 数値比較に修正**: 旧 `Sort-Object Name -Descending` は文字列順のため Godot が `4.10.x` 系に達すると `4.9.x` を「より新しい」と誤判定し、最新版を古い版として削除する時限バグだった (現状 4.6.x のみで未発火)。`Where-Object { $_.Name -as [version] }` で非 version dir を削除対象から除外しつつ (cast 例外で cleanup phase が落ちるのも防ぐ)、`Sort-Object { [version]$_.Name }` で数値比較に変更。
+- **`Clear-OldGodot` の version ソートを文字列辞書順 → `[version]` 数値比較に修正**: 旧 `Sort-Object Name -Descending` は文字列順のため Godot が `4.10.x` 系に達すると `4.9.x` を「より新しい」と誤判定し、最新版を古い版として削除する時限バグだった (現状 4.6.x のみで未発火)。`Where-Object { $_.Name -as [version] }` で非 version dir を削除対象から除外しつつ (cast 例外で cleanup phase が落ちるのも防ぐ)、`Sort-Object { [version]$_.Name }` で数値比較に変更。非 version 名 dir (pre-release suffix 付き等) が混ざっていた場合は無言で蓄積しないよう warn を 1 行出す。
 - **起動バナーの `(Phase 1)` 表記を削除**: Phase 2 / 3 完成済 (`.DESCRIPTION` と整合) なのにバナーだけ旧 Phase 表記が残り、実行者の誤読源になっていた。
 
 bump 判断: 配布スクリプトの bugfix のみ。patch (v0.1.21 → v0.1.22)。Bundle への反映は次回リリース実行時。
@@ -1273,7 +1273,7 @@ minor bump 判断: SemVer pre-1.0 原則 (= 0.x で breaking change は minor bu
 #### Fixed (累積コードレビュー指摘の対応)
 
 - **DB オープン失敗の silent success を解消** (`database_manager.gd`): `db.open_db()` の戻り値を無視し、後続の `if db == null` が常に false の dead code だったため、パス不正 / 権限不足 / ロック等で DB を開けなくても `open()` が `true` を返していた。戻り値で判定し、失敗時は `db = null` をセットして `false` を返すよう修正。これにより「DB を開けないのにゲーム 0 件として正常起動」する経路が塞がれる。
-- **ゲーム起動失敗時のログを ERROR レベル化** (`game_session.gd`): 実行ファイル未検出 / プロセス起動失敗の経路が `print("❌ …")` だったのを、同ファイルの既存パターンに揃えて `push_error` に変更 (ログのレベルフィルタで追跡可能に)。
+- **ゲーム起動失敗時のログを ERROR レベル化** (`game_session.gd`): 実行ファイル未検出 / プロセス起動失敗の経路が `print("❌ …")` だったのを、同ファイルの既存パターンに揃えて `push_error` に変更 (ログのレベルフィルタで追跡可能に)。あわせて `database_manager.gd` `open()` の失敗経路 (DB ファイル不在 / オープン失敗) も同じ理由で `push_error` に昇格。
 - **画面遷移失敗時に復帰演出フラグを汚さないようガード** (`playing.gd`): `change_scene_to_file` の戻り値を確認し、失敗時は `AppState.returning_from_game` / `returning_from_quit` を設定せず early return。成功時のフラグ設定は deferred 遷移より前なので新シーンの `_ready` から正しく参照される。
 - `version.gd` の stale なマイルストーンコメントを削除し、ファイル責務の記述に置換。
 

--- a/Launcher/scenes/playing.gd
+++ b/Launcher/scenes/playing.gd
@@ -158,6 +158,12 @@ func _on_game_exited() -> void:
 	# トランジション無しで瞬時に game_selection へ。game_selection 側が起動中画面と同じ
 	# running-view 静止状態 (プレイ中表示・背景 1.05) を再現し、起動モーションの逆再生
 	# (switch_to_normal_view: 背景ズームアウト + カルーセルフェードイン) でカルーセルへ戻る。
+	# change_scene_to_file は実遷移をフレーム末に deferred 実行するため、戻り値で即時失敗
+	# (シーンロード不可) を検知できる。失敗時は AppState フラグを汚さず復帰演出の誤再生を防ぐ。
+	# 成功時のフラグ設定は deferred 遷移より前なので、新シーンの _ready から正しく参照される。
+	var err := get_tree().change_scene_to_file("res://scenes/game_selection.tscn")
+	if err != OK:
+		push_error("[Playing] game_selection への遷移に失敗 (err=%d)" % err)
+		return
 	AppState.returning_from_game = true
 	AppState.returning_from_quit = _quit_shown  # 終了中を見せた場合は復帰再現も「終了中」で連続させる
-	get_tree().change_scene_to_file("res://scenes/game_selection.tscn")

--- a/Launcher/scripts/database_manager.gd
+++ b/Launcher/scripts/database_manager.gd
@@ -32,12 +32,11 @@ func open() -> bool:
 	# データベースパスを設定
 	db.path = db_path
 
-	# データベースを開く（godot-sqliteのAPI）
-	db.open_db()
-
-	# データベースが開けたか確認（エラーが発生した場合はdbがnullになる可能性がある）
-	if db == null:
+	# データベースを開く（godot-sqliteのAPI）。失敗時 (パス不正・権限不足・ロック等) は
+	# false が返る。db オブジェクト自体は非 null のままなので、戻り値で必ず判定する。
+	if not db.open_db():
 		print("[DatabaseManager] Error: データベースを開けませんでした: " + db_path)
+		db = null
 		return false
 
 	print("[DatabaseManager] データベースを開きました: ", db_path)

--- a/Launcher/scripts/database_manager.gd
+++ b/Launcher/scripts/database_manager.gd
@@ -25,7 +25,7 @@ func open() -> bool:
 
 	# データベースファイルが存在するか確認
 	if not FileAccess.file_exists(db_path):
-		print("[DatabaseManager] Error: データベースファイルが見つかりません: " + db_path)
+		push_error("[DatabaseManager] データベースファイルが見つかりません: " + db_path)
 		return false
 
 	# SQLiteインスタンスを作成
@@ -37,7 +37,7 @@ func open() -> bool:
 	# データベースを開く（godot-sqliteのAPI）。失敗時 (パス不正・権限不足・ロック等) は
 	# false が返る。db オブジェクト自体は非 null のままなので、戻り値で必ず判定する。
 	if not db.open_db():
-		print("[DatabaseManager] Error: データベースを開けませんでした: " + db_path)
+		push_error("[DatabaseManager] データベースを開けませんでした: " + db_path)
 		db = null
 		return false
 

--- a/Launcher/scripts/database_manager.gd
+++ b/Launcher/scripts/database_manager.gd
@@ -11,8 +11,10 @@ var db_path: String = ""
 # Launcher が想定する DB スキーマバージョン
 # Manager 側 SchemaManager.cs の CurrentDbVersion と歩調を合わせること
 # (v9, v10, v12 は backup_log 関連 / v13 は manager_sessions で Launcher は触らない /
-#  v11 の surveys・play_records 新スキーマには Launcher のクエリが既に対応済 → 単に定数追従のみ)
-const CURRENT_DB_VERSION: int = 13
+#  v11 の surveys・play_records 新スキーマには Launcher のクエリが既に対応済 /
+#  v14 は games.arguments の正規 migration 化のみで最終スキーマ不変・Launcher は arguments 対応済
+#  → いずれも単に定数追従のみ)
+const CURRENT_DB_VERSION: int = 14
 
 ## データベースを開く
 func open() -> bool:

--- a/Launcher/scripts/game_session.gd
+++ b/Launcher/scripts/game_session.gd
@@ -84,7 +84,7 @@ func start_process() -> bool:
 
 	var exe_path := GamePathResolver.find_executable(game)
 	if exe_path.is_empty():
-		print("❌ Executable not found: ", game.executable_path)
+		push_error("[GameSession] Executable not found: " + str(game.executable_path))
 		ErrorManager.show_error(ErrorCode.GAME_EXECUTABLE_NOT_FOUND)
 		_is_launching = false
 		current_game = null
@@ -102,7 +102,7 @@ func start_process() -> bool:
 
 	var pid := OS.create_process("cmd.exe", ["/C", cmd_command])
 	if pid == -1:
-		print("❌ Failed to create process.")
+		push_error("[GameSession] Failed to create process: " + str(exe_path))
 		ErrorManager.show_error(ErrorCode.GAME_EXECUTION_FAILED)
 		_is_launching = false
 		current_game = null

--- a/Launcher/version.gd
+++ b/Launcher/version.gd
@@ -1,8 +1,7 @@
 extends RefCounted
 class_name Version
 
-## ランチャーのバージョン情報
-## マイルストーン5: StoreBrowse画面（UI改善・レスポンス向上）
+## ランチャーのバージョン情報 (Launcher 版数定数の SoT)
 ##
 ## DO NOT CHANGE FORMAT: Manager parses these 3 const lines (#108 Phase 4 #161 round 5 M-5)
 ## `Manager/Services/VersionInventory.cs` の MajorRegex / MinorRegex / PatchRegex が
@@ -12,7 +11,7 @@ class_name Version
 
 const MAJOR: int = 0
 const MINOR: int = 9
-const PATCH: int = 0
+const PATCH: int = 1
 
 static func get_version_string() -> String:
 	return "v%d.%d.%d" % [MAJOR, MINOR, PATCH]

--- a/Manager/DatabaseConnection.cs
+++ b/Manager/DatabaseConnection.cs
@@ -75,7 +75,9 @@ namespace TonePrism.Manager
                     Thread.Sleep(delayMs);
                 }
             }
-            return default(T);
+            // ループは「成功時 return」「最終 retry で throw」のいずれかで必ず抜けるため到達しない。
+            // 万一 maxRetries<=0 等で到達した場合に default(T) を silent に返さず、明示的に失敗させる。
+            throw new InvalidOperationException("ExecuteWithRetry: unreachable (maxRetries 指定が不正の可能性)");
         }
 
         /// <summary>

--- a/Manager/Properties/AssemblyInfo.cs
+++ b/Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.16.2.0")]
-[assembly: AssemblyFileVersion("0.16.2.0")]
+[assembly: AssemblyVersion("0.16.3.0")]
+[assembly: AssemblyFileVersion("0.16.3.0")]

--- a/Manager/Repositories/GameRepository.cs
+++ b/Manager/Repositories/GameRepository.cs
@@ -341,12 +341,8 @@ namespace TonePrism.Manager.Repositories
                 game.Genre = new List<string>();
             }
 
-            // GetAll uses display_version alias which doesn't include arguments
-            try
-            {
-                game.Arguments = reader["arguments"] is DBNull ? null : reader["arguments"].ToString();
-            }
-            catch { }
+            // GetAll / GetById の SELECT は両方 arguments を含むため直接読む。
+            game.Arguments = reader["arguments"] is DBNull ? null : reader["arguments"].ToString();
 
             return game;
         }

--- a/Manager/SchemaManager.cs
+++ b/Manager/SchemaManager.cs
@@ -20,7 +20,9 @@ namespace TonePrism.Manager
         // v11: SPEC v1.5.1 (2026-03-28) で変更された surveys / play_records スキーマの drift 修正（v0.8.1）
         // v12: backup_log に relative_path 列追加 (#127、v0.8.2)
         // v13: manager_sessions テーブル新設 (#179、Manager LAN-wide 同時起動検出、v0.10.0)
-        private const int CurrentDbVersion = 13;
+        // v14: games.arguments を CreateTables 内アドホック ALTER から正規 MigrateV13ToV14 に移設
+        //      (累積レビュー / AGENTS.md スキーマ drift 規約準拠、v0.16.3)。最終スキーマは不変。
+        private const int CurrentDbVersion = 14;
 
         public SchemaManager(DatabaseConnection conn)
         {
@@ -280,37 +282,8 @@ namespace TonePrism.Manager
                 command.ExecuteNonQuery();
             }
 
-            // 既存のgamesテーブルにargumentsカラムがない場合は追加（マイグレーション）
-            try
-            {
-                using (var command = new SQLiteCommand("PRAGMA table_info(games)", connection, transaction))
-                {
-                    bool hasArgumentsColumn = false;
-                    using (var reader = command.ExecuteReader())
-                    {
-                        while (reader.Read())
-                        {
-                            if (reader["name"].ToString() == "arguments")
-                            {
-                                hasArgumentsColumn = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!hasArgumentsColumn)
-                    {
-                        using (var alterCommand = new SQLiteCommand("ALTER TABLE games ADD COLUMN arguments TEXT", connection, transaction))
-                        {
-                            alterCommand.ExecuteNonQuery();
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"Migration failed (arguments)", ex);
-            }
+            // games.arguments の既存 DB への retrofit は MigrateV13ToV14 (version chain) で行う。
+            // 新規 DB は上の CREATE TABLE で arguments を持つため CreateTables 側での ALTER は不要。
 
             // game_versionsテーブル作成
             string createGameVersionsTable = @"
@@ -835,6 +808,24 @@ namespace TonePrism.Manager
                         else
                         {
                             Logger.Warn("[DatabaseManager] 直前の migration が未完のため user_version は " + currentVersion + " のまま据え置き (v13 物理変更のみ先行適用)");
+                        }
+                    }
+
+                    if (currentVersion < 14)
+                    {
+                        // v13 → v14: games.arguments を正規 migration 化 (旧 CreateTables 内アドホック
+                        // ALTER から移設)。TableHasColumn で idempotent (= 既に列があれば no-op)。
+                        // games.arguments は他 migration と独立かつ最終スキーマ不変なので、v12/v13 と同じ
+                        // guard pattern で「直前 migration 未完なら user_version 据え置き」を踏襲。
+                        MigrateV13ToV14(connection, migTransaction);
+
+                        if (currentVersion >= 13)
+                        {
+                            currentVersion = 14;
+                        }
+                        else
+                        {
+                            Logger.Warn("[DatabaseManager] 直前の migration が未完のため user_version は " + currentVersion + " のまま据え置き (v14 物理変更のみ先行適用)");
                         }
                     }
 
@@ -1458,6 +1449,32 @@ namespace TonePrism.Manager
             // 誤読されない表記 (round 2 Info-2)。
             CreateManagerSessionsTable(connection, transaction);
             Logger.Info("[DatabaseManager] v12 → v13 migration 完了 (manager_sessions table 確保)");
+        }
+
+        /// <summary>
+        /// v13 → v14: games.arguments 列を追加。以前は CreateTables() 内のアドホック ALTER
+        /// (user_version 非連動・毎起動の存在チェック・失敗握り潰し) だったものを version chain に
+        /// 移設し、AGENTS.md「CreateTables() を編集したら必ず MigrateVxToVy」規約に整合させたもの。
+        /// 新規 DB は CreateTables の CREATE TABLE で既に arguments を持つため、本 migration は
+        /// arguments 列を持たない旧 DB の retrofit 専用。TableHasColumn で idempotent。
+        /// 失敗時は例外を伝播させ、呼び出し元 (CheckAndMigrateDatabase / InitializeDatabase) の
+        /// トランザクションが rollback される (旧実装の silent な握り潰しを廃止)。
+        /// </summary>
+        private void MigrateV13ToV14(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            if (!TableHasColumn(connection, transaction, "games", "arguments"))
+            {
+                Logger.Info("[DatabaseManager] v13 → v14: games.arguments 列を追加します");
+                using (var command = new SQLiteCommand("ALTER TABLE games ADD COLUMN arguments TEXT", connection, transaction))
+                {
+                    command.ExecuteNonQuery();
+                }
+                Logger.Info("[DatabaseManager] v13 → v14 migration 完了 (games.arguments 追加)");
+            }
+            else
+            {
+                Logger.Info("[DatabaseManager] v13 → v14: games.arguments は既に存在 (skip)");
+            }
         }
 
         /// <summary>

--- a/Manager/SchemaManager.cs
+++ b/Manager/SchemaManager.cs
@@ -683,6 +683,15 @@ namespace TonePrism.Manager
 
             if (currentVersion == 0)
             {
+                // 新規 DB は CreateTables が最新スキーマを作るので stamp して返すだけでよい。
+                // ただし versioning 導入前 (user_version=0 のまま) に games テーブルだけ存在する
+                // 旧 DB は games.arguments を欠く場合がある。この列は他の games 列
+                // (supported_connection / version、MigrateGamesTable で無条件 backfill) と違い
+                // version chain (MigrateV13ToV14) 管理に移したため、v0 で chain を skip すると
+                // 永久に追加されず GameRepository の SELECT/INSERT が "no such column: arguments"
+                // で失敗する (Codex P1)。idempotent な MigrateV13ToV14 を stamp 前に明示実行して
+                // 旧実装 (CreateTables 内 retrofit) と同じ v0 カバレッジを保つ。
+                MigrateV13ToV14(connection, transaction);
                 SetDbVersion(connection, CurrentDbVersion, transaction);
                 return;
             }

--- a/Release.ps1
+++ b/Release.ps1
@@ -2030,7 +2030,12 @@ function Clear-OldGodot {
     if (Test-Path $ToolsGodot) {
         # version 番号は文字列辞書順だと 4.10 < 4.9 と誤判定するため [version] cast で数値比較する。
         # `-as [version]` が $null になる非 version dir は削除対象から除外 (cast 例外で cleanup が落ちるのも防ぐ)。
-        $dirs = @(Get-ChildItem $ToolsGodot -Directory |
+        $allGodotDirs = @(Get-ChildItem $ToolsGodot -Directory)
+        # 非 version 名 dir (例: pre-release suffix 付き) は cleanup 対象外。無言で蓄積しないよう warn を出す。
+        foreach ($nv in @($allGodotDirs | Where-Object { -not ($_.Name -as [version]) })) {
+            Write-Warn "tools/godot/$($nv.Name) は version 形式でないため cleanup 対象外 (蓄積に注意)"
+        }
+        $dirs = @($allGodotDirs |
             Where-Object { $_.Name -as [version] } |
             Sort-Object { [version]$_.Name } -Descending)
         if ($dirs.Count -gt 2) {

--- a/Release.ps1
+++ b/Release.ps1
@@ -2028,7 +2028,11 @@ function Clear-OldGodot {
 
     # サーバー側 tools/godot/<version>/ は最新 2 version まで残す
     if (Test-Path $ToolsGodot) {
-        $dirs = @(Get-ChildItem $ToolsGodot -Directory | Sort-Object Name -Descending)
+        # version 番号は文字列辞書順だと 4.10 < 4.9 と誤判定するため [version] cast で数値比較する。
+        # `-as [version]` が $null になる非 version dir は削除対象から除外 (cast 例外で cleanup が落ちるのも防ぐ)。
+        $dirs = @(Get-ChildItem $ToolsGodot -Directory |
+            Where-Object { $_.Name -as [version] } |
+            Sort-Object { [version]$_.Name } -Descending)
         if ($dirs.Count -gt 2) {
             $toDelete = @($dirs | Select-Object -Skip 2)
             foreach ($d in $toDelete) {
@@ -2075,7 +2079,7 @@ function Clear-OldGodot {
 # ============================================================================
 
 Write-Host ""
-Write-Host "TonePrism Release Script (Phase 1)" -ForegroundColor White
+Write-Host "TonePrism Release Script" -ForegroundColor White
 Write-Host "Bundle Version: $Version" -ForegroundColor White
 Write-Host "RepoRoot:       $RepoRoot" -ForegroundColor White
 if ($DryRun)     { Write-Host "Mode: DRY-RUN (zip と upload を skip)" -ForegroundColor Yellow }


### PR DESCRIPTION
## 概要

毎日回していた全体コードレビューで**繰り返し挙がっていた未解決の指摘**を、現コードと突き合わせて確認のうえ修正するバグ修正 PR です。多くの指摘は既に解決済み（`gh auth status` / brand rename sweep / `Console.WriteLine`→`Logger` 等）でしたが、以下は残っていたため対応しました。

## 修正内容

### Launcher (v0.9.0 → v0.9.1)
- **`database_manager.gd`**: `db.open_db()` の戻り値を無視し、後続の `if db == null` が常に false の dead code だったため、パス不正 / 権限不足 / ロック等で DB を開けなくても `open()` が `true` を返していた。戻り値で判定し失敗時 `db=null` + `return false` に修正。→ 「DB を開けないのにゲーム0件で正常起動」する silent failure を解消。
- **`game_session.gd`**: 実行ファイル未検出 / プロセス起動失敗の `print("❌…")` を `push_error` に（ERROR レベル化）。
- **`playing.gd`**: `change_scene_to_file` の戻り値を確認し、失敗時は `AppState.returning_from_*` を設定せず early return。
- **`version.gd`**: stale なマイルストーンコメントを削除。
- **対応 DB スキーマ v13 → v14 に追従**（`CURRENT_DB_VERSION`、§8.2 #5 の共有定数規約）。

### Manager (v0.16.2 → v0.16.3)
- **`GameRepository.ReadGameInfo`**: `arguments` 読み取りの `catch {}` を削除（GetAll/GetById 双方の SELECT に `arguments` を含むため直接読み取り。コメントの記述も誤りだった）。隠れた null 化経路を排除。
- **`DatabaseConnection.ExecuteWithRetry<T>`**: 到達不能な `return default(T)` を `InvalidOperationException` に変更（silent な null/0 返却の予防）。
- **スキーマ drift 解消（DB v13 → v14）**: `games.arguments` の追加を `CreateTables()` 内の野良 ALTER（`user_version` 非連動・毎起動の存在チェック・失敗握り潰し）から正規 `MigrateV13ToV14` に移設。AGENTS.md「`CreateTables()` を編集したら必ず `MigrateVxToVy`」規約に整合。**最終スキーマは不変**（新規 DB は CREATE TABLE で arguments を持ち、retrofit は `TableHasColumn` で idempotent）。失敗時は例外を伝播させ transaction を rollback。

### Release Tooling (v0.1.21 → v0.1.22)
- **`Clear-OldGodot`**: version ソートを文字列辞書順 → `[version]` 数値比較に修正（`4.10 < 4.9` 誤判定の時限バグ。現状 4.6.x のみで未発火。非 version dir 除外ガードも追加）。
- 起動バナーの `(Phase 1)` 表記を削除。

## DB v13 → v14 の安全性
本番マシンが**まっさらな新規インストール**である前提（確認済み）で実施。
- 新規 DB: `CREATE TABLE games` で従来どおり `arguments` を持つ → `user_version=0` でチェーンをスキップしても列は存在。
- 既存 DB: チェーンが `MigrateV13ToV14` を走らせるが `TableHasColumn` で idempotent（列があれば no-op）。
- `MigrateGamesTable` が `games.arguments` を参照しないことを確認済みで、retrofit をチェーン（= `MigrateGamesTable` の後）に移しても初期化中の依存は発生しない。
- `ExpectedSchema` / SPEC §7.3 とも差分なし（スキーマ定義は不変、migration 機構のみ変更）。

## バージョン / CHANGELOG
- Launcher / Manager / Release Tooling を各 PATCH bump、CHANGELOG の対応セクションに履歴を追記（1 PR 1 bump 準拠で既存エントリに集約）。
- Bundle bump はリリース実行時に行うため本 PR では実施せず。

## なお対応を見送ったもの（理由つき）
- **`VersionInventory` への LauncherAgent 表示追加（最新レビュー High）**: WinForms Designer のラベル追加が必要で UI を実機表示して検証できないため別タスク推奨。
- **SQL テーブル名の文字列補間 / `path_manager.gd` の `ends_with("Launcher")`**: 前者は呼び出し元が全てハードコードで実害なし（防御的のみ）、後者はコード内で issue #151 に明示的に deferred 済み。
- ※「README の Visual Studio 2026 は誤記」はレビューエージェント側の知識が古い誤判定（VS 2026 は実在）のため対応せず。

## テスト
- [x] Manager (C#) を MSBuild (VS2026) でビルド確認
- [ ] **要確認**: 本番コピーの `toneprism.db` で Manager を起動し、v13 → v14 migration がクリーンに走ること（ログに「v13 → v14: games.arguments は既に存在 (skip)」or「追加します」）
- [ ] Launcher (Godot) の起動確認（DB v14 で「対応版より新しい」警告が出ないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)