### PR TITLE
fix(manager): バージョンアップ/追加のロールバック削除を FolderDeletionService に寄せる (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1974,6 +1974,14 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ## Manager（管理ソフト）
 
+### [Manager v0.20.1] - 2026-06-01
+
+#### Fixed (#288 — バージョンアップ/追加のロールバック削除を read-only 対応に)
+
+- **`GameSectionPanel` のバージョンアップ/ゲーム追加のロールバック・クリーンアップ経路の生 `Directory.Delete(..., true)`（5 箇所）を `FolderDeletionService.TryDelete`（read-only 再帰解除込み）に寄せた**。#209 で `FolderDeletionService` は read-only 対応済みだが、これらの経路だけ生 `Directory.Delete` のままで、コピー元が Unity/Godot プロジェクト（`Assets`/`Library` 等が read-only）だと**コピー失敗/中断時のロールバック削除が `UnauthorizedAccessException` で失敗**し、中途半端な版フォルダ（`.pending-create-*` や昇格済 `versionDir`）が残って次回バージョンアップの「フォルダが既に存在します」エラーの種になりうる取りこぼしだった（#209 review finding 5）。
+- 対象: missing-asset 中止 / 相対パス計算失敗 / DB 保存失敗（M5）/ 中断時 tempDir / `HandleVersionDirMoveFailure` の tempDir。**`versionDirOwnedByThisCall` ガード（並行 Manager の勝者 versionDir を敗者が消さない不変条件、#234）は維持**し、内部の delete のみ差し替え。
+- bump 判断: read-only バグの取りこぼし修正。patch (v0.20.0 → v0.20.1)。
+
 ### [Manager v0.20.0] - 2026-06-01
 
 #### Added (#209 — ゲーム編集で個別バージョンを削除)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1976,11 +1976,13 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ### [Manager v0.20.1] - 2026-06-01
 
-#### Fixed (#288 — バージョンアップ/追加のロールバック削除を read-only 対応に)
+#### Fixed (#288 — 版アップ/ゲーム追加のロールバック削除を read-only 対応に)
 
-- **`GameSectionPanel` のバージョンアップ/ゲーム追加のロールバック・クリーンアップ経路の生 `Directory.Delete(..., true)`（5 箇所）を `FolderDeletionService.TryDelete`（read-only 再帰解除込み）に寄せた**。#209 で `FolderDeletionService` は read-only 対応済みだが、これらの経路だけ生 `Directory.Delete` のままで、コピー元が Unity/Godot プロジェクト（`Assets`/`Library` 等が read-only）だと**コピー失敗/中断時のロールバック削除が `UnauthorizedAccessException` で失敗**し、中途半端な版フォルダ（`.pending-create-*` や昇格済 `versionDir`）が残って次回バージョンアップの「フォルダが既に存在します」エラーの種になりうる取りこぼしだった（#209 review finding 5）。
-- 対象: missing-asset 中止 / 相対パス計算失敗 / DB 保存失敗（M5）/ 中断時 tempDir / `HandleVersionDirMoveFailure` の tempDir。**`versionDirOwnedByThisCall` ガード（並行 Manager の勝者 versionDir を敗者が消さない不変条件、#234）は維持**し、内部の delete のみ差し替え。
-- bump 判断: read-only バグの取りこぼし修正。patch (v0.20.0 → v0.20.1)。
+- **ゲーム/版フォルダのコピー失敗・中断時のロールバック削除に残っていた生 `Directory.Delete(..., true)` を `FolderDeletionService.TryDelete`（read-only 再帰解除込み、#209）に寄せた**。コピー元が Unity/Godot プロジェクト（`Assets`/`Library` 等が read-only）だと、これらの生 delete がロールバックで `UnauthorizedAccessException` で失敗し、中途半端な版/ゲームフォルダが残って次回追加の「フォルダが既に存在します」エラーの種になりうる取りこぼしだった（#209 review finding 5）。
+  - **`GameSectionPanel`（バージョンアップ）5 箇所**: missing-asset 中止 / 相対パス計算失敗(M4) / DB 保存失敗(M5) / 中断時 tempDir(H3) / `HandleVersionDirMoveFailure` の tempDir。`versionDirOwnedByThisCall` ガード（並行 Manager の勝者フォルダを敗者が消さない不変条件、#234）は維持。
+  - **`AddGameForm`（ゲーム追加）2 箇所**（#288 review 指摘で追加）: 既存フォルダ上書き時の wipe（失敗時は従来通り friendly 例外で中断）/ rollback の版フォルダ削除（**旧 bare `catch {}` を `Result` 判定 + `Logger.Warn` 化**＝silent な zombie ゲームフォルダ残留の痕跡を残す）。`versionFolderCreatedThisCall`/`baseGameFolderCreated` ガードは維持。空の親フォルダの非再帰削除（空チェック付き）は対象外。
+- **`FolderDeletionService.TryDelete` を「throw せず常に `Result` を返す」契約に**（#288 review）: 従来は `IOException`/`UnauthorizedAccessException` のみ捕捉し他は伝播していたが、cleanup/rollback の呼び出し側が「全例外 swallow」を各所で書かずに `Result.Success` だけ見れば済むよう、想定外例外も捕捉して失敗 `Result` を返す。
+- bump 判断: read-only バグの取りこぼし修正。patch (v0.20.0 → v0.20.1)。全 87 テスト合格。
 
 ### [Manager v0.20.0] - 2026-06-01
 

--- a/Manager/AddGameForm.cs
+++ b/Manager/AddGameForm.cs
@@ -294,8 +294,9 @@ namespace TonePrism.Manager
                 var wipeResult = FolderDeletionService.TryDelete(gameBaseFolder);
                 if (!wipeResult.Success)
                 {
+                    // (#288 review) 原因はロック (Launcher 等が使用中) が大半だが、権限/属性の問題もありうるため断定せず併記。
                     throw new Exception(
-                        $"既存のゲームフォルダの削除に失敗しました（Launcher 等が使用中の可能性があります）:\n  {gameBaseFolder}\n\n{(wipeResult.LastError != null ? wipeResult.LastError.Message : "(不明)")}",
+                        $"既存のゲームフォルダの削除に失敗しました（Launcher 等が使用中、またはフォルダの権限・属性の問題の可能性があります）:\n  {gameBaseFolder}\n\n{wipeResult.ErrorMessage}",
                         wipeResult.LastError);
                 }
             }
