### PR TITLE
refactor(manager): 版セット入力検証を GameVersionSetValidator に抽出 (#242 ②)

### DIFF
--- a/Manager.Tests/GameVersionSetValidatorTests.cs
+++ b/Manager.Tests/GameVersionSetValidatorTests.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using TonePrism.Manager.Models;
+using TonePrism.Manager.Services;
+using Xunit;
+
+namespace TonePrism.Manager.Tests
+{
+    /// <summary>
+    /// (#242 ②) EditGameForm.btnOK_Click から抽出した版セット入力検証の回帰テスト。
+    /// 空 / 不正version / 正規化重複(NOCASE) / 人数 min>max の分類と per-entry 整形を検証する。
+    /// (malformed-suffix 行は VersionRegex≡SuffixRegex 統一で現状 dead path のため assert しない。
+    ///  不正 suffix は numeric 行に落ちる＝下の MalformedVersion_ で確認。)
+    /// </summary>
+    public class GameVersionSetValidatorTests
+    {
+        private static GameVersion V(int id, string version, int? min = null, int? max = null)
+            => new GameVersion { Id = id, Version = version, MinPlayers = min, MaxPlayers = max };
+
+        private static GameVersionSetValidator.Result Validate(params GameVersion[] versions)
+            => new GameVersionSetValidator().Validate(versions);
+
+        [Fact]
+        public void AllValid_NoViolations()
+        {
+            var r = Validate(V(1, "v1.0.0"), V(2, "v2.1.3", 1, 4), V(3, "v1.0.0-rc1"));
+            Assert.Equal(0, r.VersionStringIssueCount);
+            Assert.Empty(r.DuplicateVersions);
+            Assert.Empty(r.PlayerCountViolations);
+        }
+
+        [Fact]
+        public void EmptyOrNullVersion_ListedInEmptyIds()
+        {
+            var r = Validate(V(5, ""), V(6, null));
+            Assert.Equal(2, r.EmptyIds.Count);
+            Assert.Contains("(id=5)", r.EmptyIds);
+            Assert.Contains("(id=6)", r.EmptyIds);
+            Assert.Equal(2, r.VersionStringIssueCount);
+        }
+
+        [Theory]
+        [InlineData("abc")]          // 数値部なし
+        [InlineData("1.2")]          // patch 欠落
+        [InlineData("v1.0.0-rc..1")] // 空 identifier の suffix → VersionRegex 不一致 → numeric 行
+        [InlineData("v1.0.0-rc@1")]  // 不正文字 suffix → 同上
+        public void MalformedVersion_ListedInNumericEntries(string ver)
+        {
+            var r = Validate(V(7, ver));
+            Assert.Contains(r.MalformedNumericEntries, e => e.Contains("id=7"));
+            Assert.True(r.VersionStringIssueCount > 0);
+        }
+
+        [Fact]
+        public void NormalizedDuplicate_DetectedAcrossPrefixAndCase()
+        {
+            // "v1.0.0" / "1.0.0" / "V1.0.0" は正規化後同一 = 重複 1 グループ (DB の UNIQUE NOCASE と整合)。
+            var r = Validate(V(1, "v1.0.0"), V(2, "1.0.0"), V(3, "V1.0.0"));
+            Assert.Single(r.DuplicateVersions);
+        }
+
+        [Fact]
+        public void DistinctVersions_NoDuplicate()
+        {
+            var r = Validate(V(1, "v1.0.0"), V(2, "v1.0.1"), V(3, "v2.0.0"));
+            Assert.Empty(r.DuplicateVersions);
+        }
+
+        [Fact]
+        public void PlayerCount_MinGreaterThanMax_Violation()
+        {
+            var r = Validate(V(1, "v1.0.0", min: 4, max: 2));
+            Assert.Single(r.PlayerCountViolations);
+            Assert.Contains("最小 4 > 最大 2", r.PlayerCountViolations[0]);
+        }
+
+        [Fact]
+        public void PlayerCount_OkOrNull_NoViolation()
+        {
+            var r = Validate(
+                V(1, "v1.0.0", min: 1, max: 4),    // ok
+                V(2, "v2.0.0", min: 2, max: 2),    // ok (等しい)
+                V(3, "v3.0.0", min: null, max: 2), // null → skip
+                V(4, "v4.0.0", min: 4, max: null)  // null → skip
+            );
+            Assert.Empty(r.PlayerCountViolations);
+        }
+
+        [Fact]
+        public void NullEntries_SkippedWithoutCrash()
+        {
+            var r = new GameVersionSetValidator().Validate(new GameVersion[] { null, V(1, "v1.0.0"), null });
+            Assert.Equal(0, r.VersionStringIssueCount);
+            Assert.Empty(r.DuplicateVersions);
+            Assert.Empty(r.PlayerCountViolations);
+        }
+
+        [Fact]
+        public void MultipleCategories_AggregatedIndependently()
+        {
+            // 空 / numeric malformed / 正規化重複 / 人数違反 が独立カテゴリに集計される。
+            var r = Validate(
+                V(1, ""),                        // empty
+                V(2, "abc"),                     // numeric malformed
+                V(3, "v1.0.0"), V(4, "1.0.0"),   // 重複 (正規化後同一)
+                V(5, "v2.0.0", min: 5, max: 1)   // 人数違反
+            );
+            Assert.Single(r.EmptyIds);
+            Assert.True(r.MalformedNumericEntries.Count >= 1);
+            Assert.Single(r.DuplicateVersions);
+            Assert.Single(r.PlayerCountViolations);
+        }
+    }
+}

--- a/Manager.Tests/GameVersionSetValidatorTests.cs
+++ b/Manager.Tests/GameVersionSetValidatorTests.cs
@@ -86,6 +86,15 @@ namespace TonePrism.Manager.Tests
         }
 
         [Fact]
