### PR TITLE
fix: フォルダ選択でウィンドウが縮むDPIバグを修正 (FolderBrowserDialog化)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2009,6 +2009,16 @@ PR #150 で dir rename (`GCTonePrism_Launcher/` → `Launcher/`) に連動して
 
 ## Manager（管理ソフト）
 
+### [Manager v0.27.1] - 2026-06-07
+
+- **フォルダ選択ダイアログを開くたびにウィンドウが縮むバグを修正**: ゲーム追加 / バージョンアップの「ゲームフォルダ選択」を開閉するたびに、Manager 本体ウィンドウ（＋ダイアログ）が**少しずつ縮んでいく**不具合があった（拡大率 100% 超の環境、本機は 200% で発生）。本番DB作成でゲームを多数登録する際に作業不能なため修正。
+  - **原因**: フォルダ選択に使っていた WindowsAPICodePack の `CommonOpenFileDialog` は **per-monitor DPI 対応のネイティブ COM ダイアログ**。一方 Manager は DPI awareness 未宣言（unaware）なため、このダイアログを開くたびに WinForms 側ウィンドウが DPI 再スケールされ縮む（画像/実行ファイル選択の標準 `OpenFileDialog` では起きないのは、こちらが per-monitor COM ダイアログでないため）。標準 `OpenFileDialog` はフォルダを選べないので元々この COM ダイアログを使っていた。
+  - **試して不発だった対策**（記録）: (1) `SetThreadDpiAwarenessContext` でスレッドの DPI コンテキストをオーナーに固定 → 縮み止まらず（COM ダイアログが自前でコンテキストを張り直す）。(2) ダイアログ前後で全フォームのサイズを保存・復元 → 止まらず（再スケールが復元後／子コントロールごと一様に縮む）。(3) app.manifest で **System DPI awareness 宣言**（根本対策）→ 全フォームが AutoScale 再計算され**起動時点でメイン画面のレイアウトが崩壊**（実機確認、特に AutoScaleDimensions が `(6,12)` の 4 フォーム）。(4) ダイアログを**別 STA スレッド**で表示 → `CommonOpenFileDialog` がワーカースレッドで `InvalidOperationException`。
+  - **採用した修正**: フォルダ選択を WinForms 標準の **`FolderBrowserDialog`（旧来のツリー型）に変更**（新 `Services/DpiSafeFolderPicker.cs` に集約）。per-monitor COM ダイアログを使わないため awareness ミスマッチ自体が起きず**確実に縮まない**。DPI/レイアウト/manifest には一切触れない surgical な修正。UX がツリー型になる分は、**直近に選んだフォルダを記憶して次回の起点にする**ことで緩和（bulk 登録時に毎回ツリーを頭から辿らず、兄弟フォルダをすぐ選べる）。対象は `AddGameForm`（ゲームフォルダ）/ `VersionUpForm`（バージョンフォルダ）の 2 箇所。
+  - **将来**: モダンなフォルダピッカーの復活は、DPI aware 前提でレイアウトを組み直す **WPF 移行（#245）**で扱う（WPF は本来 DPI aware なのでこのミスマッチが構造的に発生しない）。
+- 検証: build 緑。**実機（拡大率 200%）でフォルダ選択を反復開閉してもウィンドウが縮まないこと・メイン画面レイアウトが正常なこと・直近フォルダ起点で開くことを目視確認**。
+- bump 判断: バグ修正のみ（破壊的変更・schema 変更なし）。patch (v0.27.0 → v0.27.1)。Launcher / Companions は無関係。
+
 ### [Manager v0.27.0] - 2026-06-07
 
 - **(#297 PR1) プレイ記録・アンケートを SQLite から撤去（JSON 直読み化へのピボット・スキーマ側）**: プレイ記録/アンケートの保存方式を「Launcher が JSON drop → Manager が SQLite へ取り込む（drop-folder）」から「**Launcher が JSON を直読みしてメモリ集計**（SQLite を経由しない）」へ転換する #297 の第 1 弾。本 PR は **Manager 側のスキーマ撤去**と SPEC 改定、Launcher の非参照化まで（書込/集計は PR2、アンケート UI は PR3）。本番DB作成前の最後のスキーマ変更として、v23 のクリーンスキーマを確定させる。

--- a/Manager/AddGameForm.cs
+++ b/Manager/AddGameForm.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using TonePrism.Manager.Models;
 using TonePrism.Manager.Services;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace TonePrism.Manager
 {
@@ -149,26 +148,15 @@ namespace TonePrism.Manager
         /// </summary>
         private void btnSelectGameFolder_Click(object sender, EventArgs e)
         {
-            using (var dialog = new CommonOpenFileDialog())
+            // フォルダ選択は DpiSafeFolderPicker 経由 (CommonOpenFileDialog の DPI 縮みバグ対策。詳細は同クラス)。
+            string folder = DpiSafeFolderPicker.PickFolder(this, "ゲームフォルダを選択してください", txtGameFolder.Text);
+            if (folder != null)
             {
-                dialog.IsFolderPicker = true;
-                dialog.Title = "ゲームフォルダを選択してください";
-                dialog.Multiselect = false;
+                sourceGameFolder = folder;
+                txtGameFolder.Text = sourceGameFolder;
 
-                // 現在のパスが設定されている場合は、そこから開始
-                if (!string.IsNullOrEmpty(txtGameFolder.Text) && Directory.Exists(txtGameFolder.Text))
-                {
-                    dialog.InitialDirectory = txtGameFolder.Text;
-                }
-
-                if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
-                {
-                    sourceGameFolder = dialog.FileName;
-                    txtGameFolder.Text = sourceGameFolder;
-                    
-                    // 自動検出を実行
-                    AutoDetectFiles();
-                }
+                // 自動検出を実行
+                AutoDetectFiles();
             }
         }
 

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -9,7 +9,6 @@ using System.Windows.Forms;
 using TonePrism.Manager.Controls;
 using TonePrism.Manager.Models;
 using TonePrism.Manager.Services;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace TonePrism.Manager
 {

--- a/Manager/Properties/AssemblyInfo.cs
+++ b/Manager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("0.27.0.0")]
-[assembly: AssemblyFileVersion("0.27.0.0")]
+[assembly: AssemblyVersion("0.27.1.0")]
+[assembly: AssemblyFileVersion("0.27.1.0")]

--- a/Manager/Services/DpiSafeFolderPicker.cs
+++ b/Manager/Services/DpiSafeFolderPicker.cs
@@ -5,9 +5,12 @@ using System.Windows.Forms;
 namespace TonePrism.Manager.Services
 {
     /// <summary>
-    /// フォルダ選択の共通ヘルパー。WinForms 標準の <see cref="FolderBrowserDialog"/> を使う。
-    /// 加えて<b>直近に選んだフォルダを記憶</b>し、次回はそこを起点に開く (bulk 登録で毎回ツリーを
-    /// 頭から辿らずに済むようにする緩和策)。
+    /// <b>ゲームフォルダ選択用</b>のヘルパー (AddGameForm / VersionUpForm)。WinForms 標準の
+    /// <see cref="FolderBrowserDialog"/> を使い、加えて<b>直近に選んだフォルダを記憶</b>して次回はそこを起点に
+    /// 開く (bulk 登録で毎回ツリーを頭から辿らずに済むようにする緩和策)。
+    /// ※ 設定タブのログ/バックアップ参照先など他のフォルダ選択は文脈 (起点) が異なり記憶共有が不適なため
+    ///   このヘルパーを経由せず <see cref="FolderBrowserDialog"/> を直接使う (DPI 縮みバグはフォルダ選択
+    ///   全般に該当しうるが、本ヘルパーはゲームフォルダ用途に閉じる)。
     ///
     /// <para>背景 (なぜモダンな CommonOpenFileDialog をやめたか): フォルダ選択にはかつて WindowsAPICodePack の
     /// <c>CommonOpenFileDialog</c> (per-monitor DPI 対応のネイティブ COM ダイアログ) を使っていたが、本アプリは
@@ -63,11 +66,27 @@ namespace TonePrism.Manager.Services
                 DialogResult result = owner != null ? dialog.ShowDialog(owner) : dialog.ShowDialog();
                 if (result == DialogResult.OK)
                 {
-                    _lastSelectedFolder = dialog.SelectedPath; // 次回の起点に記憶
-                    return dialog.SelectedPath;
+                    string path = NormalizeTrailingSeparator(dialog.SelectedPath);
+                    _lastSelectedFolder = path; // 次回の起点に記憶
+                    return path;
                 }
                 return null;
             }
+        }
+
+        /// <summary>
+        /// 末尾セパレータを正規化する。<see cref="FolderBrowserDialog.SelectedPath"/> はドライブ直下選択時に
+        /// 末尾 <c>\</c> を含む (例: "D:\")。MainForm の前例 (SPEC §3.6 変更履歴 R4 L-4) に倣い末尾 <c>\</c> /
+        /// <c>/</c> を除去するが、<b>ドライブルート ("D:\") は除去すると drive-relative path ("D:") に化けて別物に
+        /// なるため温存する</b> (長さ &gt; 3 = ドライブルートより長いものだけ trim)。
+        /// </summary>
+        private static string NormalizeTrailingSeparator(string path)
+        {
+            if (string.IsNullOrEmpty(path) || path.Length <= 3)
+            {
+                return path; // "D:\" 等のドライブルート / 空はそのまま (drive-relative 化を避ける)
+            }
+            return path.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
         }
     }
 }

