### PR TITLE
fix(manager): ストアセクション並び替えの half-write を atomic 化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1911,6 +1911,16 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ## Manager（管理ソフト）
 
+### [Manager v0.19.1] - 2026-06-01
+
+#### Fixed (ストアセクション並び替えの half-write 解消)
+
+- **ストアセクションの「↑上へ / ↓下へ」並び替えが非トランザクションで、途中失敗時に display_order が壊れる**: `StoreSectionPanel.MoveSection` が 2 セクションの `display_order` を `UpdateSection` の**別々の DB write 2 回**で入れ替えており、片方成功・片方失敗で**両者が同じ display_order になる half-write** が起きうる経路があった（#274（#253 part 2）レビューで指摘、intro 側（`IntroGuidePanel`）は #274 で解消済の同型バグ）。`StoreSectionRepository.SwapDisplayOrder`（2 件を **1 transaction** で atomic 入替）を追加し、`MoveSection` をそれに切替。`DatabaseManager.SwapSectionOrder` facade 追加。`DataLayerRoundTripTests.StoreSection_SwapDisplayOrder_SwapsAtomically` で検証。
+
+#### Bump 根拠 (v0.19.0 → v0.19.1)
+
+既存コードの bugfix（並び替えの atomic 化）のため patch bump。スキーマ変更なし・後方互換。Bundle への反映は次回リリース実行時。
+
 ### [Manager v0.19.0] - 2026-05-31
 
 #### Added (#253 part 2/3: 初回説明の編集パネル — Manager UI)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1916,6 +1916,7 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 #### Fixed (ストアセクション並び替えの half-write 解消)
 
 - **ストアセクションの「↑上へ / ↓下へ」並び替えが非トランザクションで、途中失敗時に display_order が壊れる**: `StoreSectionPanel.MoveSection` が 2 セクションの `display_order` を `UpdateSection` の**別々の DB write 2 回**で入れ替えており、片方成功・片方失敗で**両者が同じ display_order になる half-write** が起きうる経路があった（#274（#253 part 2）レビューで指摘、intro 側（`IntroGuidePanel`）は #274 で解消済の同型バグ）。`StoreSectionRepository.SwapDisplayOrder`（2 件を **1 transaction** で atomic 入替）を追加し、`MoveSection` をそれに切替。`DatabaseManager.SwapSectionOrder` facade 追加。`DataLayerRoundTripTests.StoreSection_SwapDisplayOrder_SwapsAtomically` で検証。
+- **swap の silent no-op を fail-loud 化（#275 review #1）**: `SwapDisplayOrder`（store / intro 両 repo）で、対象 row が他セッションに削除されている等で **2 行更新できなければ throw → rollback** に変更。旧実装は 0 行更新でも commit され「成功表示なのに無変更」になりえたが、`InvalidOperationException` を投げて caller の「並び替えに失敗」表示に乗せる。`StoreSection_SwapDisplayOrder_MissingRow_ThrowsInsteadOfSilentNoOp` で検証。
 
 #### Bump 根拠 (v0.19.0 → v0.19.1)
 

--- a/Manager.Tests/DataLayerRoundTripTests.cs
+++ b/Manager.Tests/DataLayerRoundTripTests.cs
@@ -102,5 +102,15 @@ namespace TonePrism.Manager.Tests
             Assert.Equal("B", all[0].Title); // order 0 が B
             Assert.Equal("A", all[1].Title); // order 1 が A
         }
+
+        [Fact]
+        public void StoreSection_SwapDisplayOrder_MissingRow_ThrowsInsteadOfSilentNoOp()
+        {
+            // (#275 review #1) 片方の section_id が存在しないと 2 行更新できず throw (fail-loud)。
+            var repo = new StoreSectionRepository(_conn);
+            var a = new StoreSectionInfo { Title = "A", SectionSource = "manual", DisplayOrder = 0, MaxDisplayCount = 5, IsVisible = true };
+            repo.Add(a);
+            Assert.Throws<InvalidOperationException>(() => repo.SwapDisplayOrder(a.SectionId, 1, 999999, 0));
+        }
     }
 }

--- a/Manager.Tests/DataLayerRoundTripTests.cs
+++ b/Manager.Tests/DataLayerRoundTripTests.cs
@@ -84,5 +84,23 @@ namespace TonePrism.Manager.Tests
             Assert.Equal("v1.0.0", read.Version);
             Assert.Contains("アクション", read.Genre);
         }