+        public void NullCollection_ReturnsEmptyResult_NoCrash()
+        {
+            var r = new GameVersionSetValidator().Validate(null);
+            Assert.Equal(0, r.VersionStringIssueCount);
+            Assert.Empty(r.DuplicateVersions);
+            Assert.Empty(r.PlayerCountViolations);
+        }
+
+        [Fact]
         public void NullEntries_SkippedWithoutCrash()
         {
             var r = new GameVersionSetValidator().Validate(new GameVersion[] { null, V(1, "v1.0.0"), null });

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -1044,12 +1044,13 @@ namespace TonePrism.Manager
                 SaveGameDataToVersion(currentSelected);
             }
 
-            // (#158 round 7 L-2 + L-3) 旧実装は (a) suffix scan / (b) 空文字 scan / (c) 数値 scan の
-            // 3 段 return で、1 つの version が複数違反を持つと user は 2-3 巡 OK を押させられる UX。
-            // 1 ループで classification → empty / malformed-suffix / malformed-numeric の 3 リストに
-            // 分けて 1 つの MessageBox で全件まとめて表示する形に集約。
-            // suffix 切り出しは TrySplit static helper 経由 (round 7 L-3、IndexOf('-') 直書きの
-            // "v-1.0.0" 誤判定余地を排除)。
+            // (既知の残存 path #158 round 6 M-1 — caller 側の前提として復元) 直前の
+            // SaveGameDataToVersion(currentSelected) で **表示中版の v.Version は clamp 値** (例: "v0.0.0" / "v99.0.0")
+            // に上書き済 → 下の validator の TryNormalize は succeed し、表示中版の malformed 入力は本 scan では
+            // catch できない。これは仕様で、LoadVersions 警告 + UI の clamp 表示 visibility (表示中版は user の目に
+            // 入る) で代替担保している。表示中版が素通りするのを「バグ」と誤認して validator を強化すると clamp 前提が
+            // 崩れるので注意 (scan は **非表示版の補完** が主目的)。scan 分類 (空/不正suffix/不正数値の 1 ループ集約・
+            // round 7 L-2/L-3) の経緯は GameVersionSetValidator 側コメントに保存。
             // (#242 ②) 版セット全体の入力検証 (空/不正suffix/不正数値/正規化重複NOCASE/人数min>max) を
             // GameVersionSetValidator に抽出。scan logic は service、presentation (MessageBox 組み立て + 表示) は
             // ここ (form) に残す。表示中以外の版も含め全件 scan するため、版切替時の SaveGameDataToVersion で

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -1050,134 +1050,66 @@ namespace TonePrism.Manager
             // 分けて 1 つの MessageBox で全件まとめて表示する形に集約。
             // suffix 切り出しは TrySplit static helper 経由 (round 7 L-3、IndexOf('-') 直書きの
             // "v-1.0.0" 誤判定余地を排除)。
