### PR TITLE
refactor(manager): gameID rename を GameIdRenameService に抽出 (#242 ③)

### DIFF
--- a/Manager.Tests/GameIdRenameServiceTests.cs
+++ b/Manager.Tests/GameIdRenameServiceTests.cs
@@ -92,6 +92,7 @@ namespace TonePrism.Manager.Tests
             Assert.False(moved);
             Assert.Empty(moves);
             Assert.Single(dbCalls);
+            Assert.Equal(("g1", "g2"), dbCalls[0]);   // recovery (b) 経路でも DB に正しい (old,new) が渡る
         }
 
         [Fact]

--- a/Manager.Tests/GameIdRenameServiceTests.cs
+++ b/Manager.Tests/GameIdRenameServiceTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using TonePrism.Manager.Services;
+using Xunit;
+
+namespace TonePrism.Manager.Tests
+{
+    /// <summary>
+    /// (#242 ③) EditGameForm.btnOK_Click から抽出した gameId rename ロジックの回帰テスト。
+    /// disk 操作 (Directory.Exists/Move) と DB 更新 (UpdateGameId) を fake に差し替え、衝突判定 3 経路と
+    /// Move + DB 更新 + DB 失敗時 rollback を deterministic に検証する。
+    /// </summary>
+    public class GameIdRenameServiceTests
+    {
+        private const string Old = @"C:\games\g1";
+        private const string New = @"C:\games\g2";
+
+        private static HashSet<string> Set(params string[] dirs) => new HashSet<string>(dirs, StringComparer.OrdinalIgnoreCase);
+
+        // updateGameId は dbThrows なら InvalidOperationException、そうでなければ dbCalls に記録。
+        // move は src を消して dst を足す (実 disk の挙動を模倣) + moves に記録。
+        private static GameIdRenameService Svc(HashSet<string> existing,
+            List<(string src, string dst)> moves = null, List<(string oldId, string newId)> dbCalls = null, bool dbThrows = false)
+        {
+            return new GameIdRenameService(
+                updateGameId: (oldId, newId) =>
+                {
+                    if (dbThrows) throw new InvalidOperationException("db fail");
+                    dbCalls?.Add((oldId, newId));
+                },
+                dirExists: p => existing.Contains(p),
+                move: (src, dst) =>
+                {
+                    moves?.Add((src, dst));
+                    existing.Remove(src);
+                    existing.Add(dst);
+                });
+        }
+
+        // ===== DecideCollision =====
+
+        [Fact]
+        public void DecideCollision_BothExist_Collision()
+            => Assert.Equal(GameIdRenameService.CollisionDecision.Collision,
+                Svc(Set(Old, New)).DecideCollision(Old, New));
+
+        [Fact]
+        public void DecideCollision_OldMissingNewExists_NeedsRecoveryConfirm()
+            => Assert.Equal(GameIdRenameService.CollisionDecision.NeedsRecoveryConfirm,
+                Svc(Set(New)).DecideCollision(Old, New));
+
+        [Fact]
+        public void DecideCollision_NewMissing_Proceed()
+            => Assert.Equal(GameIdRenameService.CollisionDecision.Proceed,
+                Svc(Set(Old)).DecideCollision(Old, New));
+
+        [Fact]
+        public void DecideCollision_BothMissing_Proceed()
+            => Assert.Equal(GameIdRenameService.CollisionDecision.Proceed,
+                Svc(Set()).DecideCollision(Old, New));
+
+        // ===== Execute =====
+
+        [Fact]
+        public void Execute_OldExists_MovesAndUpdatesDb_ReturnsTrue()
+        {
+            var existing = Set(Old);
+            var moves = new List<(string, string)>();
+            var dbCalls = new List<(string, string)>();
+            var svc = Svc(existing, moves, dbCalls);
+
+            bool moved = svc.Execute("g1", "g2", Old, New, null);
+
+            Assert.True(moved);
+            Assert.Single(moves);
+            Assert.Equal((Old, New), moves[0]);
+            Assert.Single(dbCalls);
+            Assert.Equal(("g1", "g2"), dbCalls[0]);
+        }
+
+        [Fact]
+        public void Execute_OldMissing_SkipsMove_UpdatesDb_ReturnsFalse()
+        {
+            // (b) recovery で既存フォルダ流用 = 旧フォルダ不在。Move skip、DB のみ更新。
+            var existing = Set(New);
+            var moves = new List<(string, string)>();
+            var dbCalls = new List<(string, string)>();
+            var svc = Svc(existing, moves, dbCalls);
+
+            bool moved = svc.Execute("g1", "g2", Old, New, null);
+
+            Assert.False(moved);
+            Assert.Empty(moves);
+            Assert.Single(dbCalls);
+        }
+
+        [Fact]
+        public void Execute_DbFails_RollsBackMove_Rethrows()
+        {
+            var existing = Set(Old);
+            var moves = new List<(string, string)>();
+            var svc = Svc(existing, moves, dbThrows: true);
+
+            Assert.Throws<InvalidOperationException>(() => svc.Execute("g1", "g2", Old, New, null));
+
+            // forward Move (Old→New) → DB 失敗 → rollback Move (New→Old) の 2 件が記録される。
+            Assert.Equal(2, moves.Count);
+            Assert.Equal((Old, New), moves[0]);
+            Assert.Equal((New, Old), moves[1]);
+            // disk は元に戻っている (Old が存在、New は無い)。
+            Assert.Contains(Old, existing);
+            Assert.DoesNotContain(New, existing);
+        }
+    }
+}