+
+        [Fact]
+        public void StoreSection_SwapDisplayOrder_SwapsAtomically()
+        {
+            // 並び替えの atomic swap (half-write 解消、store 側) を検証。
+            var repo = new StoreSectionRepository(_conn);
+            var a = new StoreSectionInfo { Title = "A", SectionSource = "manual", DisplayOrder = 0, MaxDisplayCount = 5, IsVisible = true };
+            var b = new StoreSectionInfo { Title = "B", SectionSource = "manual", DisplayOrder = 1, MaxDisplayCount = 5, IsVisible = true };
+            repo.Add(a);
+            repo.Add(b);
+
+            // a→b の order(1)、b→a の order(0) に入れ替え。
+            repo.SwapDisplayOrder(a.SectionId, b.DisplayOrder, b.SectionId, a.DisplayOrder);
+
+            var all = repo.GetAll(); // display_order 昇順
+            Assert.Equal("B", all[0].Title); // order 0 が B
+            Assert.Equal("A", all[1].Title); // order 1 が A
+        }
     }
 }

--- a/Manager/Controls/StoreSectionPanel.cs
+++ b/Manager/Controls/StoreSectionPanel.cs
@@ -201,14 +201,13 @@ namespace TonePrism.Manager.Controls
 
             var sectionA = _sections[idx];
             var sectionB = _sections[newIdx];
-            int tempOrder = sectionA.DisplayOrder;
-            sectionA.DisplayOrder = sectionB.DisplayOrder;
-            sectionB.DisplayOrder = tempOrder;
 
             try
             {
-                _dbManager.UpdateSection(sectionA);
-                _dbManager.UpdateSection(sectionB);
+                // display_order を **1 transaction で入れ替え** (half-write 防止)。UpdateSection を 2 回別々に
+                // 投げると片方失敗で両者が同じ display_order になるため、atomic swap に委ねる (#253/#274 で intro 側を
+                // 直したのと同型、store 側の負債解消)。a は b の order、b は a の order を持つ。
+                _dbManager.SwapSectionOrder(sectionA.SectionId, sectionB.DisplayOrder, sectionB.SectionId, sectionA.DisplayOrder);
                 LoadSections();
 
                 if (newIdx < dgvSections.Rows.Count)

--- a/Manager/DatabaseManager.cs
+++ b/Manager/DatabaseManager.cs
@@ -249,6 +249,7 @@ namespace TonePrism.Manager
         public void AddSection(StoreSectionInfo section) => _sectionRepo.Add(section);
         public void UpdateSection(StoreSectionInfo section) => _sectionRepo.Update(section);
         public void DeleteSection(int sectionId) => _sectionRepo.Delete(sectionId);
+        public void SwapSectionOrder(int sectionIdA, int orderA, int sectionIdB, int orderB) => _sectionRepo.SwapDisplayOrder(sectionIdA, orderA, sectionIdB, orderB);
 
         // --- イントロガイド (#253) ---
         public List<IntroSlide> GetAllIntroSlides() => _introSlideRepo.GetAll();

--- a/Manager/Properties/AssemblyInfo.cs
+++ b/Manager/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.19.0.0")]
-[assembly: AssemblyFileVersion("0.19.0.0")]
+[assembly: AssemblyVersion("0.19.1.0")]
+[assembly: AssemblyFileVersion("0.19.1.0")]

--- a/Manager/Repositories/IntroSlideRepository.cs
+++ b/Manager/Repositories/IntroSlideRepository.cs
@@ -142,17 +142,24 @@ namespace TonePrism.Manager.Repositories
                     {
                         try
                         {
+                            int affected = 0;
                             using (var cmd = new SQLiteCommand("UPDATE intro_slides SET display_order = @o WHERE slide_id = @id", connection, transaction))
                             {
                                 cmd.Parameters.AddWithValue("@o", orderA);
                                 cmd.Parameters.AddWithValue("@id", slideIdA);
-                                cmd.ExecuteNonQuery();
+                                affected += cmd.ExecuteNonQuery();
                             }
                             using (var cmd = new SQLiteCommand("UPDATE intro_slides SET display_order = @o WHERE slide_id = @id", connection, transaction))
                             {
                                 cmd.Parameters.AddWithValue("@o", orderB);
                                 cmd.Parameters.AddWithValue("@id", slideIdB);
-                                cmd.ExecuteNonQuery();
+                                affected += cmd.ExecuteNonQuery();
+                            }
+                            // (#275 review #1) 片方/両方の slide_id が他セッションで削除されていると 0 行更新で silent
+                            // no-op になりうるため、2 行更新できなければ throw → rollback (fail-loud)。store 側と同型。
+                            if (affected != 2)
+                            {
+                                throw new InvalidOperationException($"並び替え対象のスライドが見つかりませんでした (更新 {affected}/2 行)。他のセッションで削除された可能性があります。");
                             }
                             transaction.Commit();
                         }

--- a/Manager/Repositories/StoreSectionRepository.cs
+++ b/Manager/Repositories/StoreSectionRepository.cs
@@ -215,6 +215,46 @@ namespace TonePrism.Manager.Repositories
             });
         }
 
