### PR TITLE
test(manager): C# テスト基盤 0→1 + F-1 (v19→v20 子テーブル保全) を自動回帰化 (#239)

### DIFF
--- a/.github/workflows/manager-tests.yml
+++ b/.github/workflows/manager-tests.yml
@@ -5,14 +5,14 @@ name: Manager Tests
 # PackageReference 復元 (dotnet) と packages.config 復元 (nuget) の両方を行ってから dotnet test する。
 # net48 + System.Data.SQLite native interop のため Windows runner を使う。
 
+# (レビュー #1/#2) paths フィルタは付けない。将来この job を branch protection の required status check に
+# する場合、Manager 配下を触らない PR では job が起動せず、required check が永久 "Expected/Pending" のまま
+# merge をブロックする GHA の落とし穴を避けるため。push(main) / PR とも無条件で実行し対称化する。テストは
+# 数秒で、コストは runner 起動分のみ (docs PR 等も走るが required ゲート化を優先)。
 on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - "Manager/**"
-      - "Manager.Tests/**"
-      - ".github/workflows/manager-tests.yml"
 
 jobs:
   test:

--- a/.github/workflows/manager-tests.yml
+++ b/.github/workflows/manager-tests.yml
@@ -1,0 +1,37 @@
+name: Manager Tests
+
+# (#239) Manager のデータ層テスト (スキーマ移行 F-1 / 保存 round-trip) を PR・main push のたびに自動実行。
+# テスト基盤は SDK-style net48 + xUnit。本体 Manager は classic (packages.config) なので、SDK の
+# PackageReference 復元 (dotnet) と packages.config 復元 (nuget) の両方を行ってから dotnet test する。
+# net48 + System.Data.SQLite native interop のため Windows runner を使う。
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "Manager/**"
+      - "Manager.Tests/**"
+      - ".github/workflows/manager-tests.yml"
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+
+      # 本体 Manager の packages.config を復元 (dotnet は packages.config を復元しないため nuget で)
+      - name: Restore Manager (packages.config)
+        run: nuget restore Manager\packages.config -PackagesDirectory Manager\packages
+
+      # テストプロジェクトの PackageReference 復元 + Manager の build + テスト実行
+      - name: Run Manager tests
+        run: dotnet test Manager.Tests\TonePrism_Manager.Tests.csproj -c Debug --nologo --verbosity minimal

--- a/Manager.Tests/DataLayerRoundTripTests.cs
+++ b/Manager.Tests/DataLayerRoundTripTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SQLite;
+using System.IO;
+using TonePrism.Manager;
+using TonePrism.Manager.Models;
+using TonePrism.Manager.Repositories;
+using Xunit;
+
+namespace TonePrism.Manager.Tests
+{
+    /// <summary>
+    /// (#239) データ層の round-trip / スキーマ初期化テスト。
+    /// 一時 DB を `DatabaseConnection(string dbPath)` で指して、PathManager のプロジェクトルート検出に
+    /// 依存せず SchemaManager / repository を単体で回す。
+    /// </summary>
+    public class DataLayerRoundTripTests : IDisposable
+    {
+        private readonly string _dbPath;
+        private readonly DatabaseConnection _conn;
+
+        public DataLayerRoundTripTests()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), "tp_test_" + Guid.NewGuid().ToString("N") + ".db");
+            _conn = new DatabaseConnection(_dbPath);
+            new SchemaManager(_conn).InitializeDatabase();
+        }
+
+        public void Dispose()
+        {
+            try { SQLiteConnection.ClearAllPools(); } catch { /* ignore */ }
+            foreach (var p in new[] { _dbPath, _dbPath + "-wal", _dbPath + "-shm", _dbPath + "-journal" })
+            {
+                try { if (File.Exists(p)) File.Delete(p); } catch { /* ignore */ }
+            }
+        }
+
+        [Fact]
+        public void FreshDb_InitializeDatabase_ReachesTargetVersion()
+        {
+            var schema = new SchemaManager(_conn);
+            Assert.Equal(schema.GetTargetDatabaseVersion(), schema.GetActualDatabaseVersion());
+            Assert.True(schema.TablesExist());
+        }
+
+        [Fact]
+        public void GameRepository_AddThenGetById_RoundTripsCoreFields()
+        {
+            var devRepo = new DeveloperRepository(_conn);
+            var gameRepo = new GameRepository(_conn, devRepo);
+
+            var game = new GameInfo
+            {
+                GameId = "round_trip_test",
+                Title = "ラウンドトリップ確認",
+                Description = "説明",
+                ReleaseYear = 2026,
+                MinPlayers = 1,
+                MaxPlayers = 2,
+                Difficulty = 2,
+                PlayTime = 3,
+                ControllerSupport = true,
+                SupportedConnection = 1,
+                IsVisible = true,
+                Version = "v1.0.0",
+                Genre = new List<string> { "アクション" },
+                Developers = new List<DeveloperInfo>(),
+            };
+            gameRepo.Add(game);
+
+            var read = gameRepo.GetById("round_trip_test");
+
+            Assert.NotNull(read);
+            Assert.Equal(game.GameId, read.GameId);
+            Assert.Equal(game.Title, read.Title);
+            Assert.Equal(game.Description, read.Description);
+            Assert.Equal(game.ReleaseYear, read.ReleaseYear);
+            Assert.Equal(game.MinPlayers, read.MinPlayers);
+            Assert.Equal(game.MaxPlayers, read.MaxPlayers);
+            Assert.Equal(game.Difficulty, read.Difficulty);
+            Assert.Equal(game.PlayTime, read.PlayTime);
+            Assert.True(read.ControllerSupport);
+            Assert.Equal(game.SupportedConnection, read.SupportedConnection);
+            Assert.Equal("v1.0.0", read.Version);
+            Assert.Contains("アクション", read.Genre);
+        }
+    }
+}

