### PR TITLE
fix: DataGridView 自動生成列の幅設定で WinForms 内部 NRE を回避（復元後 reload でクラッシュ）

### DIFF
--- a/Manager/Controls/IntroGuidePanel.cs
+++ b/Manager/Controls/IntroGuidePanel.cs
@@ -104,7 +104,11 @@ namespace TonePrism.Manager.Controls
             if (col == null) return;
             col.Visible = true;
             col.HeaderText = header;
-            col.Width = width;
+            // (NRE 対策) auto-generated column の transient state で WinForms 内部 (DataGridViewBand.set_Thickness) が
+            // NullReferenceException を投げる経路がある (StoreSectionPanel と同根、復元後の reload 等で顕在化)。
+            // 握りつぶして起動を止めない (列幅は既定で代替されるだけ)。
+            try { col.Width = width; }
+            catch { /* WinForms 内部の transient 例外は無視。起動を優先する。 */ }
         }
 
         private IntroSlide Selected()

--- a/Manager/Controls/StoreSectionPanel.cs
+++ b/Manager/Controls/StoreSectionPanel.cs
@@ -92,7 +92,12 @@ namespace TonePrism.Manager.Controls
             if (col == null) return;
             col.Visible = true;
             col.HeaderText = headerText;
-            col.Width = width;
+            // (NRE 対策) この grid は下で AutoSizeColumnsMode=Fill にするため、列幅は Width でなく FillWeight 比で決まる。
+            // Width(Thickness) を設定すると Fill で無視されるうえ、auto-generated column の transient state で WinForms 内部
+            // (DataGridViewBand.set_Thickness) が NullReferenceException を投げる経路があった (復元後の DatabaseChanged →
+            // 全 panel reload 等で顕在化)。FillWeight に変えて Thickness を一切触らず NRE を構造的に回避する。
+            try { col.FillWeight = width; }
+            catch { /* WinForms 内部の transient 例外は無視。列幅は Fill で再計算され表示に影響しない。 */ }
         }
 
         private StoreSectionInfo GetSelectedSection()


### PR DESCRIPTION
## 症状
`StoreSectionPanel.ConfigureColumn`（および同型の `IntroGuidePanel`）で、`DataGridView` の自動生成列に `col.Width` を設定したときに **`System.NullReferenceException`**（`DataGridViewBand.set_Thickness` 内）でクラッシュする。とくに **復元後の `DatabaseChanged` → 全 panel reload** の経路で顕在化（#250 PR3b の実機確認中に遭遇）。本体は **既存バグ**（main にも存在、PR3b とは無関係）。

```
System.NullReferenceException
   at System.Windows.Forms.DataGridViewBand.set_Thickness(Int32 value)
   at System.Windows.Forms.DataGridViewColumn.set_Width(Int32 value)
   at TonePrism.Manager.Controls.StoreSectionPanel.ConfigureColumn(...) line 95
```

## 原因
auto-generated column の transient state（DataSource バインド直後・SuspendLayout 中・Handle 未確定等）で、`Width`(=`Thickness`) setter が WinForms 内部のレイアウト計算に入って null deref する経路。既存の防御（`Columns.Contains` + null チェック + `SuspendLayout`）は **col 取得まで**しか守っておらず、`Width` setter 内部の NRE は素通りしていた。

## 修正
- **`StoreSectionPanel`**（`AutoSizeColumnsMode = Fill`）: `col.Width` → **`col.FillWeight`** に変更。Fill モードでは列幅は `FillWeight` 比で決まり `Width` は無視されるため、そもそも `Width` を設定する意味がなく、かつ NRE の原因 `Thickness` を一切触らずに**構造的に回避**できる（列幅比は従来の Width 値をそのまま流用）。
- **`IntroGuidePanel`**（非 Fill）: `col.Width` を **try-catch** で保険（transient NRE 時はスキップし、列幅は既定で代替して**起動を止めない**）。

## 検証
- build 緑 / テスト **156 件合格**。
- ※ 実機での目視（ストアタブ・初回説明タブの列表示、復元後の panel reload でクラッシュしないこと）は申し送り。

## 関連
#250 PR3b（PR #304）の実機確認中に発見。独立バグのため別 PR。PR3b ブランチには実機確認継続のため本コミットを cherry-pick 済み（本 PR が main にマージされれば PR3b 側は重複解消）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)