### PR TITLE
fix(manager): ゲームID 検証エラーを理由別文言に (#206, Manager v0.17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1916,6 +1916,7 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 #### Fixed (#206: ゲームID 検証エラーの理由別文言)
 
 - **ゲームID が無効なとき、理由に関わらず「英数字…のみ」固定文言を表示していた**: `GameFormHelper.IsValidGameId(string, out errorMessage)` は理由別文言 (空 / 64文字超 / 文字種 / Windows 予約名 `CON`/`PRN`/`NUL`/`COM1` 等) を返せるのに、`AddGameForm` / `EditGameForm` の呼び出しが bool-only overload + ハードコード文言を使い**理由を握り潰していた**。64文字超や予約名で弾かれた user にも「文字種が悪い」と誤誘導する状態だった。両 callsite を `out errorMessage` overload に切替え、返ってきた理由別文言をそのまま MessageBox 表示する。**検証ロジックは不変・表示文言のみ**。`docs/usage/games.md` (#106) の「保存時に Manager が知らせてくれる」記述とも整合。
+- **ID 重複エラーの文言が Add / Edit で不統一だった (follow-up)**: 追加 (`AddGameForm`: 「このゲームIDは既に…別のIDを入力してください。」具体 ID なし) と ID 変更 (`GameRepository.UpdateGameId`: 「ゲームID「{id}」は既に…」案内なし) で文言が違っていた。両者を `ゲームID「{id}」は既に使用されています。別のIDを入力してください。`（具体 ID + 案内の両取り）に統一。
 
 #### Bump 根拠 (v0.17.0 → v0.17.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1911,6 +1911,16 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ## Manager（管理ソフト）
 
+### [Manager v0.17.1] - 2026-05-30
+
+#### Fixed (#206: ゲームID 検証エラーの理由別文言)
+
+- **ゲームID が無効なとき、理由に関わらず「英数字…のみ」固定文言を表示していた**: `GameFormHelper.IsValidGameId(string, out errorMessage)` は理由別文言 (空 / 64文字超 / 文字種 / Windows 予約名 `CON`/`PRN`/`NUL`/`COM1` 等) を返せるのに、`AddGameForm` / `EditGameForm` の呼び出しが bool-only overload + ハードコード文言を使い**理由を握り潰していた**。64文字超や予約名で弾かれた user にも「文字種が悪い」と誤誘導する状態だった。両 callsite を `out errorMessage` overload に切替え、返ってきた理由別文言をそのまま MessageBox 表示する。**検証ロジックは不変・表示文言のみ**。`docs/usage/games.md` (#106) の「保存時に Manager が知らせてくれる」記述とも整合。
+
+#### Bump 根拠 (v0.17.0 → v0.17.1)
+
+表示文言のみの bugfix のため patch bump。スキーマ/挙動変更なし・後方互換。Bundle への反映は次回リリース実行時。
+
 ### [Manager v0.17.0] - 2026-05-30
 
 > **（統合エントリ / 1 PR 1 bump）** 本エントリは PR #236 の内容を **1 バージョンに統合**したもの: #234 シリーズ（追加/編集/版アップのデータ整合性）+ 累積監査ラウンド 2〜9 + 復元後整合性チェック + `backup_log` 廃止→file-scan 化 + DB schema v16→v20。開発中は v0.16.5〜v0.21.0 と多数 bump したが未リリース（Bundle v0.7.0 が積んだのは v0.16.4）のため単一 bump へ圧縮。以下は実施順の **新→旧** で各ラウンドの詳細を保持し、テーマ（追加/編集/版up/バックアップ/復元/スキーマ）はラウンド間で重複する。旧版の区切りは `<!-- 統合元(旧): ... -->` コメントで追跡可能。なお本エントリ内に残る各 `#### Bump 根拠 (vX → vY)` 見出しは**統合前の各ラウンドの根拠**（履歴）であり、現行の単一 bump は **v0.16.4 → v0.17.0**。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1917,6 +1917,7 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 - **ゲームID が無効なとき、理由に関わらず「英数字…のみ」固定文言を表示していた**: `GameFormHelper.IsValidGameId(string, out errorMessage)` は理由別文言 (空 / 64文字超 / 文字種 / Windows 予約名 `CON`/`PRN`/`NUL`/`COM1` 等) を返せるのに、`AddGameForm` / `EditGameForm` の呼び出しが bool-only overload + ハードコード文言を使い**理由を握り潰していた**。64文字超や予約名で弾かれた user にも「文字種が悪い」と誤誘導する状態だった。両 callsite を `out errorMessage` overload に切替え、返ってきた理由別文言をそのまま MessageBox 表示する。**検証ロジックは不変・表示文言のみ**。`docs/usage/games.md` (#106) の「保存時に Manager が知らせてくれる」記述とも整合。
 - **ID 重複エラーの文言が Add / Edit で不統一だった (follow-up)**: 追加 (`AddGameForm`: 「このゲームIDは既に…別のIDを入力してください。」具体 ID なし) と ID 変更 (`GameRepository.UpdateGameId`: 「ゲームID「{id}」は既に…」案内なし) で文言が違っていた。両者を `ゲームID「{id}」は既に使用されています。別のIDを入力してください。`（具体 ID + 案内の両取り）に統一。
+- **`IsValidGameId` 直前の冗長な空チェックを削除し helper に一本化 (follow-up, #257 レビュー)**: `AddGameForm` / `EditGameForm` とも `IsValidGameId(out)` の直前に同一文言の `IsNullOrWhiteSpace` ガードが残っており、helper の「空」分岐 (同じ「ゲームIDを入力してください。」を返す) が dead code になっていた。コメントは「空 / …」を含むのに空欄が helper を通らない記述↔実装の不一致もあった。先行ガードを削除して空欄も `IsValidGameId` 経由に統一 (同文言・同 Focus・同 return で挙動不変)。
 
 #### Bump 根拠 (v0.17.0 → v0.17.1)
 

--- a/Manager/AddGameForm.cs
+++ b/Manager/AddGameForm.cs
@@ -716,15 +716,10 @@ namespace TonePrism.Manager
         private bool ValidateInput()
         {
             // ゲームID
-            if (string.IsNullOrWhiteSpace(txtGameId.Text))
-            {
-                MessageBox.Show("ゲームIDを入力してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                txtGameId.Focus();
-                return false;
-            }
-
             // (#206) ゲームID 検証: 理由別文言 (空 / 64文字超 / 文字種 / Windows 予約名 CON/PRN/NUL/COM1 等) を
             // 区別して表示する。bool-only overload + ハードコード文言だと「文字種が悪い」一択で誤誘導していた。
+            // 空欄も IsValidGameId が "ゲームIDを入力してください。" を返すため、ここに一本化 (先行する空チェックは
+            // helper に内包され dead だったので削除、#257 レビュー)。
             if (!GameFormHelper.IsValidGameId(txtGameId.Text, out string gameIdError))
             {
                 MessageBox.Show(gameIdError, "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);

--- a/Manager/AddGameForm.cs
+++ b/Manager/AddGameForm.cs
@@ -830,10 +830,11 @@ namespace TonePrism.Manager
             }
 
             // ゲームIDの重複チェック
+            // (#206 follow-up) Edit 経路 (GameRepository.UpdateGameId) と文言統一: 具体 ID + 案内。
             var existingGame = dbManager.GetGameById(txtGameId.Text.Trim());
             if (existingGame != null)
             {
-                MessageBox.Show("このゲームIDは既に使用されています。別のIDを入力してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show($"ゲームID「{txtGameId.Text.Trim()}」は既に使用されています。別のIDを入力してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtGameId.Focus();
                 return false;
             }

--- a/Manager/AddGameForm.cs
+++ b/Manager/AddGameForm.cs
@@ -723,10 +723,11 @@ namespace TonePrism.Manager
                 return false;
             }
 
-            // ゲームIDの文字種チェック（英数字と一部の記号のみ許可）
-            if (!GameFormHelper.IsValidGameId(txtGameId.Text))
+            // (#206) ゲームID 検証: 理由別文言 (空 / 64文字超 / 文字種 / Windows 予約名 CON/PRN/NUL/COM1 等) を
+            // 区別して表示する。bool-only overload + ハードコード文言だと「文字種が悪い」一択で誤誘導していた。
+            if (!GameFormHelper.IsValidGameId(txtGameId.Text, out string gameIdError))
             {
-                MessageBox.Show("ゲームIDは英数字、アンダースコア（_）、ハイフン（-）のみ使用できます。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show(gameIdError, "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtGameId.Focus();
                 return false;
             }

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -1757,14 +1757,10 @@ namespace TonePrism.Manager
         private bool ValidateInput()
         {
             // ゲームID
-            if (string.IsNullOrWhiteSpace(txtGameId.Text))
-            {
-                MessageBox.Show("ゲームIDを入力してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                txtGameId.Focus();
-                return false;
-            }
             // (#206) ゲームID 検証: 理由別文言 (空 / 64文字超 / 文字種 / Windows 予約名 CON/PRN/NUL/COM1 等) を
             // 区別して表示する (AddGameForm と同様、out errorMessage overload を使う)。
+            // 空欄も IsValidGameId が "ゲームIDを入力してください。" を返すため、ここに一本化 (先行する空チェックは
+            // helper に内包され dead だったので削除、#257 レビュー)。
             if (!GameFormHelper.IsValidGameId(txtGameId.Text, out string gameIdError))
             {
                 MessageBox.Show(gameIdError, "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -1763,9 +1763,11 @@ namespace TonePrism.Manager
                 txtGameId.Focus();
                 return false;
             }
-            if (!GameFormHelper.IsValidGameId(txtGameId.Text))
+            // (#206) ゲームID 検証: 理由別文言 (空 / 64文字超 / 文字種 / Windows 予約名 CON/PRN/NUL/COM1 等) を
+            // 区別して表示する (AddGameForm と同様、out errorMessage overload を使う)。
+            if (!GameFormHelper.IsValidGameId(txtGameId.Text, out string gameIdError))
             {
-                MessageBox.Show("ゲームIDには半角英数字、ハイフン(-)、アンダースコア(_)のみ使用できます。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show(gameIdError, "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtGameId.Focus();
                 return false;
             }

--- a/Manager/Properties/AssemblyInfo.cs
+++ b/Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.17.0.0")]
-[assembly: AssemblyFileVersion("0.17.0.0")]
+[assembly: AssemblyVersion("0.17.1.0")]
+[assembly: AssemblyFileVersion("0.17.1.0")]

--- a/Manager/Repositories/GameRepository.cs
+++ b/Manager/Repositories/GameRepository.cs
@@ -272,7 +272,8 @@ namespace TonePrism.Manager.Repositories
                         cmd.Parameters.AddWithValue("@newId", newId);
                         long count = (long)cmd.ExecuteScalar();
                         if (count > 0)
-                            throw new InvalidOperationException($"ゲームID「{newId}」は既に使用されています。");
+                            // (#206 follow-up) AddGameForm と文言統一 (具体 ID + 案内)。
+                            throw new InvalidOperationException($"ゲームID「{newId}」は既に使用されています。別のIDを入力してください。");
                     }
 
                     // PRAGMA foreign_keys はトランザクション外でのみ変更可能


### PR DESCRIPTION
Phase 1 (#249) の1本目。

## 問題
ゲームID が無効なとき、**理由に関わらず「英数字…のみ」固定文言**を表示していた。`GameFormHelper.IsValidGameId(string, out errorMessage)` は理由別文言（空 / 64文字超 / 文字種 / Windows 予約名 `CON`/`PRN`/`NUL`/`COM1` 等）を返せるのに、`AddGameForm` / `EditGameForm` の呼び出しが **bool-only overload + ハードコード文言**を使い理由を握り潰していた。→ 64文字超や予約名で弾かれた user に「文字種が悪い」と誤誘導。

## 修正
両 callsite を `out errorMessage` overload に切替え、返ってきた**理由別文言をそのまま表示**。**検証ロジックは不変・表示文言のみ**。

## 確認
- msbuild Debug ビルド OK
- `dotnet test`（既存4件）green（UI文言変更なので回帰なし）
- Manager **v0.17.0 → v0.17.1**（patch、後方互換）
- docs 変更なし（ID ルール自体は不変、`docs/usage/games.md` は既に「保存時に Manager が知らせてくれる」記述済）

Closes #206