@@ -688,7 +689,7 @@ namespace TonePrism.Manager
                 // (#288) read-only な Unity/Godot コピー (Assets/Library 等) でも消せるよう FolderDeletionService 経由。
                 // 旧 bare catch を Result 判定 + Logger.Warn に変更 (silent な zombie ゲームフォルダ残留の痕跡を残す)。
                 var delResult = FolderDeletionService.TryDelete(destinationGameFolder);
-                if (!delResult.Success) Logger.Warn("[AddGameForm] (#288) rollback の versionDir 削除失敗 (read-only/ロック等): " + destinationGameFolder + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
+                if (!delResult.Success) Logger.Warn("[AddGameForm] (#288) rollback の versionDir 削除失敗 (read-only/ロック等): " + destinationGameFolder + ": " + delResult.ErrorMessage);
             }
 
             if (baseGameFolderCreated && !string.IsNullOrEmpty(baseGameFolder) && Directory.Exists(baseGameFolder))

--- a/Manager/AddGameForm.cs
+++ b/Manager/AddGameForm.cs
@@ -289,14 +289,14 @@ namespace TonePrism.Manager
             }
             if (wipeExistingOnCopy && Directory.Exists(gameBaseFolder))
             {
-                try
-                {
-                    Directory.Delete(gameBaseFolder, true);
-                }
-                catch (Exception ex)
+                // (#288) read-only な Unity/Godot 既存フォルダ (Assets/Library 等が read-only) でも消せるよう
+                // FolderDeletionService 経由。失敗時は従来通り friendly 例外で中断 (Launcher 等の使用中ロックを想定)。
+                var wipeResult = FolderDeletionService.TryDelete(gameBaseFolder);
+                if (!wipeResult.Success)
                 {
                     throw new Exception(
-                        $"既存のゲームフォルダの削除に失敗しました（Launcher 等が使用中の可能性があります）:\n  {gameBaseFolder}\n\n{ex.Message}", ex);
+                        $"既存のゲームフォルダの削除に失敗しました（Launcher 等が使用中の可能性があります）:\n  {gameBaseFolder}\n\n{(wipeResult.LastError != null ? wipeResult.LastError.Message : "(不明)")}",
+                        wipeResult.LastError);
                 }
             }
 