--- a/Manager/EditGameForm.cs
+++ b/Manager/EditGameForm.cs
@@ -1162,79 +1162,48 @@ namespace TonePrism.Manager
 
                 if (gameIdChanged)
                 {
-                    // フォルダリネームを先に実行（失敗時にDB不整合を防ぐ）
+                    // (#242 ③) フォルダ rename + DB 更新を GameIdRenameService に抽出。衝突判定 (a/b/c) は service、
+                    // (b) recovery 確認の MessageBox と ProcessingDialog 表示は form 側に残す (UI 責務)。
                     string oldFolder = PathManager.GetGameFolder(oldGameId);
                     string newFolder = PathManager.GetGameFolder(newGameId);
+                    var gameIdRenameService = new GameIdRenameService(dbManager);
 
-                    // (#158 round 7 L-4 + round 8 codex P2) collision 判定を 3 経路に分ける:
-                    //   (a) 両方存在: 真の collision、Move 不能 → throw
-                    //   (b) oldFolder 不在 + newFolder 存在: recovery 可能性 (前回 rename interrupted +
-                    //       disk 既に新名 + DB が旧 ID のまま) または別 user の手動作成 folder で silent
-                    //       merge risk。区別不能なので user に明示確認 dialog (OK = 既存使用 / Cancel = abort)
-                    //   (c) newFolder 不在: 通常 path (oldFolder Move or DB only update)
-                    // round 7 L-4 は (b) を一律 throw にしていたため legitimate recovery が永久 block
-                    // されていたが、確認 dialog で silent merge risk と recovery 両立。
-                    bool oldFolderExists = System.IO.Directory.Exists(oldFolder);
-                    bool newFolderExists = System.IO.Directory.Exists(newFolder);
-                    if (oldFolderExists && newFolderExists)
+                    switch (gameIdRenameService.DecideCollision(oldFolder, newFolder))
                     {
-                        // (a) 両方存在 = collision
-                        throw new InvalidOperationException($"フォルダ「{newFolder}」が既に存在します。");
-                    }
-                    if (!oldFolderExists && newFolderExists)
-                    {
-                        // (b) recovery 可能性 / silent merge risk → user 確認
-                        var dr = MessageBox.Show(this,
-                            "指定された新しいゲーム ID のフォルダが既に存在しますが、旧 ID のフォルダは" +
-                            "見つかりません:\n  " + newFolder + "\n\n" +
-                            "これは前回の rename が DB 更新前に中断された残骸か、別目的で手動作成された" +
-                            "フォルダの可能性があります。\n\n" +
-                            "  ・ 前者なら「OK」で既存フォルダの中身を引き継いで DB のみ更新します\n" +
-                            "  ・ 後者なら「キャンセル」して中身を別の場所に退避してから再試行してください\n\n" +
-                            "既存フォルダの中身をそのまま使って DB を新 gameId に更新しますか?",
-                            "フォルダ同期確認", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
-                        if (dr != DialogResult.OK)
-                        {
-                            throw new OperationCanceledException("ユーザーがフォルダ同期をキャンセルしました。");
-                        }
-                        // OK: ProcessingDialog 内の `if (Directory.Exists(oldFolder)) { Move; folderRenamed=true; }`
-                        // で Move skip + folderRenamed=false のまま DB 更新が走る。
+                        case GameIdRenameService.CollisionDecision.Collision:
+                            // (a) 旧・新 両方存在 = collision (Move 不能)
+                            throw new InvalidOperationException($"フォルダ「{newFolder}」が既に存在します。");
+                        case GameIdRenameService.CollisionDecision.NeedsRecoveryConfirm:
+                            // (b) 旧不在 + 新存在: 前回 rename 中断の残骸 or 手動作成。silent merge risk と recovery を
+                            // user 確認で両立 (#158 round 7 L-4 + round 8 codex P2)。OK = 既存フォルダ流用で DB のみ更新
+                            // (Execute は oldFolder 不在を見て Move skip)、Cancel = abort。
+                            var recoveryDr = MessageBox.Show(this,
+                                "指定された新しいゲーム ID のフォルダが既に存在しますが、旧 ID のフォルダは" +
+                                "見つかりません:\n  " + newFolder + "\n\n" +
+                                "これは前回の rename が DB 更新前に中断された残骸か、別目的で手動作成された" +
+                                "フォルダの可能性があります。\n\n" +
+                                "  ・ 前者なら「OK」で既存フォルダの中身を引き継いで DB のみ更新します\n" +
+                                "  ・ 後者なら「キャンセル」して中身を別の場所に退避してから再試行してください\n\n" +
+                                "既存フォルダの中身をそのまま使って DB を新 gameId に更新しますか?",
+                                "フォルダ同期確認", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                            if (recoveryDr != DialogResult.OK)
+                            {
+                                throw new OperationCanceledException("ユーザーがフォルダ同期をキャンセルしました。");
+                            }
+                            break;
                     }
 
-                    // ゲームフォルダのリネームは同一ボリュームでは一瞬だが、共有フォルダ越しや
-                    // クロスボリュームでは内部的にコピー＋削除になり時間がかかる。
-                    // ProcessingDialog で進捗を表示する。
+                    // ゲームフォルダ rename は同一ボリュームでは一瞬だが、共有 / cross-volume では内部 copy+delete で
+                    // 時間がかかるため ProcessingDialog (marquee) で包む。worker は service.Execute (Move + DB + 失敗時
+                    // rollback) を呼び、失敗は caught に退避して rethrow → 外側 catch でエラー表示 (background thread から
+                    // MessageBox を出さない pattern)。
                     Exception caught = null;
+                    bool folderMoved = false;
                     using (var dialog = new ProcessingDialog((IProgress<ProgressInfo> progress, CancellationToken token) =>
                     {
                         try
                         {
-                            progress?.Report(new ProgressInfo(-1, "フォルダをリネーム中...", $"{oldFolder} → {newFolder}"));
-
-                            bool folderRenamed = false;
-                            if (System.IO.Directory.Exists(oldFolder))
-                            {
-                                System.IO.Directory.Move(oldFolder, newFolder);
-                                folderRenamed = true;
-                                AssetsChangedOnDisk = true; // (#295) games/ フォルダを移動した = ゲーム本体が変わった
-                            }
-
-                            progress?.Report(new ProgressInfo(-1, "データベースを更新中...", $"ゲームID: {oldGameId} → {newGameId}"));
-
-                            try
-                            {
-                                dbManager.UpdateGameId(oldGameId, newGameId);
-                            }
-                            catch
-                            {
-                                // DB更新失敗時はフォルダを元に戻す
-                                if (folderRenamed)
-                                {
-                                    progress?.Report(new ProgressInfo(-1, "ロールバック中...", "フォルダを元の名前に戻しています"));
-                                    System.IO.Directory.Move(newFolder, oldFolder);
-                                }
-                                throw;
-                            }
+                            folderMoved = gameIdRenameService.Execute(oldGameId, newGameId, oldFolder, newFolder, progress);
                         }
                         catch (Exception ex)
                         {
@@ -1256,6 +1225,12 @@ namespace TonePrism.Manager
                             return;
                         }
                     }
+
+                    // (#295) games/ フォルダを実際に Move した = ゲーム本体が変わった。Move 成功確定後 (dialog 後・UI
+                    // スレッド) に立てる。DB 失敗時は Execute が rollback (Move 戻し) して throw するため folderMoved は
+                    // false のまま = AssetsChangedOnDisk を立てない (旧実装は worker 内で Move 直後に立て、rollback されても
+                    // true が残る軽微な quirk があった。観測上は成功時同値・失敗時は form が開いたままで次の成功時に設定)。
+                    if (folderMoved) AssetsChangedOnDisk = true;
 
                     // gameFolderを更新（以降のパス処理で使用）
                     gameFolder = newFolder;

--- a/Manager/Services/GameIdRenameService.cs
+++ b/Manager/Services/GameIdRenameService.cs
@@ -1,0 +1,101 @@
+using System;
+
+namespace TonePrism.Manager.Services
+{
+    /// <summary>
+    /// (#242 ③ ゲーム登録フォーム WPF 化) ゲーム ID 変更に伴う games フォルダの rename + DB 更新を
+    /// EditGameForm.btnOK_Click から抽出した service。元は god-method 直書きの重ロジック
+    /// (CLAUDE.md「UI は薄く、ロジックは外へ」)。挙動は完全保存。
+    ///
+    /// 2 段構成:
+    ///   <see cref="DecideCollision"/> (副作用は dirExists のみ) = 旧/新フォルダの存在から衝突 3 経路を判定。
+    ///     (a) 両方存在 = 真の衝突 / (b) 旧不在+新存在 = recovery 確認要 / (c) それ以外 = 通常。
+    ///   <see cref="Execute"/> (disk Move + DB) = 旧フォルダがあれば Move → UpdateGameId、DB 失敗時は Move 戻し。
+    ///     ProcessingDialog の worker から呼ぶ前提で <see cref="ProgressInfo"/> を report。失敗時は throw
+    ///     (caller の worker が rethrow → 外側 catch でエラー表示)。
+    ///
+    /// (b) recovery 確認の MessageBox と ProcessingDialog の表示は **caller (form) の責務**。本 service は
+    /// 判定と disk/DB 操作のみで UI を持たない。disk 操作 / DB 更新は ctor で注入可能 (既定 = System.IO / DatabaseManager)
+    /// → 単体テストで fake を差し込み、衝突判定・Move・DB 失敗時 rollback を検証する。
+    /// </summary>
+    public class GameIdRenameService
+    {
+        private readonly Func<string, bool> _dirExists;
+        private readonly Action<string, string> _move;
+        private readonly Action<string, string> _updateGameId;
+
+        /// <summary>本番用。<paramref name="db"/> の UpdateGameId を使う。disk 操作も既定 System.IO。</summary>
+        public GameIdRenameService(DatabaseManager db, Func<string, bool> dirExists = null, Action<string, string> move = null)
+        {
+            if (db == null) throw new ArgumentNullException(nameof(db));
+            _dirExists = dirExists ?? System.IO.Directory.Exists;
+            _move = move ?? System.IO.Directory.Move;
+            _updateGameId = db.UpdateGameId;
+        }
+
+        /// <summary>単体テスト用。DB 更新 / disk 操作をすべて fake で差し込む。</summary>
+        internal GameIdRenameService(Action<string, string> updateGameId, Func<string, bool> dirExists, Action<string, string> move)
+        {
+            _updateGameId = updateGameId ?? throw new ArgumentNullException(nameof(updateGameId));
+            _dirExists = dirExists ?? throw new ArgumentNullException(nameof(dirExists));
+            _move = move ?? throw new ArgumentNullException(nameof(move));
+        }
+
+        public enum CollisionDecision
+        {
+            /// <summary>(c) 通常経路。Execute へ進む (旧フォルダがあれば Move、無ければ DB のみ更新)。</summary>
+            Proceed,
+            /// <summary>(a) 旧・新フォルダ両方存在 = Move 不能の真の衝突。caller は中止 (例外) する。</summary>
+            Collision,
+            /// <summary>(b) 旧不在 + 新存在 = 前回 rename 中断の残骸 or 手動作成。caller は recovery 可否を user 確認する。</summary>
+            NeedsRecoveryConfirm
+        }
+
+        /// <summary>
+        /// 旧/新 games フォルダの存在から衝突 3 経路 (#158 round 7 L-4 + round 8 codex P2) を判定する。
+        /// </summary>
+        public CollisionDecision DecideCollision(string oldFolder, string newFolder)
+        {
+            bool oldExists = _dirExists(oldFolder);
+            bool newExists = _dirExists(newFolder);
+            if (oldExists && newExists) return CollisionDecision.Collision;
+            if (!oldExists && newExists) return CollisionDecision.NeedsRecoveryConfirm;
+            return CollisionDecision.Proceed;
+        }
+
+        /// <summary>
+        /// 旧フォルダが存在すれば <paramref name="newFolder"/> へ Move し、DB の gameId を更新する。DB 更新が失敗したら
+        /// Move を元に戻して例外を rethrow する (= caller の ProcessingDialog worker が捕捉し、外側 catch でエラー表示)。
+        /// 旧フォルダ不在 (= (b) recovery で user が既存使用を選んだ等) は Move を skip して DB のみ更新する。
+        /// </summary>
+        /// <returns>実際にフォルダを物理 Move したか (caller は true のとき AssetsChangedOnDisk を立てる)。</returns>
+        public bool Execute(string oldGameId, string newGameId, string oldFolder, string newFolder, IProgress<ProgressInfo> progress)
+        {
+            progress?.Report(new ProgressInfo(-1, "フォルダをリネーム中...", $"{oldFolder} → {newFolder}"));
+
+            bool folderRenamed = false;
+            if (_dirExists(oldFolder))
+            {
+                _move(oldFolder, newFolder);
+                folderRenamed = true;
+            }
+
+            progress?.Report(new ProgressInfo(-1, "データベースを更新中...", $"ゲームID: {oldGameId} → {newGameId}"));
+            try
+            {
+                _updateGameId(oldGameId, newGameId);
+            }
+            catch
+            {
+                // DB 更新失敗時はフォルダを元に戻す (disk と DB の片側だけ進んだ drift を防ぐ)。
+                if (folderRenamed)
+                {
+                    progress?.Report(new ProgressInfo(-1, "ロールバック中...", "フォルダを元の名前に戻しています"));
+                    _move(newFolder, oldFolder);
+                }
+                throw;
+            }
+            return folderRenamed;
+        }
+    }
+}

--- a/Manager/Services/GameIdRenameService.cs
+++ b/Manager/Services/GameIdRenameService.cs
@@ -5,7 +5,10 @@ namespace TonePrism.Manager.Services
     /// <summary>
     /// (#242 ③ ゲーム登録フォーム WPF 化) ゲーム ID 変更に伴う games フォルダの rename + DB 更新を
     /// EditGameForm.btnOK_Click から抽出した service。元は god-method 直書きの重ロジック
-    /// (CLAUDE.md「UI は薄く、ロジックは外へ」)。挙動は完全保存。
+    /// (CLAUDE.md「UI は薄く、ロジックは外へ」)。挙動は基本保存。唯一の差分は <c>AssetsChangedOnDisk</c> の扱いで、
+    /// 旧は worker 内 Move 直後に立てて DB 失敗 rollback でも true が残る quirk があったが、新は Execute が DB 失敗時に
+    /// throw → caller が Move+DB 成功確定後にのみ立てる (= rollback を正しく反映、観測上は成功時同値。EditGameForm の
+    /// 該当コメント参照)。
     ///
     /// 2 段構成:
     ///   <see cref="DecideCollision"/> (副作用は dirExists のみ) = 旧/新フォルダの存在から衝突 3 経路を判定。


### PR DESCRIPTION
## 概要
ゲーム登録フォーム WPF 化（#242）の **god-file 分割 ③（最後の重ロジック抽出）**。`EditGameForm.btnOK_Click` から **gameId 変更時の games フォルダ rename + DB 更新**を `GameIdRenameService` に抽出。挙動保存。①（[#379](https://github.com/ken1208git/TonePrism/pull/379) 版rename）②（[#380](https://github.com/ken1208git/TonePrism/pull/380) 入力検証）に続く。

## 抽出した service
- **`DecideCollision(oldFolder, newFolder)`**（副作用は dirExists のみ）= 衝突 3 経路を判定: (a) 両方存在＝真の衝突 / (b) 旧不在+新存在＝recovery 確認要 / (c) 通常（#158 round 7 L-4 + round 8 codex P2）
- **`Execute(...)`**（disk Move + DB）= 旧フォルダがあれば Move → `UpdateGameId`、DB 失敗時は Move 戻し + rethrow。`IProgress` を report
- **(b) recovery 確認 MessageBox / ProcessingDialog 表示は form 側に残す**（UI 責務）。service は判定 + disk/DB のみ
- disk/DB を ctor 注入可能 → 単体テストで fake 差し込み

## external image copy は本 PR 対象外（意図的スコープ）
外部画像取込（`CopyExternalImagesToVersionFolder` 等）は **form 状態に密結合**（textbox 読み書き・`_pendingExternal*` maps・`ImageCopyPlan.AssignBackTextBox` に TextBox 参照埋め込み・preview 更新・conflict dialog）＝ pure logic でなく UI オーケストレーション。standalone 抽出は state 引き回しが過大で低品質になるため、**#324 WPF 化で ViewModel state（pending maps→ViewModel / textbox writeback→binding）に吸収する方が筋**と判断。これで #242 の主目的「重い framework 非依存ロジック（rename×2 + 検証）を抽出」は達成。

## テスト
- **新規 7 テスト**（DecideCollision 衝突3経路 / Execute: 旧あり Move+DB / 旧なし skip+DB / DB失敗 Move戻し rollback）
- **261/261 緑**（既存 254 + 新規 7）。警告クリーン

## 軽微改善（faithful からの意図的差分）
`AssetsChangedOnDisk` を **Move 成功確定後**（dialog 後・UI スレッド）に設定。旧実装は worker 内 Move 直後で立て、DB 失敗で rollback されても `true` が残る quirk があった（観測上は成功時同値・失敗時は form が開いたままで次の成功時に設定されるため実害なし）。`Execute` が DB 失敗時 throw → `folderMoved` が false のままになる方が rollback を正しく反映。

## バージョン
挙動不変の refactor のため **bump 無し**（#242 本体＝WPF 化着地時に bump）。

## マージ前の実機確認（保存系のため・任意だが推奨）
- 捨てゲームで **gameId 変更 → OK** → `games/<新ID>/` にフォルダがリネームされ DB と一致、Launcher で起動できること。
- gameId + 版番号を同時変更（rename×2 経路の合流）も一巡。

Related #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)