--- a/Manager.Tests/SchemaMigrationTests.cs
+++ b/Manager.Tests/SchemaMigrationTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using TonePrism.Manager;
+using Xunit;
+
+namespace TonePrism.Manager.Tests
+{
+    /// <summary>
+    /// (#239 / F-1) 既存 DB の in-place スキーマ移行が子テーブルを CASCADE で消さないことの自動回帰テスト。
+    /// 最高 blast-radius な v19 → v20 の `games` 親テーブル recreate を、実データ入りの v19 状態 DB で検証する。
+    /// これまで手動 (sqlite3 + 実機 Manager) でしか確認できなかった F-1 を自動化し、net10 移行 (Phase 4) の
+    /// data-core 再検証ゲートとしても効かせる。
+    /// </summary>
+    public class SchemaMigrationTests : IDisposable
+    {
+        private readonly string _dbPath;
+
+        public SchemaMigrationTests()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), "tp_mig_" + Guid.NewGuid().ToString("N") + ".db");
+        }
+
+        public void Dispose()
+        {
+            try { SQLiteConnection.ClearAllPools(); } catch { /* ignore */ }
+            foreach (var p in new[] { _dbPath, _dbPath + "-wal", _dbPath + "-shm", _dbPath + "-journal" })
+            {
+                try { if (File.Exists(p)) File.Delete(p); } catch { /* ignore */ }
+            }
+        }
+
+        [Fact]
+        public void V19ToV20_GamesRecreate_PreservesChildRows_NoCascade()
+        {
+            BuildV19DbWithChildren(_dbPath, playTime: 2);
+
+            // in-place migration (v19 → v20、games 親テーブル recreate を foreign_keys=OFF で実行)
+            new SchemaManager(new DatabaseConnection(_dbPath)).InitializeDatabase();
+            SQLiteConnection.ClearAllPools();
+
+            using (var c = new SQLiteConnection($"Data Source={_dbPath};Version=3;"))
+            {
+                c.Open();
+                Assert.Equal(20L, ScalarLong(c, "PRAGMA user_version"));
+                // 子テーブルが CASCADE で巻き添え削除されていない
+                Assert.Equal(1L, ScalarLong(c, "SELECT COUNT(*) FROM games"));
+                Assert.Equal(2L, ScalarLong(c, "SELECT COUNT(*) FROM game_versions"));
+                Assert.Equal(1L, ScalarLong(c, "SELECT COUNT(*) FROM developers"));
+                Assert.Equal(1L, ScalarLong(c, "SELECT COUNT(*) FROM play_records"));
+                // FK 整合: foreign_key_check が違反行を返さない
+                using (var cmd = new SQLiteCommand("PRAGMA foreign_key_check", c))
+                using (var r = cmd.ExecuteReader())
+                {
+                    Assert.False(r.Read(), "foreign_key_check に違反行が残っている");
+                }
+                // play_time CHECK が付与された
+                var ddl = ScalarString(c, "SELECT sql FROM sqlite_master WHERE type='table' AND name='games'");
+                Assert.Contains("play_time INTEGER CHECK", ddl, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void V19ToV20_OutOfRangePlayTime_SkipsAndStaysV19_WithoutCrashOrDataLoss()
+        {
+            BuildV19DbWithChildren(_dbPath, playTime: 5); // 範囲外 (1-3 でない)
+
+            // 範囲外データ残存時は hard-fail せず skip + retry (user_version 据え置き、起動を止めない)
+            var ex = Record.Exception(() => new SchemaManager(new DatabaseConnection(_dbPath)).InitializeDatabase());
+            Assert.Null(ex); // クラッシュしない
+            SQLiteConnection.ClearAllPools();
+
+            using (var c = new SQLiteConnection($"Data Source={_dbPath};Version=3;"))
+            {
+                c.Open();
+                Assert.Equal(19L, ScalarLong(c, "PRAGMA user_version")); // 据え置き (次回是正後に適用)
+                Assert.Equal(2L, ScalarLong(c, "SELECT COUNT(*) FROM game_versions")); // 子は無事
+            }
+        }
+
+        /// <summary>
+        /// versioning 前の v19 状態 DB を raw SQL で構築する: `games` は v20 から play_time CHECK を除いた形、
+        /// 子テーブルは FK ON DELETE CASCADE。1 game + 2 versions + 1 developer + 1 play_record を投入。
+        /// </summary>
+        private static void BuildV19DbWithChildren(string dbPath, int playTime)
+        {
+            using (var c = new SQLiteConnection($"Data Source={dbPath};Version=3;"))
+            {
+                c.Open();
+                Exec(c, "PRAGMA foreign_keys=ON");
+                Exec(c, @"CREATE TABLE games (
+                    game_id TEXT PRIMARY KEY, title TEXT NOT NULL, description TEXT, release_year INTEGER,
+                    genre TEXT, min_players INTEGER, max_players INTEGER,
+                    difficulty INTEGER CHECK(difficulty BETWEEN 1 AND 3), play_time INTEGER,
+                    controller_support INTEGER DEFAULT 0, supported_connection INTEGER DEFAULT 0,
+                    thumbnail_path TEXT, background_path TEXT, executable_path TEXT,
+                    display_order INTEGER DEFAULT 0, is_visible INTEGER DEFAULT 1,
+                    controls TEXT, key_mapping TEXT, arguments TEXT, version TEXT)");
+                Exec(c, @"CREATE TABLE game_versions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, game_id TEXT NOT NULL, version TEXT NOT NULL,
+                    executable_path TEXT NOT NULL, arguments TEXT, description TEXT, title TEXT, genre TEXT,
+                    min_players INTEGER, max_players INTEGER, difficulty INTEGER, play_time INTEGER,
+                    controller_support INTEGER DEFAULT 0, supported_connection INTEGER DEFAULT 0,
+                    thumbnail_path TEXT, background_path TEXT, update_note TEXT, registered_at TEXT NOT NULL,
+                    FOREIGN KEY(game_id) REFERENCES games(game_id) ON DELETE CASCADE)");
+                Exec(c, @"CREATE TABLE developers (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, game_id TEXT, last_name TEXT, first_name TEXT,
+                    grade TEXT, version_id INTEGER,
+                    FOREIGN KEY(game_id) REFERENCES games(game_id) ON DELETE CASCADE,
+                    FOREIGN KEY(version_id) REFERENCES game_versions(id) ON DELETE CASCADE)");
+                Exec(c, @"CREATE TABLE play_records (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, game_id TEXT, start_time TEXT, end_time TEXT,
+                    play_duration INTEGER, player_count INTEGER,
+                    FOREIGN KEY(game_id) REFERENCES games(game_id) ON DELETE CASCADE)");
+
+                Exec(c, $"INSERT INTO games (game_id, title, difficulty, play_time, version) VALUES ('g1','Game 1',2,{playTime},'1.1.0')");
+                Exec(c, "INSERT INTO game_versions (game_id, version, executable_path, registered_at) VALUES ('g1','1.0.0','v1.0.0/g.exe','2026-01-01 00:00:00')");
+                Exec(c, "INSERT INTO game_versions (game_id, version, executable_path, registered_at) VALUES ('g1','1.1.0','v1.1.0/g.exe','2026-01-02 00:00:00')");
+                Exec(c, "INSERT INTO developers (game_id, last_name, first_name, grade) VALUES ('g1','山田','太郎','3')");
+                Exec(c, "INSERT INTO play_records (game_id, start_time, end_time, play_duration, player_count) VALUES ('g1','2026-01-01 10:00:00','2026-01-01 10:05:00',300,1)");
+
+                Exec(c, "PRAGMA user_version=19");
+            }
+        }
+
+        private static void Exec(SQLiteConnection c, string sql)
+        {
+            using (var cmd = new SQLiteCommand(sql, c)) cmd.ExecuteNonQuery();
+        }
+        private static long ScalarLong(SQLiteConnection c, string sql)
+        {
+            using (var cmd = new SQLiteCommand(sql, c)) return Convert.ToInt64(cmd.ExecuteScalar());
+        }
+        private static string ScalarString(SQLiteConnection c, string sql)
+        {
+            using (var cmd = new SQLiteCommand(sql, c)) { var o = cmd.ExecuteScalar(); return o?.ToString() ?? ""; }
+        }
+    }
+}

--- a/Manager.Tests/TonePrism_Manager.Tests.csproj
+++ b/Manager.Tests/TonePrism_Manager.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- (#239) C# テスト基盤 0→1。SDK-style + target net48 にすることで、net10 移行 (#245 Phase 4) 時は
+       TargetFramework を一行差し替えるだけで済む (テストコード・フレームワークはそのまま carry over)。
+       本体 Manager は classic (packages.config) のままで、本テストは SDK-style から ProjectReference する。 -->
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <RootNamespace>TonePrism.Manager.Tests</RootNamespace>
+    <AssemblyName>TonePrism_Manager.Tests</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <Platforms>AnyCPU</Platforms>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!-- Manager と同版の System.Data.SQLite + native interop (Stub が SQLite.Interop.dll を出力へコピー) -->
+    <PackageReference Include="Stub.System.Data.SQLite.Core.NetFramework" Version="1.0.119.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Manager\TonePrism_Manager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Manager/DatabaseConnection.cs
+++ b/Manager/DatabaseConnection.cs
@@ -16,9 +16,16 @@ namespace TonePrism.Manager
         public string ConnectionString => connectionString;
         public string DbPath => dbPath;
 
-        public DatabaseConnection()
+        public DatabaseConnection() : this(PathManager.DatabasePath) { }
+
+        /// <summary>
+        /// (#239 テスト基盤) 任意の DB パスを指定して接続を作る。production は `PathManager.DatabasePath` を使う
+        /// 既定 ctor 経由で、本 ctor は主にテストが一時 DB を指すために使う (PathManager のプロジェクトルート
+        /// 検出に依存せず `SchemaManager` / repository を単体で回せるようにする)。本体挙動は不変。
+        /// </summary>
+        public DatabaseConnection(string dbPath)
         {
-            dbPath = PathManager.DatabasePath;
+            this.dbPath = dbPath;
             // SMB ネットワーク共有上での運用安全性のため journal_mode=DELETE を使用 (#103)
             // Busy Timeout はライブラリ側にもフォールバックとして指定する
             connectionString = $"Data Source={dbPath};Version=3;Busy Timeout=10000;";


### PR DESCRIPTION
**Phase 0 の最後の土台**（#249）。C# テストプロジェクトを 0→1 で新設し、ずっと手動だった **F-1（既存DBの in-place 移行で子テーブルが CASCADE で消えないか）を自動回帰テスト化**。

## 構成
- SDK-style csproj（**target net48 / xUnit / System.Data.SQLite 1.0.119.0 = 本体と同版**）で classic な Manager を ProjectReference。→ **net10 移行(Phase 4)時は `<TargetFramework>` を一行差し替えるだけ**で carry over。
- テスト可能性: `DatabaseConnection(string dbPath)` ctor を追加（既定 ctor は `PathManager` 経由で**本体挙動不変**、テストは一時 DB を指す）。

## テスト 4 件（全緑）
1. フレッシュ DB `InitializeDatabase` → target version 到達 + `TablesExist`
2. `GameRepository` Add→GetById の**保存 round-trip**（入力=保存=再読込）
3. **F-1**: v19 実データ DB（games + 子3テーブル）の移行で `games` 親再作成しても**子が CASCADE で消えない** + `foreign_key_check` 0 + play_time CHECK 付与
4. **F-1**: 範囲外 play_time で **skip + user_version 19 据え置き + クラッシュ/データ損失なし**

## 実行
`dotnet test Manager.Tests/TonePrism_Manager.Tests.csproj`（ローカルで全4緑を確認済）

## 備考
- **バージョン bump なし**（test 基盤 + テスト専用 ctor、runtime 挙動不変）・CHANGELOG 対象外（dev インフラ）。
- net10 移行の data-core 再検証ゲートとして以後ずっと効く。

Closes #239