@@ -685,7 +685,10 @@ namespace TonePrism.Manager
             // 触らない。baseGameFolderCreated と同じパターン。
             if (versionFolderCreatedThisCall && !string.IsNullOrEmpty(destinationGameFolder) && Directory.Exists(destinationGameFolder))
             {
-                try { Directory.Delete(destinationGameFolder, true); } catch { }
+                // (#288) read-only な Unity/Godot コピー (Assets/Library 等) でも消せるよう FolderDeletionService 経由。
+                // 旧 bare catch を Result 判定 + Logger.Warn に変更 (silent な zombie ゲームフォルダ残留の痕跡を残す)。
+                var delResult = FolderDeletionService.TryDelete(destinationGameFolder);
+                if (!delResult.Success) Logger.Warn("[AddGameForm] (#288) rollback の versionDir 削除失敗 (read-only/ロック等): " + destinationGameFolder + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
             }
 
             if (baseGameFolderCreated && !string.IsNullOrEmpty(baseGameFolder) && Directory.Exists(baseGameFolder))

--- a/Manager/Controls/GameSectionPanel.cs
+++ b/Manager/Controls/GameSectionPanel.cs
@@ -340,7 +340,7 @@ namespace TonePrism.Manager.Controls
                             {
                                 // (#288) read-only な Unity/Godot コピー (Assets/Library 等) でも消せるよう FolderDeletionService 経由。
                                 var delResult = FolderDeletionService.TryDelete(versionDir);
-                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (追加精査 ②) versionDir 削除失敗 (read-only/ロック等): " + versionDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
+                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (追加精査 ②) versionDir 削除失敗 (read-only/ロック等): " + versionDir + ": " + delResult.ErrorMessage);
                             }
                             MessageBox.Show(
                                 "コピー後のファイルが見つかりません。バージョンアップを中止しました:\n\n  " +
@@ -365,7 +365,7 @@ namespace TonePrism.Manager.Controls
                             {
                                 // (#288) read-only コピー対応のため FolderDeletionService 経由。
                                 var delResult = FolderDeletionService.TryDelete(versionDir);
-                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (M4) versionDir 削除失敗 (read-only/ロック等): " + versionDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
+                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (M4) versionDir 削除失敗 (read-only/ロック等): " + versionDir + ": " + delResult.ErrorMessage);
                             }
                             MessageBox.Show(
                                 "実行ファイルの相対パス計算に失敗しました。バージョンアップを中止しました。\n\n" +
@@ -440,7 +440,7 @@ namespace TonePrism.Manager.Controls
                             {
                                 // (#288) read-only コピー対応のため FolderDeletionService 経由。
                                 var delResult = FolderDeletionService.TryDelete(versionDir);
-                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (M5) versionDir rollback 削除失敗 (read-only/ロック等): " + versionDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
+                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (M5) versionDir rollback 削除失敗 (read-only/ロック等): " + versionDir + ": " + delResult.ErrorMessage);
                                 cleanupNote = "\n\nコピーしたファイルは削除しました。";
                             }
                             else
@@ -468,7 +468,7 @@ namespace TonePrism.Manager.Controls
                         // versionDir は触らない (= 我々はまだ owner ではない、勝者が既に作っていれば破壊しない)。
                         // (#288) read-only コピー (.pending-create) でも消せるよう FolderDeletionService 経由。
                         var delResult = FolderDeletionService.TryDelete(tempDir);
-                        if (!delResult.Success) Logger.Warn("[GameSectionPanel] (H3) 中断時の tempDir 削除失敗 (read-only/ロック等): " + tempDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
+                        if (!delResult.Success) Logger.Warn("[GameSectionPanel] (H3) 中断時の tempDir 削除失敗 (read-only/ロック等): " + tempDir + ": " + delResult.ErrorMessage);
 
                         if (processingDialog.DialogResult == DialogResult.Cancel)
                         {
@@ -491,7 +491,7 @@ namespace TonePrism.Manager.Controls
         {
             // (#288) read-only コピー (.pending-create) でも消せるよう FolderDeletionService 経由。
             var delResult = FolderDeletionService.TryDelete(tempDir);
-            if (!delResult.Success) Logger.Warn("[GameSectionPanel] (round 5 H1) tempDir 削除失敗 (read-only/ロック等): " + tempDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
+            if (!delResult.Success) Logger.Warn("[GameSectionPanel] (round 5 H1) tempDir 削除失敗 (read-only/ロック等): " + tempDir + ": " + delResult.ErrorMessage);
 
             string detail = moveEx is UnauthorizedAccessException
                 ? "別の Manager が同じバージョン番号で既にフォルダを作成した、または対象フォルダの権限が制限されている可能性があります。"

--- a/Manager/Controls/GameSectionPanel.cs
+++ b/Manager/Controls/GameSectionPanel.cs
@@ -338,8 +338,9 @@ namespace TonePrism.Manager.Controls
                         {
                             if (versionDirOwnedByThisCall)
                             {
-                                try { if (Directory.Exists(versionDir)) Directory.Delete(versionDir, true); }
-                                catch (Exception delEx) { Logger.Warn("[GameSectionPanel] (追加精査 ②) versionDir 削除失敗: " + versionDir + ": " + delEx.Message); }
+                                // (#288) read-only な Unity/Godot コピー (Assets/Library 等) でも消せるよう FolderDeletionService 経由。
+                                var delResult = FolderDeletionService.TryDelete(versionDir);
+                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (追加精査 ②) versionDir 削除失敗 (read-only/ロック等): " + versionDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
                             }
                             MessageBox.Show(
                                 "コピー後のファイルが見つかりません。バージョンアップを中止しました:\n\n  " +
@@ -362,7 +363,9 @@ namespace TonePrism.Manager.Controls
                         {
                             if (versionDirOwnedByThisCall)
                             {
-                                try { if (Directory.Exists(versionDir)) Directory.Delete(versionDir, true); } catch { /* swallow */ }
+                                // (#288) read-only コピー対応のため FolderDeletionService 経由。
+                                var delResult = FolderDeletionService.TryDelete(versionDir);
+                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (M4) versionDir 削除失敗 (read-only/ロック等): " + versionDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
                             }
                             MessageBox.Show(
                                 "実行ファイルの相対パス計算に失敗しました。バージョンアップを中止しました。\n\n" +
@@ -435,8 +438,9 @@ namespace TonePrism.Manager.Controls
                             string cleanupNote;
                             if (versionDirOwnedByThisCall)
                             {
-                                try { if (Directory.Exists(versionDir)) Directory.Delete(versionDir, true); }
-                                catch (Exception delEx) { Logger.Warn("[GameSectionPanel] (M5) versionDir rollback 削除失敗: " + versionDir + ": " + delEx.Message); }
+                                // (#288) read-only コピー対応のため FolderDeletionService 経由。
+                                var delResult = FolderDeletionService.TryDelete(versionDir);
+                                if (!delResult.Success) Logger.Warn("[GameSectionPanel] (M5) versionDir rollback 削除失敗 (read-only/ロック等): " + versionDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
                                 cleanupNote = "\n\nコピーしたファイルは削除しました。";
                             }
                             else
@@ -462,8 +466,9 @@ namespace TonePrism.Manager.Controls
                         // 防止のため掃除する。
                         // (Critical-1) この経路は ProcessingDialog 内 = Move 前なので、片付け対象は tempDir のみ。
                         // versionDir は触らない (= 我々はまだ owner ではない、勝者が既に作っていれば破壊しない)。
-                        try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true); }
-                        catch (Exception delEx) { Logger.Warn("[GameSectionPanel] (H3) 中断時の tempDir 削除失敗: " + tempDir + ": " + delEx.Message); }
+                        // (#288) read-only コピー (.pending-create) でも消せるよう FolderDeletionService 経由。
+                        var delResult = FolderDeletionService.TryDelete(tempDir);
+                        if (!delResult.Success) Logger.Warn("[GameSectionPanel] (H3) 中断時の tempDir 削除失敗 (read-only/ロック等): " + tempDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
 
                         if (processingDialog.DialogResult == DialogResult.Cancel)
                         {
@@ -484,8 +489,9 @@ namespace TonePrism.Manager.Controls
         /// </summary>
         private static void HandleVersionDirMoveFailure(string tempDir, string versionDir, Exception moveEx)
         {
-            try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true); }
-            catch (Exception delEx) { Logger.Warn("[GameSectionPanel] (round 5 H1) tempDir 削除失敗: " + tempDir + ": " + delEx.Message); }
+            // (#288) read-only コピー (.pending-create) でも消せるよう FolderDeletionService 経由。
+            var delResult = FolderDeletionService.TryDelete(tempDir);
+            if (!delResult.Success) Logger.Warn("[GameSectionPanel] (round 5 H1) tempDir 削除失敗 (read-only/ロック等): " + tempDir + ": " + (delResult.LastError != null ? delResult.LastError.Message : "(不明)"));
 
             string detail = moveEx is UnauthorizedAccessException
                 ? "別の Manager が同じバージョン番号で既にフォルダを作成した、または対象フォルダの権限が制限されている可能性があります。"

--- a/Manager/Properties/AssemblyInfo.cs
+++ b/Manager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.20.0.0")]
-[assembly: AssemblyFileVersion("0.20.0.0")]
+[assembly: AssemblyVersion("0.20.1.0")]
+[assembly: AssemblyFileVersion("0.20.1.0")]

--- a/Manager/Services/FolderDeletionService.cs
+++ b/Manager/Services/FolderDeletionService.cs
@@ -18,13 +18,19 @@ namespace TonePrism.Manager.Services
             public bool Success { get; set; }
             public Exception LastError { get; set; }
             public string Path { get; set; }
+
+            /// <summary>(#288 review) ログ/メッセージ用の最終エラー文言。LastError 不在時は "(不明)"。呼び出し側の null-guard 重複を集約。</summary>
+            public string ErrorMessage => LastError != null ? LastError.Message : "(不明)";
         }
 
         /// <summary>
-        /// フォルダを最大 5 回 × 200ms 間隔でリトライ削除する (read-only 属性は ForceDeleteDirectory が再帰解除、#209)。
-        /// `IOException` / `UnauthorizedAccessException` は transient lock とみなし retry、それ以外の想定外例外は retry せず
-        /// 即 `Result` (`Success=false`, `LastError` セット) を返す。**本メソッドは throw しない (best-effort never-throw API)**
-        /// (#288): cleanup / rollback の呼び出し側が全例外 swallow を各所で書かずに `Result.Success` だけ見れば済む。
+        /// フォルダを最大 5 回 × 200ms 間隔でリトライ削除する。
+        /// `IOException`（使用中ロック等）と一時的な `UnauthorizedAccessException` は待機 retry で解消を狙う。
+        /// **read-only 属性由来の `UnauthorizedAccessException` は待っても消えない**が、2 回目以降は `Directory.Delete` →
+        /// `ForceDeleteDirectory`（属性を再帰解除しながら削除）に切り替わるため解決する（fast-path→robust-path 切替、#209）。
+        /// それ以外の想定外例外は retry せず即 `Result` (`Success=false`, `LastError` セット) を返す。
+        /// **本メソッドは throw しない (best-effort never-throw API、#288)**: cleanup / rollback の呼び出し側が
+        /// 全例外 swallow を各所で書かずに `Result.Success` だけ見れば済む。
         /// path が null/空、またはフォルダが存在しない場合は `Success=true` を返す。
         /// </summary>
         public static Result TryDelete(string path)

--- a/Manager/Services/FolderDeletionService.cs
+++ b/Manager/Services/FolderDeletionService.cs
@@ -21,9 +21,11 @@ namespace TonePrism.Manager.Services
         }
 
         /// <summary>
-        /// フォルダを最大 5 回 × 200ms 間隔でリトライ削除する。
-        /// IOException / UnauthorizedAccessException のみ捕捉、それ以外は throw。
-        /// path が null/空、またはフォルダが存在しない場合は Success=true を返す。
+        /// フォルダを最大 5 回 × 200ms 間隔でリトライ削除する (read-only 属性は ForceDeleteDirectory が再帰解除、#209)。
+        /// `IOException` / `UnauthorizedAccessException` は transient lock とみなし retry、それ以外の想定外例外は retry せず
+        /// 即 `Result` (`Success=false`, `LastError` セット) を返す。**本メソッドは throw しない (best-effort never-throw API)**
+        /// (#288): cleanup / rollback の呼び出し側が全例外 swallow を各所で書かずに `Result.Success` だけ見れば済む。
+        /// path が null/空、またはフォルダが存在しない場合は `Success=true` を返す。
         /// </summary>
         public static Result TryDelete(string path)
         {

--- a/Manager/Services/FolderDeletionService.cs
+++ b/Manager/Services/FolderDeletionService.cs
@@ -66,6 +66,14 @@ namespace TonePrism.Manager.Services
                     if (i == maxRetries - 1) return result;
                     Thread.Sleep(delayMs);
                 }
+                catch (Exception ex)
+                {
+                    // (#288 review) 想定外例外 (ArgumentException 等) は transient lock ではないので retry せず失敗を返す。
+                    // TryDelete は best-effort 削除サービスとして「throw せず常に Result を返す」契約にし、cleanup /
+                    // rollback の呼び出し側が「全例外 swallow」を各所で書かずに Result.Success だけ見れば済むようにする。
+                    result.LastError = ex;
+                    return result;
+                }
             }
             return result;
         }

--- a/Manager/Services/GameVersionDeletionService.cs
+++ b/Manager/Services/GameVersionDeletionService.cs
@@ -145,7 +145,7 @@ namespace TonePrism.Manager.Services
                 {
                     Logger.Warn("[GameVersionDeletionService] (#209) DB 削除済だが退避フォルダの物理削除に失敗 (orphan 残存): "
                         + pendingFolder + ": "
-                        + (del.LastError != null ? del.LastError.Message : "(不明)")
+                        + del.ErrorMessage
                         + (phase3Unexpected != null ? " (想定外例外: " + phase3Unexpected.GetType().Name + ")" : ""));
                     return new Result
                     {

--- a/Manager/Services/GameVersionDeletionService.cs
+++ b/Manager/Services/GameVersionDeletionService.cs
@@ -123,9 +123,10 @@ namespace TonePrism.Manager.Services
             // ===== Phase 3: 退避フォルダの物理削除 (best-effort) =====
             // (#209 review finding 3) Phase 2 (DB) は既に commit 済。ここから先で例外が外へ抜けると、呼び出し側は
             // result=null の generic エラー経路に入り UI 同期/グリッド再読込をしない = DB だけ確定して画面が stale に
-            // なる窓ができる。FolderDeletionService.TryDelete は IOException/UnauthorizedAccessException 以外を再 throw
-            // しうるため、Phase 3 全体を try で囲み、想定外例外も PhysicalDeleteDeferred (DB 確定済) に落とす
-            // (= 「Phase 2 成功後は必ず Result を返す/throw しない」契約)。
+            // なる窓ができる。これを防ぐため Phase 3 全体を try で囲み、想定外例外も PhysicalDeleteDeferred (DB 確定済)
+            // に落とす (=「Phase 2 成功後は必ず Result を返す/throw しない」契約)。
+            // (#288) FolderDeletionService.TryDelete は now never-throw (常に Result を返す) なので下の catch は通常
+            //   到達しないが、その契約が将来 regress しても上記の stale 窓を作らないための防御 belt として残す。
             if (renamed)
             {
                 FolderDeletionService.Result del;


### PR DESCRIPTION
## 概要

#209 で `FolderDeletionService.TryDelete` に **read-only 属性の再帰解除**を入れ、版削除・ゲームごと削除は Unity/Godot の read-only フォルダでも消せるようになった。しかし `GameSectionPanel` の**バージョンアップ/ゲーム追加のロールバック・クリーンアップ経路**には `FolderDeletionService` を通さない**生 `Directory.Delete(..., true)`** が 5 箇所残っていた（#209 review finding 5）。これらを `FolderDeletionService.TryDelete` に寄せる取りこぼし修正。

Closes #288

## 問題
コピー元が Unity/Godot プロジェクト（`Assets`/`Library`/`Packages` 等が read-only）だと、バージョンアップのコピー失敗/中断時に **ロールバック削除が `UnauthorizedAccessException` で失敗** → 中途半端な版フォルダ（`.pending-create-*` や昇格済 `versionDir`）が残り、次回バージョンアップの「フォルダが既に存在します」エラーの種になりうる。＝ #209 で実機で踏んだのと同じ read-only バグが、版アップの巻き戻し経路に残っていた。

## 変更
生 `Directory.Delete(..., true)` 5 箇所 → `FolderDeletionService.TryDelete`（read-only 再帰解除込み）に置換:
1. missing-asset 中止時の `versionDir` 削除（追加精査 ②）
2. 相対パス計算失敗時の `versionDir` 削除（M4）
3. DB 保存失敗時の `versionDir` rollback 削除（M5）
4. 中断（Cancel/Abort）時の `tempDir` 削除（H3）
5. `HandleVersionDirMoveFailure` の `tempDir` 削除

**`versionDirOwnedByThisCall` ガード**（並行 Manager の勝者 `versionDir` を敗者が物理削除しない不変条件、#234 Critical-1）は維持し、内部の delete のみ差し替え。失敗は `Result.Success` で判定し `Logger.Warn`。

## 検証
- 全 87 テスト合格（`FolderDeletionService` の read-only テストが置換先の挙動を担保）。build 緑。
- 生 `Directory.Delete` の残存なし（line 523 はコメントのみ）。
- bump: Manager patch **0.20.0 → 0.20.1**。

## スコープ
版アップ動線の繊細な不変条件（temp→昇格、勝者非破壊）を壊さないよう、各箇所を個別確認のうえ内部 delete のみ差し替え（#209 から分離した理由）。SPEC 変更なし（既存 `FolderDeletionService` 機構への追従）、docs 影響なし（内部経路で UI/操作に変化なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