+        /// <summary>
+        /// 2 セクションの display_order を **1 transaction で**入れ替える。並び替えで `UpdateSection` を 2 回
+        /// 別々に投げると、片方成功・片方失敗で両者が同じ display_order になる half-write が起きうるため、atomic な
+        /// swap を提供する (#253 part 2 / #274 で `IntroSlideRepository` に入れたのと同型、store 側の負債を解消)。
+        /// </summary>
+        public void SwapDisplayOrder(int sectionIdA, int orderA, int sectionIdB, int orderB)
+        {
+            _conn.ExecuteWithRetry(() =>
+            {
+                using (var connection = new SQLiteConnection(_conn.ConnectionString))
+                {
+                    _conn.OpenConnectionWithJournalMode(connection);
+                    using (var transaction = connection.BeginTransaction())
+                    {
+                        try
+                        {
+                            using (var cmd = new SQLiteCommand("UPDATE store_sections SET display_order = @o WHERE section_id = @id", connection, transaction))
+                            {
+                                cmd.Parameters.AddWithValue("@o", orderA);
+                                cmd.Parameters.AddWithValue("@id", sectionIdA);
+                                cmd.ExecuteNonQuery();
+                            }
+                            using (var cmd = new SQLiteCommand("UPDATE store_sections SET display_order = @o WHERE section_id = @id", connection, transaction))
+                            {
+                                cmd.Parameters.AddWithValue("@o", orderB);
+                                cmd.Parameters.AddWithValue("@id", sectionIdB);
+                                cmd.ExecuteNonQuery();
+                            }
+                            transaction.Commit();
+                        }
+                        catch
+                        {
+                            transaction.Rollback();
+                            throw;
+                        }
+                    }
+                }
+            });
+        }
+
         private List<GameInfo> GetGamesBySectionId(int sectionId, SQLiteConnection connection, StoreSectionInfo section = null)
         {
             var games = new List<GameInfo>();

--- a/Manager/Repositories/StoreSectionRepository.cs
+++ b/Manager/Repositories/StoreSectionRepository.cs
@@ -231,17 +231,25 @@ namespace TonePrism.Manager.Repositories
                     {
                         try
                         {
+                            int affected = 0;
                             using (var cmd = new SQLiteCommand("UPDATE store_sections SET display_order = @o WHERE section_id = @id", connection, transaction))
                             {
                                 cmd.Parameters.AddWithValue("@o", orderA);
                                 cmd.Parameters.AddWithValue("@id", sectionIdA);
-                                cmd.ExecuteNonQuery();
+                                affected += cmd.ExecuteNonQuery();
                             }
                             using (var cmd = new SQLiteCommand("UPDATE store_sections SET display_order = @o WHERE section_id = @id", connection, transaction))
                             {
                                 cmd.Parameters.AddWithValue("@o", orderB);
                                 cmd.Parameters.AddWithValue("@id", sectionIdB);
-                                cmd.ExecuteNonQuery();
+                                affected += cmd.ExecuteNonQuery();
+                            }
+                            // (#275 review #1) 片方/両方の section_id が他セッションで削除されていると 0 行更新で
+                            // silent no-op (成功表示なのに無変更) になりうるため、2 行更新できなければ throw → rollback
+                            // (fail-loud、caller の MoveSection が「並び替えに失敗」を表示)。
+                            if (affected != 2)
+                            {
+                                throw new InvalidOperationException($"並び替え対象のセクションが見つかりませんでした (更新 {affected}/2 行)。他のセッションで削除された可能性があります。");
                             }
                             transaction.Commit();
                         }


### PR DESCRIPTION
## 概要

`StoreSectionPanel.MoveSection`（ストアセクションの「↑上へ / ↓下へ」）の並び替えが**非トランザクション**で、途中失敗時に `display_order` が壊れる half-write を解消する。

PR #274（#253 part 2）のレビューで指摘された **intro 側（`IntroGuidePanel`）と同型の既存バグ**（intro は #274 で解消済、store 側が残っていた）。

## 問題

`MoveSection` は 2 セクションの `display_order` を `UpdateSection` の**別々の DB write 2 回**で入れ替えていた。A 成功・B 失敗で **A は新 order・B は旧 order のまま → 両者が同じ display_order** になる不整合（in-memory も swap 済）。

## 修正

- `StoreSectionRepository.SwapDisplayOrder(idA, orderA, idB, orderB)`：2 件を **1 transaction** で atomic に入替（#274 の `IntroSlideRepository.SwapDisplayOrder` と同型）
- `DatabaseManager.SwapSectionOrder` facade 追加
- `MoveSection` を atomic swap に切替（in-memory swap を撤去）

## テスト / 検証
- `DataLayerRoundTripTests.StoreSection_SwapDisplayOrder_SwapsAtomically`（2 セクション seed → swap → display_order 入替を assert）
- `MSBuild` build green ／ `dotnet test` **23/23 合格**
- Manager **v0.19.1**（patch、既存コード bugfix）。スキーマ変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)