--- a/Manager/Services/DpiSafeFolderPicker.cs
+++ b/Manager/Services/DpiSafeFolderPicker.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace TonePrism.Manager.Services
+{
+    /// <summary>
+    /// フォルダ選択の共通ヘルパー。WinForms 標準の <see cref="FolderBrowserDialog"/> を使う。
+    /// 加えて<b>直近に選んだフォルダを記憶</b>し、次回はそこを起点に開く (bulk 登録で毎回ツリーを
+    /// 頭から辿らずに済むようにする緩和策)。
+    ///
+    /// <para>背景 (なぜモダンな CommonOpenFileDialog をやめたか): フォルダ選択にはかつて WindowsAPICodePack の
+    /// <c>CommonOpenFileDialog</c> (per-monitor DPI 対応のネイティブ COM ダイアログ) を使っていたが、本アプリは
+    /// DPI awareness 未宣言 (unaware) のため、拡大率 100% 超 (例: 200%) で開くたびに WinForms 側ウィンドウが
+    /// DPI 再スケールして<b>少しずつ縮む</b>バグがあった (画像/実行ファイル選択の標準 OpenFileDialog では起きない)。
+    /// 回避を順に試したが不発: (1) スレッド DPI コンテキスト固定 → 縮み止まらず、(2) サイズ復元 → 止まらず、
+    /// (3) プロセスへ DPI awareness 宣言 (app.manifest) → 全フォームのレイアウト崩壊 (実機確認)、
+    /// (4) 別 STA スレッドで表示 → <c>CommonOpenFileDialog</c> がワーカースレッドで InvalidOperationException。
+    /// 結論として「モダンダイアログ維持 × 縮み回避」は DPI aware 化以外に確実な道がなく、それはレイアウト崩壊で
+    /// 不可のため、本ダイアログは採用しない。</para>
+    ///
+    /// <para>採用 (<see cref="FolderBrowserDialog"/>): 旧来のツリー型。WinForms 内で動き per-monitor COM ダイアログを
+    /// 使わないため awareness ミスマッチ自体が起きず<b>縮まない</b>。UX が素朴な分は「直近フォルダ記憶」で緩和する。
+    /// モダンピッカーの復活は DPI aware 前提でレイアウトを組み直す WPF 移行 (#245) で扱う。</para>
+    /// </summary>
+    public static class DpiSafeFolderPicker
+    {
+        // 直近に選択したフォルダ (プロセス内で記憶)。bulk 登録時に兄弟フォルダをすぐ選べるよう次回の起点に使う。
+        private static string _lastSelectedFolder;
+
+        /// <summary>
+        /// フォルダ選択ダイアログを表示し、選択されたフォルダの絶対パスを返す。キャンセル時は null。
+        /// </summary>
+        /// <param name="owner">モーダルのオーナー (呼び出し元フォーム)。</param>
+        /// <param name="title">説明テキスト (ダイアログ上部に表示)。</param>
+        /// <param name="initialDirectory">初期選択フォルダ。指定が無ければ直近選択フォルダを起点にする。null/空可。</param>
+        public static string PickFolder(IWin32Window owner, string title, string initialDirectory = null)
+        {
+            using (var dialog = new FolderBrowserDialog())
+            {
+                dialog.Description = title;
+                // 既存ゲームフォルダの選択用途なので「新しいフォルダーの作成」ボタンは出さない。
+                dialog.ShowNewFolderButton = false;
+
+                // 起点: 明示指定 > 直近選択 の順 (どちらも実在する場合のみ)。SelectedPath を与えると
+                // そのフォルダを選択状態でツリーが展開され、兄弟フォルダが見える状態で開く。
+                string start = null;
+                if (!string.IsNullOrEmpty(initialDirectory) && Directory.Exists(initialDirectory))
+                {
+                    start = initialDirectory;
+                }
+                else if (!string.IsNullOrEmpty(_lastSelectedFolder) && Directory.Exists(_lastSelectedFolder))
+                {
+                    start = _lastSelectedFolder;
+                }
+                if (start != null)
+                {
+                    dialog.SelectedPath = start;
+                }
+
+                DialogResult result = owner != null ? dialog.ShowDialog(owner) : dialog.ShowDialog();
+                if (result == DialogResult.OK)
+                {
+                    _lastSelectedFolder = dialog.SelectedPath; // 次回の起点に記憶
+                    return dialog.SelectedPath;
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/Manager/Services/DpiSafeFolderPicker.cs
+++ b/Manager/Services/DpiSafeFolderPicker.cs
@@ -25,7 +25,9 @@ namespace TonePrism.Manager.Services
     /// </summary>
     public static class DpiSafeFolderPicker
     {
-        // 直近に選択したフォルダ (プロセス内で記憶)。bulk 登録時に兄弟フォルダをすぐ選べるよう次回の起点に使う。
+        // 直近に選択したフォルダ。プロセス内で記憶し、AddGameForm / VersionUpForm 横断で共有する
+        // (どちらもゲームフォルダ選択で起点が同じ親になりやすいため共有が有益)。bulk 登録時に兄弟フォルダを
+        // すぐ選べるよう次回の起点に使う。
         private static string _lastSelectedFolder;
 
         /// <summary>

--- a/Manager/TonePrism_Manager.csproj
+++ b/Manager/TonePrism_Manager.csproj
@@ -240,6 +240,7 @@
     <Compile Include="Services\SessionBackupCoordinator.cs" />
     <Compile Include="Services\BackupCatalogService.cs" />
     <Compile Include="Services\DeveloperListManager.cs" />
+    <Compile Include="Services\DpiSafeFolderPicker.cs" />
     <Compile Include="Services\FileOperationService.cs" />
     <Compile Include="Services\FolderDeletionService.cs" />
     <Compile Include="Services\GameFormHelper.cs" />

--- a/Manager/VersionUpForm.cs
+++ b/Manager/VersionUpForm.cs
@@ -7,7 +7,6 @@ using System.Windows.Forms;
 using TonePrism.Manager.Controls;
 using TonePrism.Manager.Models;
 using TonePrism.Manager.Services;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace TonePrism.Manager
 {
@@ -228,25 +227,21 @@ namespace TonePrism.Manager
 
         private void btnSelectGameFolder_Click(object sender, EventArgs e)
         {
-            using (var dialog = new CommonOpenFileDialog())
+            // フォルダ選択は DpiSafeFolderPicker 経由 (CommonOpenFileDialog の DPI 縮みバグ対策。詳細は同クラス)。
+            string folder = DpiSafeFolderPicker.PickFolder(this, "新しいバージョンのゲームフォルダを選択してください");
+            if (folder != null)
             {
-                dialog.IsFolderPicker = true;
-                dialog.Title = "新しいバージョンのゲームフォルダを選択してください";
+                selectedFolderPath = folder;
+                txtGameFolder.Text = selectedFolderPath;
+                SourceFolderPath = selectedFolderPath;
 
-                if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
-                {
-                    selectedFolderPath = dialog.FileName;
-                    txtGameFolder.Text = selectedFolderPath;
-                    SourceFolderPath = selectedFolderPath;
-                    
-                    // フォルダ選択後、ファイルのパスをクリアして自動検出
-                    txtExecutablePath.Text = "";
-                    txtThumbnailPath.Text = "";
-                    txtBackgroundPath.Text = "";
-                    RelativeExecutablePath = "";
-                    
-                    AutoDetectFiles();
-                }
+                // フォルダ選択後、ファイルのパスをクリアして自動検出
+                txtExecutablePath.Text = "";
+                txtThumbnailPath.Text = "";
+                txtBackgroundPath.Text = "";
+                RelativeExecutablePath = "";
+
+                AutoDetectFiles();
             }
         }
 


### PR DESCRIPTION
## 概要

ゲーム追加 / バージョンアップの**「ゲームフォルダ選択」を開閉するたびに Manager 本体ウィンドウ（＋ダイアログ）が少しずつ縮んでいく**不具合を修正。拡大率 100% 超の環境（本機は **200%**）で発生。本番DB作成でゲームを多数登録する作業を阻害するため修正した。

## 原因
フォルダ選択に使っていた WindowsAPICodePack の `CommonOpenFileDialog` は **per-monitor DPI 対応のネイティブ COM ダイアログ**。一方 Manager は DPI awareness 未宣言（unaware）なため、このダイアログを開くたびに WinForms 側ウィンドウが DPI 再スケールされて縮む。画像/実行ファイル選択の標準 `OpenFileDialog` で起きないのは、こちらが per-monitor COM ダイアログではないため（標準 `OpenFileDialog` はフォルダを選べないので、フォルダ選択にだけこの COM ダイアログを使っていた）。

## 試して不発だった対策（記録）
1. `SetThreadDpiAwarenessContext` でスレッドの DPI コンテキストをオーナーに固定 → 縮み止まらず（COM ダイアログが自前でコンテキストを張り直す）
2. ダイアログ前後で全フォームのサイズを保存・復元 → 止まらず（再スケールが復元後／子コントロールごと一様に縮む）
3. **app.manifest で System DPI awareness 宣言**（根本対策）→ 全フォームが AutoScale 再計算され**起動時点でメイン画面のレイアウトが崩壊**（実機確認）
4. ダイアログを**別 STA スレッド**で表示 → `CommonOpenFileDialog` がワーカースレッドで `InvalidOperationException`

→「モダンダイアログ維持 × 縮み回避」は DPI aware 化以外に確実な道がなく、それはレイアウト崩壊で不可と判明。

## 採用した修正
- フォルダ選択を WinForms 標準の **`FolderBrowserDialog`（ツリー型）に変更**し、新 `Services/DpiSafeFolderPicker.cs` に集約。per-monitor COM ダイアログを使わないため awareness ミスマッチ自体が起きず**確実に縮まない**。DPI/レイアウト/manifest には一切触れない surgical な修正
- ツリー型の手間は**「直近に選んだフォルダを記憶して次回の起点にする」**で緩和（bulk 登録で毎回ツリーを頭から辿らず、兄弟フォルダをすぐ選べる）
- 対象: `AddGameForm`（ゲームフォルダ）/ `VersionUpForm`（バージョンフォルダ）の 2 箇所

## 将来
モダンなフォルダピッカーの復活は、DPI aware 前提でレイアウトを組み直す **WPF 移行（#245）**で扱う（WPF は本来 DPI aware なのでこのミスマッチが構造的に発生しない）。

## 検証
- build 緑（Manager v0.27.0 → **v0.27.1** patch）
- **実機（拡大率 200%）で確認**: フォルダ選択を反復開閉してもウィンドウが縮まない / メイン画面レイアウト正常 / 直近フォルダ起点で開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