-            var emptyIds = new List<string>();
-            var malformedSuffixEntries = new List<string>();
-            var malformedNumericEntries = new List<string>();
-            foreach (var item in cmbVersionList.Items)
-            {
-                if (!(item is GameVersion vChk)) continue;
-                string ver = vChk.Version;
-                if (string.IsNullOrEmpty(ver))
-                {
-                    emptyIds.Add("(id=" + vChk.Id + ")");
-                    continue;
-                }
-                string core, sfx;
-                if (SemverInputControl.TrySplit(ver, out core, out sfx))
-                {
-                    if (!SemverInputControl.IsSuffixValid(sfx))
-                    {
-                        malformedSuffixEntries.Add("  - id=" + vChk.Id + ": '" + ver + "' (suffix 部分: '" + sfx + "')");
-                    }
-                }
-                string normIgnored;
-                if (!SemverInputControl.TryNormalize(ver, out normIgnored))
-                {
-                    malformedNumericEntries.Add("  - id=" + vChk.Id + ": '" + ver + "'");
-                }
-            }
-            if (emptyIds.Count > 0 || malformedSuffixEntries.Count > 0 || malformedNumericEntries.Count > 0)
+            // (#242 ②) 版セット全体の入力検証 (空/不正suffix/不正数値/正規化重複NOCASE/人数min>max) を
+            // GameVersionSetValidator に抽出。scan logic は service、presentation (MessageBox 組み立て + 表示) は
+            // ここ (form) に残す。表示中以外の版も含め全件 scan するため、版切替時の SaveGameDataToVersion で
+            // 各版に commit 済の値が対象になる (直前の SaveGameDataToVersion(currentSelected) で表示中版も反映済)。
+            var versionValidation = new GameVersionSetValidator().Validate(cmbVersionList.Items.OfType<GameVersion>());
+
+            // (1) version 文字列の問題 (空/不正suffix/不正数値) を 1 つの MessageBox に集約 (#158 round 7 L-2)。
+            if (versionValidation.VersionStringIssueCount > 0)
             {
                 var sb = new System.Text.StringBuilder();
                 sb.AppendLine("以下のバージョンに修正が必要です。Manager の dropdown で該当 version を" +
                     "選択して入力欄を直してから再度 OK を押してください (= このまま OK すると DB に" +
                     "書き戻されます)。");
                 sb.AppendLine();
-                if (emptyIds.Count > 0)
+                if (versionValidation.EmptyIds.Count > 0)
                 {
-                    sb.AppendLine("● バージョン文字列が空 / 未設定 (" + emptyIds.Count + " 件):");
-                    sb.AppendLine("  " + string.Join("\n  ", emptyIds));
+                    sb.AppendLine("● バージョン文字列が空 / 未設定 (" + versionValidation.EmptyIds.Count + " 件):");
+                    sb.AppendLine("  " + string.Join("\n  ", versionValidation.EmptyIds));
                     sb.AppendLine();
                 }
-                if (malformedSuffixEntries.Count > 0)
+                if (versionValidation.MalformedSuffixEntries.Count > 0)
                 {
-                    sb.AppendLine("● suffix 部分が SemVer 形式ではない (" + malformedSuffixEntries.Count +
+                    sb.AppendLine("● suffix 部分が SemVer 形式ではない (" + versionValidation.MalformedSuffixEntries.Count +
                         " 件、英数字とハイフンの identifier をピリオドで区切る形式のみ可、例: rc1 / beta.2):");
-                    sb.AppendLine(string.Join("\n", malformedSuffixEntries));
+                    sb.AppendLine(string.Join("\n", versionValidation.MalformedSuffixEntries));
                     sb.AppendLine();
                 }
-                if (malformedNumericEntries.Count > 0)
+                if (versionValidation.MalformedNumericEntries.Count > 0)
                 {
                     sb.AppendLine("● 数値部 (Major/Minor/Patch) または書式が parse 不能 (" +
-                        malformedNumericEntries.Count + " 件):");
-                    sb.AppendLine(string.Join("\n", malformedNumericEntries));
+                        versionValidation.MalformedNumericEntries.Count + " 件):");
+                    sb.AppendLine(string.Join("\n", versionValidation.MalformedNumericEntries));
                     sb.AppendLine();
                 }
-                int total = emptyIds.Count + malformedSuffixEntries.Count + malformedNumericEntries.Count;
                 MessageBox.Show(this, sb.ToString().TrimEnd(),
-                    "バージョン入力エラー (" + total + " 件)",
+                    "バージョン入力エラー (" + versionValidation.VersionStringIssueCount + " 件)",
                     MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
-            // 既知の残存 path (#158 round 6 M-1): currently-displayed の malformed は前段 dup-check 直前
-            // SaveGameDataToVersion(currentSelected) で v.Version が clamp 値 (例: "v0.0.0" or "v99.0.0")
-            // に上書き済 → 上の TryNormalize は succeed → 本 scan では catch できない。LoadVersions
-            // 警告での user 認知 + UI clamp 表示 visibility に頼る (= 表示中 version は user の目に入る)。
-            // (#158 round 6 codex P2) GroupBy のキーを TryNormalize 結果に変える。旧実装は raw v.Version
-            // で比較していたため、過去 DB の "v1.0.0" / "1.0.0" / "V1.0.0" を別 key として素通しして
-            // semantic 上は重複なのに通る silent danger があった (= Q2 fix の裏口再オープン状態)。
-            // (#158 round 7 M-1) 上の事前 scan (空文字 / malformed-suffix / malformed-numeric の 3 段
-            // 集約) で全 malformed を弾いて return しているため、ここに到達する時点で全件 TryNormalize
-            // 成功確定。三項の `: v.Version` fallback path は事実上 dead code だが defensive に残す
-            // (= 万一上の scan が緩められた場合の guard rail として機能、silent regression 防止)。
-            // (#158 round 8 senior Low #4) `.Where(v => !string.IsNullOrEmpty(v.Version))` filter は
-            // L-2 の事前 scan で空文字 version を return で弾いた後なので dead path、defensive guard
-            // rail として残す (round 7 M-1 の fallback コメントと同方針、片方だけ defensive コメント
-            // 付いて非対称だったため両方に注記)。
-            var versionDups = cmbVersionList.Items
-                .OfType<GameVersion>()
-                .Where(v => !string.IsNullOrEmpty(v.Version))
-                // (PR #236 レビュー対応 #2) GroupBy を OrdinalIgnoreCase に。raw-fallback キー (正規化不能版) が
-                // 既定の Ordinal だと "V1.0" と "v1.0" のような case 違いが group 化されず UI 重複ガードを素通りし、
-                // DB の UNIQUE(game_id, version COLLATE NOCASE) に raw で当たって SQLiteException (フレンドリーで
-                // ない技術的エラー) として表面化していた。DB の NOCASE collation と UI 判定を揃えて事前に弾く。
-                .GroupBy(v =>
-                {
-                    string normalized;
-                    return SemverInputControl.TryNormalize(v.Version, out normalized) ? normalized : v.Version;
-                }, StringComparer.OrdinalIgnoreCase)
-                .Where(g => g.Count() > 1)
-                .Select(g =>
-                {
-                    // 重複 key + 重複した raw 値群を表示 (normalize 後同じだが原型は違う場合の手がかり)
-                    var raws = g.Select(v => v.Version).Distinct().ToList();
-                    return raws.Count == 1 ? g.Key : g.Key + " (生値: " + string.Join(" / ", raws) + ")";
-                })
-                .ToList();
-            if (versionDups.Count > 0)
+
+            // (2) 正規化重複 (SemVer 正規化後・v 大小/leading v 無視、DB の UNIQUE NOCASE と整合)。
+            if (versionValidation.DuplicateVersions.Count > 0)
             {
                 MessageBox.Show(
                     "以下のバージョン名が複数のエントリで重複しています (SemVer 正規化後の比較、" +
                     "v 大文字/小文字・leading v 有無は同一視):\n\n  " +
-                    string.Join("\n  ", versionDups) +
+                    string.Join("\n  ", versionValidation.DuplicateVersions) +
                     "\n\nバージョン管理ドロップダウンで該当の項目を選択し、別の名前に変更してください。",
                     "バージョン重複エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
-            // (Finding #4) 全版の「最小プレイ人数 > 最大プレイ人数」を検出する。OK 時の ValidateInput →
-            // ValidatePlayerCount (下の ~1800) は表示中の NumericUpDown 値しか見ないため、非表示の版で
-            // min>max にしたまま別の版を表示して OK すると素通りしていた (SemVer 重複は上で全件 scan するのに
-            // 対し非対称)。版切替時の SaveGameDataToVersion で各版に commit 済の値を全件比較し、違反版を
-            // 列挙して block する (両方とも非 null のときのみ比較。Add/VersionUp は常に ≥1 を書くため
-            // 実運用で null になる経路は限定的だが、表示中版は ValidateInput が先に弾くので本 scan は非表示版を補完)。
-            var playerCountViolations = new List<string>();
-            foreach (var item in cmbVersionList.Items)
-            {
-                if (!(item is GameVersion vPc)) continue;
-                if (vPc.MinPlayers.HasValue && vPc.MaxPlayers.HasValue && vPc.MinPlayers.Value > vPc.MaxPlayers.Value)
-                {
-                    playerCountViolations.Add("  - " + (vPc.Version ?? "(id=" + vPc.Id + ")")
-                        + ": 最小 " + vPc.MinPlayers.Value + " > 最大 " + vPc.MaxPlayers.Value);
-                }
-            }
-            if (playerCountViolations.Count > 0)
+            // (3) 全版の「最小プレイ人数 > 最大プレイ人数」(表示中版は ValidateInput が先に弾くので非表示版を補完)。
+            if (versionValidation.PlayerCountViolations.Count > 0)
             {
                 MessageBox.Show(this,
                     "以下のバージョンで「最小プレイ人数 > 最大プレイ人数」になっています。\n" +
                     "バージョン管理ドロップダウンで該当の版を選び、人数を修正してから再度 OK してください:\n\n" +
-                    string.Join("\n", playerCountViolations),
-                    "プレイ人数の入力エラー (" + playerCountViolations.Count + " 件)",
+                    string.Join("\n", versionValidation.PlayerCountViolations),
+                    "プレイ人数の入力エラー (" + versionValidation.PlayerCountViolations.Count + " 件)",
                     MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }

--- a/Manager/Services/GameVersionSetValidator.cs
+++ b/Manager/Services/GameVersionSetValidator.cs
@@ -23,11 +23,11 @@ namespace TonePrism.Manager.Services
         /// <summary>検証結果。各リストは表示用の per-entry 文字列 (caller は header を付けて MessageBox 化)。</summary>
         public class Result
         {
-            public List<string> EmptyIds = new List<string>();               // "(id=N)"
-            public List<string> MalformedSuffixEntries = new List<string>(); // "  - id=N: 'ver' (suffix 部分: 'sfx')"
-            public List<string> MalformedNumericEntries = new List<string>();// "  - id=N: 'ver'"
-            public List<string> DuplicateVersions = new List<string>();      // "key" or "key (生値: a / b)"
-            public List<string> PlayerCountViolations = new List<string>();  // "  - ver: 最小 N > 最大 M"
+            public List<string> EmptyIds { get; } = new List<string>();               // "(id=N)"
+            public List<string> MalformedSuffixEntries { get; } = new List<string>(); // "  - id=N: 'ver' (suffix 部分: 'sfx')"
+            public List<string> MalformedNumericEntries { get; } = new List<string>();// "  - id=N: 'ver'"
+            public List<string> DuplicateVersions { get; } = new List<string>();      // "key" or "key (生値: a / b)"
+            public List<string> PlayerCountViolations { get; } = new List<string>();  // "  - ver: 最小 N > 最大 M"
 
             /// <summary>version 文字列の問題 (空 + 不正 suffix + 不正数値) の合計件数。1 つの MessageBox に集約する単位。</summary>
             public int VersionStringIssueCount =>
@@ -36,7 +36,7 @@ namespace TonePrism.Manager.Services
 
         public Result Validate(IEnumerable<GameVersion> versions)
         {
-            var list = versions.ToList();
+            var list = (versions ?? Enumerable.Empty<GameVersion>()).ToList();
             var r = new Result();
 
             // ===== (1) version 文字列 scan (#158 round 7 L-2 + L-3) =====
@@ -73,7 +73,7 @@ namespace TonePrism.Manager.Services
             // DB の UNIQUE(game_id, version COLLATE NOCASE) と判定を揃え、case 違い重複が SQLiteException で表面化
             // するのを事前に弾く。`: v.Version` fallback (正規化不能版) と `Where(!IsNullOrEmpty)` は (1) で弾いた
             // 後の dead path だが defensive guard rail として残す (#158 round 7 M-1 / round 8 Low #4)。
-            r.DuplicateVersions = list
+            r.DuplicateVersions.AddRange(list
                 .Where(v => v != null && !string.IsNullOrEmpty(v.Version))
                 .GroupBy(v =>
                 {
@@ -85,8 +85,7 @@ namespace TonePrism.Manager.Services
                 {
                     var raws = g.Select(v => v.Version).Distinct().ToList();
                     return raws.Count == 1 ? g.Key : g.Key + " (生値: " + string.Join(" / ", raws) + ")";
-                })
-                .ToList();
+                }));
 
             // ===== (3) 人数 min>max (#158 Finding #4) =====
             // 表示中の NumericUpDown 値しか見ない ValidateInput を補完し、非表示版で min>max のまま別版を表示して

--- a/Manager/Services/GameVersionSetValidator.cs
+++ b/Manager/Services/GameVersionSetValidator.cs
@@ -10,7 +10,9 @@ namespace TonePrism.Manager.Services
     /// (#242 ② ゲーム登録フォーム WPF 化) EditGameForm.btnOK_Click から「版セット全体の入力検証」を抽出した
     /// 純関数 service。編集中の in-memory 版セット (cmbVersionList の全版) を走査し、構造化した違反を返す。
     /// scan logic は本 service、presentation (MessageBox の組み立て + 表示) は caller (form) 側に残す。
-    /// 元は god-method 直書きの 3 段 scan (CLAUDE.md「UI は薄く、ロジックは外へ」)。挙動は完全保存。
+    /// 元は god-method 直書きの 3 段 scan (CLAUDE.md「UI は薄く、ロジックは外へ」)。
+    /// 観測可能な挙動 (最初に出る MessageBox とその順序) は保存。内部は旧 early-return から「3 カテゴリを
+    /// 常時 eager 計算 → caller が表示順で early-return」に変更 (= 計算経路のみ変化、null 安全で例外差もなし)。
     ///
     /// 検証する 3 観点 (各々が独立した違反カテゴリ):
     ///   (1) version 文字列の問題 — 空 / 不正 suffix / 不正数値 (1 つの MessageBox に集約する 3 分類)
@@ -20,14 +22,28 @@ namespace TonePrism.Manager.Services
     /// </summary>
     public class GameVersionSetValidator
     {
-        /// <summary>検証結果。各リストは表示用の per-entry 文字列 (caller は header を付けて MessageBox 化)。</summary>
+        /// <summary>
+        /// 検証結果 (immutable)。各リストは表示用の per-entry 文字列 (caller は header を付けて MessageBox 化)。
+        /// caller は読み取りのみのため <see cref="IReadOnlyList{T}"/> で公開し、書き換え不可の契約にする。
+        /// </summary>
         public class Result
         {
-            public List<string> EmptyIds { get; } = new List<string>();               // "(id=N)"
-            public List<string> MalformedSuffixEntries { get; } = new List<string>(); // "  - id=N: 'ver' (suffix 部分: 'sfx')"
-            public List<string> MalformedNumericEntries { get; } = new List<string>();// "  - id=N: 'ver'"
-            public List<string> DuplicateVersions { get; } = new List<string>();      // "key" or "key (生値: a / b)"
-            public List<string> PlayerCountViolations { get; } = new List<string>();  // "  - ver: 最小 N > 最大 M"
+            public Result(
+                List<string> emptyIds, List<string> malformedSuffixEntries, List<string> malformedNumericEntries,
+                List<string> duplicateVersions, List<string> playerCountViolations)
+            {
+                EmptyIds = emptyIds;
+                MalformedSuffixEntries = malformedSuffixEntries;
+                MalformedNumericEntries = malformedNumericEntries;
+                DuplicateVersions = duplicateVersions;
+                PlayerCountViolations = playerCountViolations;
+            }
+
+            public IReadOnlyList<string> EmptyIds { get; }               // "(id=N)"
+            public IReadOnlyList<string> MalformedSuffixEntries { get; } // "  - id=N: 'ver' (suffix 部分: 'sfx')"
+            public IReadOnlyList<string> MalformedNumericEntries { get; }// "  - id=N: 'ver'"
+            public IReadOnlyList<string> DuplicateVersions { get; }      // "key" or "key (生値: a / b)"
+            public IReadOnlyList<string> PlayerCountViolations { get; }  // "  - ver: 最小 N > 最大 M"
 
             /// <summary>version 文字列の問題 (空 + 不正 suffix + 不正数値) の合計件数。1 つの MessageBox に集約する単位。</summary>
             public int VersionStringIssueCount =>
@@ -37,7 +53,10 @@ namespace TonePrism.Manager.Services
         public Result Validate(IEnumerable<GameVersion> versions)
         {
             var list = (versions ?? Enumerable.Empty<GameVersion>()).ToList();
-            var r = new Result();
+            var emptyIds = new List<string>();
+            var malformedSuffixEntries = new List<string>();
+            var malformedNumericEntries = new List<string>();
+            var playerCountViolations = new List<string>();
 
             // ===== (1) version 文字列 scan (#158 round 7 L-2 + L-3) =====
             // 旧実装は suffix/空/数値の 3 段 return で 1 version が複数違反だと 2-3 巡 OK を押させた UX を、
@@ -53,18 +72,18 @@ namespace TonePrism.Manager.Services
                 string ver = vChk.Version;
                 if (string.IsNullOrEmpty(ver))
                 {
-                    r.EmptyIds.Add("(id=" + vChk.Id + ")");
+                    emptyIds.Add("(id=" + vChk.Id + ")");
                     continue;
                 }
                 string core, sfx;
                 if (SemverInputControl.TrySplit(ver, out core, out sfx))
                 {
                     if (!SemverInputControl.IsSuffixValid(sfx))
-                        r.MalformedSuffixEntries.Add("  - id=" + vChk.Id + ": '" + ver + "' (suffix 部分: '" + sfx + "')");
+                        malformedSuffixEntries.Add("  - id=" + vChk.Id + ": '" + ver + "' (suffix 部分: '" + sfx + "')");
                 }
                 string normIgnored;
                 if (!SemverInputControl.TryNormalize(ver, out normIgnored))
-                    r.MalformedNumericEntries.Add("  - id=" + vChk.Id + ": '" + ver + "'");
+                    malformedNumericEntries.Add("  - id=" + vChk.Id + ": '" + ver + "'");
             }
 
             // ===== (2) 正規化重複 (NOCASE) =====
@@ -73,7 +92,7 @@ namespace TonePrism.Manager.Services
             // DB の UNIQUE(game_id, version COLLATE NOCASE) と判定を揃え、case 違い重複が SQLiteException で表面化
             // するのを事前に弾く。`: v.Version` fallback (正規化不能版) と `Where(!IsNullOrEmpty)` は (1) で弾いた
             // 後の dead path だが defensive guard rail として残す (#158 round 7 M-1 / round 8 Low #4)。
-            r.DuplicateVersions.AddRange(list
+            var duplicateVersions = list
                 .Where(v => v != null && !string.IsNullOrEmpty(v.Version))
                 .GroupBy(v =>
                 {
@@ -85,7 +104,8 @@ namespace TonePrism.Manager.Services
                 {
                     var raws = g.Select(v => v.Version).Distinct().ToList();
                     return raws.Count == 1 ? g.Key : g.Key + " (生値: " + string.Join(" / ", raws) + ")";
-                }));
+                })
+                .ToList();
 
             // ===== (3) 人数 min>max (#158 Finding #4) =====
             // 表示中の NumericUpDown 値しか見ない ValidateInput を補完し、非表示版で min>max のまま別版を表示して
@@ -94,11 +114,11 @@ namespace TonePrism.Manager.Services
             {
                 if (vPc == null) continue;
                 if (vPc.MinPlayers.HasValue && vPc.MaxPlayers.HasValue && vPc.MinPlayers.Value > vPc.MaxPlayers.Value)
-                    r.PlayerCountViolations.Add("  - " + (vPc.Version ?? "(id=" + vPc.Id + ")")
+                    playerCountViolations.Add("  - " + (vPc.Version ?? "(id=" + vPc.Id + ")")
                         + ": 最小 " + vPc.MinPlayers.Value + " > 最大 " + vPc.MaxPlayers.Value);
             }
 
-            return r;
+            return new Result(emptyIds, malformedSuffixEntries, malformedNumericEntries, duplicateVersions, playerCountViolations);
         }
     }
 }

--- a/Manager/Services/GameVersionSetValidator.cs
+++ b/Manager/Services/GameVersionSetValidator.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TonePrism.Manager.Controls;
+using TonePrism.Manager.Models;
+
+namespace TonePrism.Manager.Services
+{
+    /// <summary>
+    /// (#242 ② ゲーム登録フォーム WPF 化) EditGameForm.btnOK_Click から「版セット全体の入力検証」を抽出した
+    /// 純関数 service。編集中の in-memory 版セット (cmbVersionList の全版) を走査し、構造化した違反を返す。
+    /// scan logic は本 service、presentation (MessageBox の組み立て + 表示) は caller (form) 側に残す。
+    /// 元は god-method 直書きの 3 段 scan (CLAUDE.md「UI は薄く、ロジックは外へ」)。挙動は完全保存。
+    ///
+    /// 検証する 3 観点 (各々が独立した違反カテゴリ):
+    ///   (1) version 文字列の問題 — 空 / 不正 suffix / 不正数値 (1 つの MessageBox に集約する 3 分類)
+    ///   (2) 正規化重複 — SemVer 正規化後 (v 大小・leading v 無視) の NOCASE 重複 (DB の UNIQUE と整合)
+    ///   (3) 人数 — 非表示版も含めた全版の「最小プレイ人数 &gt; 最大プレイ人数」
+    /// caller は version-string → 重複 → 人数 の順で early-return しながら MessageBox を出す。
+    /// </summary>
+    public class GameVersionSetValidator
+    {
+        /// <summary>検証結果。各リストは表示用の per-entry 文字列 (caller は header を付けて MessageBox 化)。</summary>
+        public class Result
+        {
+            public List<string> EmptyIds = new List<string>();               // "(id=N)"
+            public List<string> MalformedSuffixEntries = new List<string>(); // "  - id=N: 'ver' (suffix 部分: 'sfx')"
+            public List<string> MalformedNumericEntries = new List<string>();// "  - id=N: 'ver'"
+            public List<string> DuplicateVersions = new List<string>();      // "key" or "key (生値: a / b)"
+            public List<string> PlayerCountViolations = new List<string>();  // "  - ver: 最小 N > 最大 M"
+
+            /// <summary>version 文字列の問題 (空 + 不正 suffix + 不正数値) の合計件数。1 つの MessageBox に集約する単位。</summary>
+            public int VersionStringIssueCount =>
+                EmptyIds.Count + MalformedSuffixEntries.Count + MalformedNumericEntries.Count;
+        }
+
+        public Result Validate(IEnumerable<GameVersion> versions)
+        {
+            var list = versions.ToList();
+            var r = new Result();
+
+            // ===== (1) version 文字列 scan (#158 round 7 L-2 + L-3) =====
+            // 旧実装は suffix/空/数値の 3 段 return で 1 version が複数違反だと 2-3 巡 OK を押させた UX を、
+            // 1 ループで empty / malformed-suffix / malformed-numeric の 3 リストに分類し 1 MessageBox に集約。
+            // suffix 切り出しは TrySplit static helper 経由 (IndexOf('-') 直書きの "v-1.0.0" 誤判定を排除)。
+            // 注意: malformed-suffix は **現状 dead path**。round 5 M-1 で VersionRegex の suffix group を SuffixRegex と
+            // 同一パターンに揃えたため、TrySplit が成功 (= VersionRegex match) した時点で捕捉 suffix は必ず IsSuffixValid を
+            // 満たす。不正 suffix は VersionRegex 不一致で TrySplit=false となり、結局 TryNormalize 失敗 → numeric 行に入る。
+            // 両 regex が将来分岐したときの guard rail として残す (挙動は旧実装と同一)。
+            foreach (var vChk in list)
+            {
+                if (vChk == null) continue;
+                string ver = vChk.Version;
+                if (string.IsNullOrEmpty(ver))
+                {
+                    r.EmptyIds.Add("(id=" + vChk.Id + ")");
+                    continue;
+                }
+                string core, sfx;
+                if (SemverInputControl.TrySplit(ver, out core, out sfx))
+                {
+                    if (!SemverInputControl.IsSuffixValid(sfx))
+                        r.MalformedSuffixEntries.Add("  - id=" + vChk.Id + ": '" + ver + "' (suffix 部分: '" + sfx + "')");
+                }
+                string normIgnored;
+                if (!SemverInputControl.TryNormalize(ver, out normIgnored))
+                    r.MalformedNumericEntries.Add("  - id=" + vChk.Id + ": '" + ver + "'");
+            }
+
+            // ===== (2) 正規化重複 (NOCASE) =====
+            // (#158 round 6 codex P2) GroupBy のキーを TryNormalize 結果に。raw v.Version 比較だと "v1.0.0"/"1.0.0"/
+            // "V1.0.0" が別 key で素通りし semantic 重複が漏れる。(PR #236 #2) GroupBy を OrdinalIgnoreCase にして
+            // DB の UNIQUE(game_id, version COLLATE NOCASE) と判定を揃え、case 違い重複が SQLiteException で表面化
+            // するのを事前に弾く。`: v.Version` fallback (正規化不能版) と `Where(!IsNullOrEmpty)` は (1) で弾いた
+            // 後の dead path だが defensive guard rail として残す (#158 round 7 M-1 / round 8 Low #4)。
+            r.DuplicateVersions = list
+                .Where(v => v != null && !string.IsNullOrEmpty(v.Version))
+                .GroupBy(v =>
+                {
+                    string normalized;
+                    return SemverInputControl.TryNormalize(v.Version, out normalized) ? normalized : v.Version;
+                }, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .Select(g =>
+                {
+                    var raws = g.Select(v => v.Version).Distinct().ToList();
+                    return raws.Count == 1 ? g.Key : g.Key + " (生値: " + string.Join(" / ", raws) + ")";
+                })
+                .ToList();
+
+            // ===== (3) 人数 min>max (#158 Finding #4) =====
+            // 表示中の NumericUpDown 値しか見ない ValidateInput を補完し、非表示版で min>max のまま別版を表示して
+            // OK する素通りを塞ぐ。両方とも非 null のときのみ比較。
+            foreach (var vPc in list)
+            {
+                if (vPc == null) continue;
+                if (vPc.MinPlayers.HasValue && vPc.MaxPlayers.HasValue && vPc.MinPlayers.Value > vPc.MaxPlayers.Value)
+                    r.PlayerCountViolations.Add("  - " + (vPc.Version ?? "(id=" + vPc.Id + ")")
+                        + ": 最小 " + vPc.MinPlayers.Value + " > 最大 " + vPc.MaxPlayers.Value);
+            }
+
+            return r;
+        }
+    }
+}


### PR DESCRIPTION
## 概要
ゲーム登録フォーム WPF 化（#242）の **god-file 分割 ②**。`EditGameForm.btnOK_Click` から **版セット全体の入力検証（~130 行）**を純関数 `GameVersionSetValidator` に抽出。挙動・メッセージ・順序・early-return は完全保存（behavior-preserving refactor）。①（[#379](https://github.com/ken1208git/TonePrism/pull/379) rename 抽出）に続く流れ。

## 抽出した service
`Validate(IEnumerable<GameVersion>)` → `Result` に 5 カテゴリの構造化違反を返す純関数:
- `EmptyIds` — version 文字列が空 / null
- `MalformedSuffixEntries` — 不正 suffix（後述: 現状 dead path）
- `MalformedNumericEntries` — `TryNormalize` 不能（数値部 / 書式不正）
- `DuplicateVersions` — SemVer 正規化後 NOCASE 重複（DB の `UNIQUE(game_id, version COLLATE NOCASE)` と整合）
- `PlayerCountViolations` — 全版の「最小 > 最大」（非表示版も含め補完）

**scan logic は service、presentation（MessageBox 組み立て + 表示）は form 側に残す**。form は `version 文字列 → 重複 → 人数` の順で early-return しつつ MessageBox を出す薄い配線に縮小。

## 発見（faithful に維持しつつ明記）
`malformed-suffix` 行は **現状 dead path**。round 5 M-1 で `VersionRegex` の suffix group を `SuffixRegex` と同一パターンに揃えたため、`TrySplit` 成功時の suffix は必ず `IsSuffixValid` を満たす。不正 suffix は `VersionRegex` 不一致 → `TryNormalize` 失敗 → numeric 行へ落ちる。両 regex 分岐時の guard rail として残置（挙動は旧実装と同一）。

## テスト
- **新規 12 テスト**（空 / null skip / malformed→numeric（`abc`/`1.2`/空 identifier suffix/不正文字 suffix）/ 正規化重複 NOCASE（`v1.0.0`≡`1.0.0`≡`V1.0.0`）/ 人数 min>max / ok・null / 多カテゴリ独立集計）
- **253/253 緑**（既存 241 + 新規 12）。警告クリーン

## バージョン
挙動不変の refactor のため **bump 無し**（#242 本体＝WPF 化着地時に bump）。

## マージ前の実機確認（任意・主経路は単体テストで担保）
- 捨てゲームで版を 2 つにし、片方を不正版番号 / 重複 / min>max にして OK → それぞれ従来どおりの MessageBox が出て保存が止まること（version 文字列 → 重複 → 人数 の順）。

Related #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)